### PR TITLE
fixed #6457 ブログにて、タグで記事を一覧表示できない点を改修

### DIFF
--- a/lib/Baser/Plugin/Blog/Controller/BlogController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogController.php
@@ -580,7 +580,7 @@ class BlogController extends BlogAppController {
 				'recursive' => 1
 			));
 			if (isset($tags[0]['BlogPost'][0]['id'])) {
-				$ids = Hash::extract($tags, '{n}.BlogPost.id');
+				$ids = Hash::extract($tags, '{n}.BlogPost.{n}.id');
 				$conditions['BlogPost.id'] = $ids;
 			} else {
 				return array();


### PR DESCRIPTION
Hash::extract による記事ID取得の仕方が変わっているようでした。
レビューよろしくお願いします。
