### PR TITLE
Vagrant環境でbaserCMSを実行するとブラウザでの静的ファイル(CSS等)の読み込みが不完全になる問題に対応

### DIFF
--- a/vagrant_cookbooks/httpd/templates/default/httpd.conf.erb
+++ b/vagrant_cookbooks/httpd/templates/default/httpd.conf.erb
@@ -473,7 +473,7 @@ HostnameLookups Off
 # filesystem) can improve performance; for details, please see
 # http://httpd.apache.org/docs/2.2/mod/core.html#enablemmap
 #
-#EnableMMAP off
+EnableMMAP off
 
 #
 # EnableSendfile: Control whether the sendfile kernel support is 
@@ -482,7 +482,7 @@ HostnameLookups Off
 # filesystems.  Please see
 # http://httpd.apache.org/docs/2.2/mod/core.html#enablesendfile
 #
-#EnableSendfile off
+EnableSendfile off
 
 #
 # ErrorLog: The location of the error log file.


### PR DESCRIPTION
ネットワークマウントされたドキュメントルートで問題が出るらしい。
下記URL参照。
http://httpd.apache.org/docs/2.2/mod/core.html#enablemmap
http://httpd.apache.org/docs/2.2/mod/core.html#enablesendfile
