### PR TITLE
php.ini で pdo_mysql.so を有効にし、mysql.so を無効にしているケースでインストールが正常に行えない問題の解決

### DIFF
--- a/lib/Baser/Controller/InstallationsController.php
+++ b/lib/Baser/Controller/InstallationsController.php
@@ -588,22 +588,21 @@ class InstallationsController extends AppController {
 		/* DBソース取得 */
 		$dbsource = array();
 		$folder = new Folder();
+		$pdoDrivers = PDO::getAvailableDrivers();
 
 		/* MySQL利用可否 */
-		if (function_exists('mysql_connect')) {
+		if (in_array('mysql', $pdoDrivers)) {
 			$dbsource['mysql'] = 'MySQL';
 		}
 
 		/* PostgreSQL利用可否 */
-		if (function_exists('pg_connect')) {
+		if (in_array('pgsql', $pdoDrivers)) {
 			$dbsource['postgres'] = 'PostgreSQL';
 		}
 
 		/* SQLite利用可否チェック */
 		// windowsは一旦非サポート
-		if (class_exists('PDO') && version_compare(preg_replace('/[a-z-]/', '', phpversion()), '5', '>=') && (DS != '\\')) {
-
-			$pdoDrivers = PDO::getAvailableDrivers();
+		if (version_compare(preg_replace('/[a-z-]/', '', phpversion()), '5', '>=') && (DS != '\\')) {
 			if (in_array('sqlite', $pdoDrivers)) {
 				$dbFolderPath = APP . 'db' . DS . 'sqlite';
 				if (is_writable(dirname($dbFolderPath)) && $folder->create($dbFolderPath, 0777)) {


### PR DESCRIPTION
# 現象

php.ini にて

pdo_mysql.so -> 有効
mysql.so -> 無効

なケースでインストールステップ3でデータベースタイプが選択できず、インストールが正常に行えない。
# 変更の概要

データソースの利用可否判定処理でPDOの機能を使っていない箇所をPDOを使うように変更しました。CakePHP2 系の System Requirements に PDO が含まれているため、積極的にPDOの機能を使ってデータベース実装の利用可否判定をしても問題ないと判断しました。
