### PR TITLE
管理画面CSSのfont-familyを変更（メイリオを追記, ヒラギノ角ゴ Proをヒラギノ角ゴ ProNに変更）

### DIFF
--- a/lib/Baser/View/webroot/css/admin/default.css
+++ b/lib/Baser/View/webroot/css/admin/default.css
@@ -60,7 +60,7 @@ td {
 	padding: 0;
 }
 body {
-	font-family:"ヒラギノ角ゴ Pro W3", "ＭＳ Ｐゴシック", Arial, sans-serif;
+	font-family: "Hiragino Kaku Gothic ProN", "ヒラギノ角ゴ ProN W3", Meiryo, "メイリオ", "MS PGothic", "ＭＳ Ｐゴシック", Sans-Serif;
 	text-align:center;
 }
 table {
@@ -166,7 +166,7 @@ form {
 	display:inline;
 }
 input, textarea, select, option {
-	font-family:"ヒラギノ角ゴ Pro W3", "ＭＳ Ｐゴシック", Arial, sans-serif;
+	font-family: "Hiragino Kaku Gothic ProN", "ヒラギノ角ゴ ProN W3", Meiryo, "メイリオ", "MS PGothic", "ＭＳ Ｐゴシック", Sans-Serif;
 }
 input[type=text], textarea, select, input[type=password] {
 	margin:3px 2px;
@@ -188,7 +188,7 @@ input[type=checkbox] {
 input[type=submit],
 input[type=reset],
 input[type=button] {
-	font-family:"ヒラギノ角ゴ Pro W3", "ＭＳ Ｐゴシック", Arial, sans-serif;
+	font-family: "Hiragino Kaku Gothic ProN", "ヒラギノ角ゴ ProN W3", Meiryo, "メイリオ", "MS PGothic", "ＭＳ Ｐゴシック", Sans-Serif;
 }
 input[type=text], textarea, input[type=password] {
 	font-size: 1.4em;

--- a/lib/Baser/View/webroot/css/admin/toolbar.css
+++ b/lib/Baser/View/webroot/css/admin/toolbar.css
@@ -38,7 +38,7 @@ html, body {
 	width:100%;
 	font-size: 12px;
 	border-bottom: 1px solid #444;
-	font-family:"ヒラギノ角ゴ Pro W3", "ＭＳ Ｐゴシック", Arial, sans-serif!important;
+	font-family: "Hiragino Kaku Gothic ProN", "ヒラギノ角ゴ ProN W3", Meiryo, "メイリオ", "MS PGothic", "ＭＳ Ｐゴシック", Sans-Serif !important;
 }
 #ToolbarInner {
 	padding: 0 30px;


### PR DESCRIPTION
/lib/Baser/View/webroot/css/admin 内にあるCSSファイルについて、
和文フォントの指定がある箇所を標題のとおり変更してみました。
游ゴシックについては外してありますので、改めてご判断いただければ幸いです。
