### PR TITLE
code非表示対応 fixes #3726

### DIFF
--- a/baser/controllers/pages_controller.php
+++ b/baser/controllers/pages_controller.php
@@ -706,7 +706,8 @@ class PagesController extends AppController {
 		
 		// 一時ファイルとしてビューを保存
 		// タグ中にPHPタグが入る為、ファイルに保存する必要がある
-		$contents = $this->Page->addBaserPageTag(null, $page['Page']['contents'], $page['Page']['title'],$page['Page']['description']);
+		// modified #3726 codeを追加 yuse@gmail.com 
+		$contents = $this->Page->addBaserPageTag(null, $page['Page']['contents'], $page['Page']['title'],$page['Page']['description'],$page['Page']['code']); 
 		$path = TMP.'pages_preview_'.$id.$this->ext;
 		$file = new File($path);
 		$file->open('w');


### PR DESCRIPTION
#3726 固定ページのプレビュー時、「コード」フィールドに入力した内容が反映されていない模様

上記について対応を行いました。
