### PR TITLE
リンク先にhttpから指定されている場合、SSLページのリンク先URLをサイトURLからのフルパスで生成しないように。

### DIFF
--- a/baser/views/helpers/bc_baser.php
+++ b/baser/views/helpers/bc_baser.php
@@ -939,8 +939,8 @@ class BcBaserHelper extends AppHelper {
 			}
 		}
 
-		// 現在SSLのURLの場合、フルパスで取得（javascript:は除外）
-		if(($this->isSSL() || $ssl) && !preg_match('/^javascript:/', $_url)) {
+		// 現在SSLのURLの場合、フルパスで取得（javascript:とhttpから始まるものは除外）
+		if(($this->isSSL() || $ssl) && !preg_match('/^javascript:/', $_url) && !preg_match('/^http/', $_url)) {
 			$_url = preg_replace("/^\//", "", $_url);
 			if(preg_match('/^admin\//', $_url)) {
 				$admin = true;


### PR DESCRIPTION
$bcBaser->linkにて、現在がSSLページの場合はwebサイトURLからのフルパスでリンク先を生成しているが、httpから始まるリンク先が指定されていた場合は、
http://domain.com/http:〜
という不正なリンクが生成されるので、httpから始まるリンクの場合は除外する修正をしました。

よかったマージお願いします。
