### PR TITLE
1813.和暦日付において年月まで入力して入力エラーが発生すると年が消える対応

### DIFF
--- a/baser/views/helpers/bc_time.php
+++ b/baser/views/helpers/bc_time.php
@@ -225,7 +225,21 @@ class BcTimeHelper extends TimeHelper {
  * @access public
  */
 	function convertToWareki($date) {
-
+	    
+	    // add start yuse@gmail.com
+		// 配列形式の場合は、YMDが揃っていない場合も変換を走らせる為、
+		// Yがある場合、MDが空でもセットする。
+		if(is_array($date)){
+			if(!empty($date['year'])){
+				if(empty($date['month'])){
+					$date['month'] = "01";
+				}
+				if(empty($date['day'])){
+					$date['day'] = "01";
+				}
+			}
+		}
+		// add end
 		$dateArray = $this->convertToWarekiArray($date);
 		if(is_array($dateArray) && !empty($dateArray)) {
 			return $dateArray['year'] . '/' . $dateArray['month'] . '/' . $dateArray['day'];


### PR DESCRIPTION
#1813 メールフォームの和暦日付において年月まで入力して入力エラーが発生すると年が消える　

の対応になります。

そもそもの原因は、bc_time.phpのconvertToWarekiArrayメソッドが完全なYYYYMMDD形式の場合しか
変換をしないのに対して、問い合わせ上では、YYYYのみやMMのみの入力でも上記メソッドをCallできるためでした。

処理上は、convertToWarekiArrayをconvertToWarekiをラッパーにしてCallしています。
convertToWarekiはここ以外では使われていなかったので、YYYYの入力があった場合は、
月日を補完して和暦変換させるようにしました。

よろしくお願いします。
