### PR TITLE
Firefox(Mac), IE11(Windows)で、ブログ記事編集画面の「新しいカテゴリを追加」ボタンを押してカテゴリ登録すると、エラーが表示される件の修正

### DIFF
--- a/lib/Baser/Plugin/Blog/View/BlogPosts/admin/form.php
+++ b/lib/Baser/Plugin/Blog/View/BlogPosts/admin/form.php
@@ -160,6 +160,7 @@ $(function(){
 				$("#BlogPostBlogCategoryId").effect("highlight",{},1500);
 			}
 		});
+		return false;
 	});
 });
 </script>


### PR DESCRIPTION
おねがいします！
