### PR TITLE
CakePHP脆弱性対応：(1.3.16-1.3.17)修正差分反映

### DIFF
--- a/cake/libs/controller/controller.php
+++ b/cake/libs/controller/controller.php
@@ -995,11 +995,11 @@ class Controller extends Object {
 		if (isset($options['show'])) {
 			$options['limit'] = $options['show'];
 		}
-                
-                if (isset($options['order']) && empty($options['sort'])) {
-                    $options['sort'] = $options['order'];
-                    unset($options['order']);
-                }
+
+		if (isset($options['order']) && empty($options['sort'])) {
+			$options['sort'] = $options['order'];
+			unset($options['order']);
+		}
 
 		if (isset($options['sort'])) {
 			$direction = null;
@@ -1021,9 +1021,9 @@ class Controller extends Object {
 			}
 			$value = $options['order'][$key];
 			unset($options['order'][$key]);
-                        $correctAlias = ($alias == $object->alias);
-                    
-                        if ($correctAlias && $object->hasField($field)) {
+			$correctAlias = ($alias == $object->alias);
+
+			if ($correctAlias && $object->hasField($field)) {
 				$options['order'][$object->alias . '.' . $field] = $value;
 			} elseif ($correctAlias && $object->hasField($key, true)) {
 				$options['order'][$field] = $value;


### PR DESCRIPTION
CakePHP1.3系にてセキュリティアップデートがリリースされていたため、baserCMSへの修正適用を行いました。

作業概要
・CakePHP1.3.16 <-> 1.3.17のdiff取得
・取得差分をbaserCMS内、CakePHP1.2.12へ適用

修正内容概要
/cake/libs/controller/controller.phpのpaginateメソッドへの修正対応

補足
ソースコード中に半角スペースが混ざっていたためタブへ置換しました。
取り込み候補は fffd86a でお願いします

よろしくお願いします
