### PR TITLE
メール設定でSMTPサーバのTLS暗号化通信に対応

### DIFF
--- a/lib/Baser/Config/Data/Default/site_configs.csv
+++ b/lib/Baser/Config/Data/Default/site_configs.csv
@@ -12,6 +12,7 @@
 "","smtp_user","","",""
 "","smtp_password","","",""
 "","smtp_port","","",""
+"","smtp_tls","0","",""
 "","formal_name","baserCMS inc. [ƒfƒ‚]","",""
 "","mobile","1","",""
 "","admin_list_num","10","",""

--- a/lib/Baser/Controller/BcAppController.php
+++ b/lib/Baser/Controller/BcAppController.php
@@ -733,12 +733,14 @@ class BcAppController extends Controller {
 			$port = ($this->siteConfigs['smtp_port']) ? $this->siteConfigs['smtp_port'] : 25;
 			$username = ($this->siteConfigs['smtp_user']) ? $this->siteConfigs['smtp_user'] : null;
 			$password = ($this->siteConfigs['smtp_password']) ? $this->siteConfigs['smtp_password'] : null;
+			$tls = $this->siteConfigs['smtp_tls'] && ($this->siteConfigs['smtp_tls'] == 1);
 		} else {
 			$transport = 'Mail';
 			$host = 'localhost';
 			$port = 25;
 			$username = null;
 			$password = null;
+			$tls = null;
 		}
 
 		$config = array(
@@ -746,7 +748,8 @@ class BcAppController extends Controller {
 			'host' => $host,
 			'port' => $port,
 			'username' => $username,
-			'password' => $password
+			'password' => $password,
+			'tls' => $tls
 		);
 
 		$cakeEmail = new CakeEmail($config);

--- a/lib/Baser/View/SiteConfigs/admin/form.php
+++ b/lib/Baser/View/SiteConfigs/admin/form.php
@@ -449,6 +449,15 @@ h2 {}
 				<div id="helptextSmtpPassword" class="helptext">メールの送信にSMTPサーバーを利用する場合指定します。</div>
 			</td>
 		</tr>
+		<tr>
+			<th><?php echo $this->BcForm->label('SiteConfig.smtp_tls', 'SMTP TLS暗号化') ?></th>
+			<td class="col-input">
+				<?php echo $this->BcForm->input('SiteConfig.smtp_tls', array('type' => 'radio', 'options' => $this->BcText->booleanDoList('TLS暗号化を利用'))) ?>
+				<?php echo $this->BcForm->error('SiteConfig.smtp_tls') ?>
+				<?php echo $this->Html->image('admin/icn_help.png', array('id' => 'helpSmtpTls', 'class' => 'btn help', 'alt' => 'ヘルプ')) ?>
+				<div id="helptextSmtpTls" class="helptext">SMTPサーバーがTLS暗号化を利用する場合指定します。</div>
+			</td>
+		</tr>
 	</table>
 </div>
 


### PR DESCRIPTION
baserCMSユーザー会　ご担当者様

GmailなどTLS暗号化通信に対応した外部SMTPサーバーを指定する機会が少なからずあるので、
メールのSMTP設定で対応できるように修正しました。

主な内容はlib/Baser/Controller/BcAppController.phpのsendMailメソッドにおいて、
[CakeEmail](http://book.cakephp.org/2.0/en/core-utility-libraries/email.html#configuration)のインスタンス生成時のオプションに’tls’の値を追加した程度です。

ご検討よろしくお願いいたします。
