### PR TITLE
PHP5.4での環境において、誤ったURLにリダイレクトされる点を修正

### DIFF
--- a/baser/controllers/baser_app_controller.php
+++ b/baser/controllers/baser_app_controller.php
@@ -1268,11 +1268,14 @@ class BaserAppController extends Controller {
 		$url = addSessionId($url, true);
 		// 管理システムでのURLの生成が CakePHP の標準仕様と違っていたので調整
 		// ※ Routing.admin を変更した場合
+		// >>> CUSTOMIZE MODIFY 2013/06/17 arata
+		// PHP5.4での環境において、誤ったURLにリダイレクトされる点を修正
 		if (!isset($url['admin']) && !empty($this->params['admin'])) {
 			$url['admin'] = true;
 		} elseif (isset($url['admin']) && !$url['admin']) {
 			unset($url['admin']);
 		}
+		// <<<
 		parent::redirect($url, $status, $exit);
 		
 	}


### PR DESCRIPTION
未ログイン時に URL/admin へアクセスするとリダイレクトに失敗する状態を修正しました。
