### PR TITLE
固定ページカテゴリー情報編集のときにリンクが不正になるのを調整＋余分な文字を削除

### DIFF
--- a/lib/Baser/View/PageCategories/admin/form.php
+++ b/lib/Baser/View/PageCategories/admin/form.php
@@ -104,11 +104,11 @@ function pageTypeChengeHandler() {
 <div id="AjaxControlSources" class="display-none"><?php $this->BcBaser->url(array('controller' => 'page_categories', 'action' => 'ajax_control_sources')) ?></div>
 
 <?php if ($this->request->action == 'admin_edit' && $indexPage): ?>
-	<div class="em-box align-left">1
+	<div class="em-box align-left">
 		<?php if ($indexPage['status']): ?>
-			<strong>このカテゴリのURL：<?php $this->BcBaser->link($this->BcBaser->getUri('/' . $indexPage['url']), '/' . $indexPage['url'], array('target' => '_blank')) ?></strong>
+			<strong>このカテゴリのURL：<?php $this->BcBaser->link($this->BcBaser->getUri($indexPage['url']), $indexPage['url'], array('target' => '_blank')) ?></strong>
 		<?php else: ?>
-			<strong>このカテゴリのURL：<?php echo $this->BcBaser->getUri('/' . $indexPage['url']) ?></strong>
+			<strong>このカテゴリのURL：<?php echo $this->BcBaser->getUri($indexPage['url']) ?></strong>
 		<?php endif ?>
 	</div>
 <?php endif ?>


### PR DESCRIPTION
フォーラムで報告がありました。
- 固定ページカテゴリのURLが不正になる  
  http://forum.basercms.net/modules/newbb/viewtopic.php?topic_id=1465&forum=4

原因と思われるファイルを編集してみましたのでレビューをおねがいします。
