### PR TITLE
Blog.BlogBaserHelper::blogPosts()オプションで、テンプレートの変更設定が無視されている不具合を修正

### DIFF
--- a/lib/Baser/Plugin/Blog/Controller/BlogController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogController.php
@@ -967,10 +967,11 @@ class BlogController extends BlogAppController {
 	public function posts($blogContentId, $limit = 5) {
 		if (!empty($this->params['named']['template'])) {
 			$template = $this->request->params['named']['template'];
-			unset($this->request->params['named']['template']);
 		} else {
 			$template = 'posts';
 		}
+		unset($this->request->params['named']['template']);
+
 		$this->layout = null;
 		$this->contentId = $blogContentId;
 

--- a/lib/Baser/Plugin/Blog/View/Helper/BlogBaserHelper.php
+++ b/lib/Baser/Plugin/Blog/View/Helper/BlogBaserHelper.php
@@ -79,9 +79,6 @@ class BlogBaserHelper extends AppHelper {
 			}
 		}
 
-		if (!isset($options['templates'])) {
-			$templates = 'posts';
-		}
 		$options['template'] = $options['templates'];
 		unset($options['templates']);
 


### PR DESCRIPTION
blogPostsのテンプレート指定がauto変数で何も処理せずに捨てられていたため、有効化する修正をしました。

一つご相談があって…　$options['templates']なのですが、requestAction()はオプション名が「template」となっているため整合性の問題があります。今回の修正では$options['template']=$options['templates']としてからunset()しましたが、意味的には「template」なので、blogPosts()のオプション名を変更した方が良いのではないかと思います。ただAPIの仕様変更ということになりますのでこのPRでは見送りました。どうしましょうか？
