### PR TITLE
$this->BcAuth->allow で同じメソットを2回宣言していたので片方を削除。

### DIFF
--- a/baser/controllers/users_controller.php
+++ b/baser/controllers/users_controller.php
@@ -85,9 +85,7 @@ class UsersController extends AppController {
 				'admin_logout', 
 				'admin_login_exec', 
 				'admin_reset_password',
-				'admin_ajax_login',
-				'admin_login_exec',
-				'admin_reset_password'
+				'admin_ajax_login'
 		);
 		$this->set('usePermission',$this->UserGroup->checkOtherAdmins());
 		


### PR DESCRIPTION
こんなのもチケット切るべきですかね？
