### PR TITLE
baserCMS管理画面でinput type=buttonを利用した際の不要なforcsイベントを除去

### DIFF
--- a/lib/Baser/View/webroot/js/admin/startup.js
+++ b/lib/Baser/View/webroot/js/admin/startup.js
@@ -177,6 +177,7 @@ $(function(){
 	$("input, textarea, select").focus(function(){
 		$(this).addClass('active');
 	});
+	$("input[type=button]").off('focus'); // input type="button"はフォーカス時に activeクラスを追加するイベントを除去
 	$("input, textarea, select").focusout(function(){
 		$(this).removeClass('active');
 	});


### PR DESCRIPTION
管理画面のinput type="button"に対するフォーカスイベントをunbindするコードを追加しています。
どうぞよろしくお願いします。
