### PR TITLE
エディタプラグインの拡張性を高めるためにクラスを付加。

### DIFF
--- a/lib/Baser/View/Pages/admin/form.php
+++ b/lib/Baser/View/Pages/admin/form.php
@@ -447,7 +447,7 @@ function pageTypeChengeHandler() {
 	</table>
 </div>
 
-<div class="section" style="text-align:center">
+<div class="section editor-area">
 	<?php echo $this->BcForm->editor('Page.contents', array_merge(array(
 		'editor' => @$siteConfig['editor'],
 		'editorUseDraft' => true,

--- a/lib/Baser/webroot/css/admin/contents.css
+++ b/lib/Baser/webroot/css/admin/contents.css
@@ -482,6 +482,12 @@ table.sub-menu{
 	cursor: pointer;
 }
 
+/* edit form
+----------------------------------------------- */
+.editor-area {
+	text-align: center;
+}
+
 /* button
 ----------------------------------------------- */
 


### PR DESCRIPTION
エディタプラグイン開発の際に、エディタのセクションとなる`div`要素を特定できるようにクラスを付加しました。

`text-align: center`がどのシーンで必要だったのかわかりませんでしたが、念のためCSSファイルに記載しています。
