### PR TITLE
メールフォーム管理にて、メールフォームアカウント名が空で登録される不具合を改修

### DIFF
--- a/lib/Baser/Plugin/Mail/Model/MailContent.php
+++ b/lib/Baser/Plugin/Mail/Model/MailContent.php
@@ -72,7 +72,9 @@ class MailContent extends MailAppModel {
 				'message' => '入力されたメールフォームアカウント名は既に使用されています。'),
 			'maxLength' => array(
 				'rule' => array('maxLength', 100),
-				'message' => 'メールフォームアカウント名は100文字以内で入力してください。')
+				'message' => 'メールフォームアカウント名は100文字以内で入力してください。'),
+			'notEmpty' => array('rule' => array('notEmpty'),
+				'message' => "メールフォームアカウント名を入力してください。")
 		),
 		'title' => array(
 			array('rule' => array('notEmpty'),


### PR DESCRIPTION
メールフォーム設定編集画面内、基本項目の「メールフォームアカウント名 」に関するバリデーションを追加しました！！ご確認よろしくお願い致します！！
