### PR TITLE
郵便番号自動補完の保管先入力欄1つでも2つでも動作するように修正

### DIFF
--- a/baser/plugins/mail/views/helpers/mailform.php
+++ b/baser/plugins/mail/views/helpers/mailform.php
@@ -94,7 +94,11 @@ class MailformHelper extends BcFreezeHelper {
 				unset($attributes['rows']);
 				unset($attributes['empty']);
 				$address1 = $this->__name(array(),$options[1]);
-				$address2 = $this->__name(array(),$options[2]);
+				if(empty($options[2])) {
+					$address2 = $this->__name(array(),$options[1]);
+				} else {
+					$address2 = $this->__name(array(),$options[2]);
+				}
 				$attributes['onKeyUp'] = "AjaxZip3.zip2addr(this,'','{$address1['name']}','{$address2['name']}')";
 				$out = $this->Javascript->link('ajaxzip3.js').$this->text($fieldName,$attributes);
 				break;


### PR DESCRIPTION
郵便番号自動補完の補完先入力欄
address1|address2　と2つリスト指定しなければエラーが出ていたものを
address1　と1つだけの指定でも動作するように修正
