### PR TITLE
受信メール詳細画面で br タグがエスケープされる不具合を調整

### DIFF
--- a/lib/Baser/Plugin/Mail/View/MailMessages/admin/view.php
+++ b/lib/Baser/Plugin/Mail/View/MailMessages/admin/view.php
@@ -40,7 +40,7 @@
 				echo $field['before_attachment'];
 			}
 			if (!$field['no_send']) {
-				echo $this->BcText->autoLink(nl2br($this->Maildata->control(
+				echo nl2br($this->BcText->autoLink($this->Maildata->control(
 							$mailField['MailField']['type'], $message['Message'][$mailField['MailField']['field_name']], $this->Mailfield->getOptions($mailField['MailField'])
 				)));
 			}


### PR DESCRIPTION
マルチチェックボックスで複数項目を選択した場合など、改行の <br /> がエスケープされて文字列として表示されるようです。
nl2br の処理を後にもってきて、エスケープされないようにしてみました。
レビューをおねがいします。
