### PR TITLE
$this->BcBaser->page の引数がページ名に変わったのでコメント変更

### DIFF
--- a/lib/Baser/View/Helper/BcBaserHelper.php
+++ b/lib/Baser/View/Helper/BcBaserHelper.php
@@ -1766,7 +1766,9 @@ END_FLASH;
  * ページをエレメントとして読み込む
  *
  * ※ レイアウトは読み込まない
- * @param int $id
+ * @param string $url
+ * @param array $params
+ * @param array $options
  * @manual
  */
 	public function page($url, $params = array(), $options = array()) {


### PR DESCRIPTION
フォーラムの[ページをエレメントとして読み込む](http://forum.basercms.net/modules/newbb/viewtopic.php?topic_id=1353&forum=5)の質問で $this->BcBaser->page を見たところ、引数がページID（バージョン2）からページ名（バージョン3）に変わったようなので、コメントに反映してみました。
