### PR TITLE
カレンダー表示のタイトルを「yyyy年mm月」にする。fixes #3400

### DIFF
--- a/baser/vendors/css/jquery-ui/ui.all.css
+++ b/baser/vendors/css/jquery-ui/ui.all.css
@@ -511,6 +511,7 @@ button.ui-button::-moz-focus-inner { border: 0; padding: 0; } /* reset extra pad
 .ui-datepicker select.ui-datepicker-month-year {width: 100%;}
 .ui-datepicker select.ui-datepicker-month,
 .ui-datepicker select.ui-datepicker-year { width: 49%;}
+.ui-datepicker span.ui-datepicker-year:after { content: '年';}
 .ui-datepicker table {width: 100%; font-size: .9em; border-collapse: collapse; margin:0 0 .4em; }
 .ui-datepicker th { padding: .7em .3em; text-align: center; font-weight: bold; border: 0;  }
 .ui-datepicker td { border: 0; padding: 1px; }

--- a/baser/vendors/js/i18n/ui.datepicker-ja.js
+++ b/baser/vendors/js/i18n/ui.datepicker-ja.js
@@ -15,6 +15,6 @@ jQuery(function($){
 		dayNamesMin: ['日','月','火','水','木','金','土'],
 		dateFormat: 'yy/mm/dd', firstDay: 0,
 		isRTL: false,
-		showMonthAfterYear: false};
+		showMonthAfterYear: true};
 	$.datepicker.setDefaults($.datepicker.regional['ja']);
 });


### PR DESCRIPTION
ただし、適用theme内にjs/i18n/ui.datepicker-ja.jsが存在するとそちらが優先されます。 fixes #3400
