### PR TITLE
オブジェクトの参照渡しの削除

### DIFF
--- a/lib/Baser/Controller/Component/BcManagerComponent.php
+++ b/lib/Baser/Controller/Component/BcManagerComponent.php
@@ -445,7 +445,7 @@ class BcManagerComponent extends Component {
 		$datasource = $this->getDatasourceName($datasource);
 
 		$dbfilename = APP . 'Config' . DS . 'database.php';
-		$file = & new File($dbfilename);
+		$file = new File($dbfilename);
 
 		if ($file !== false) {
 


### PR DESCRIPTION
PHP5.3以上でxdebug使っているとエラーが上がってきてしまうので修正しました。
