### PR TITLE
fix #6475 コンテンツナビとローカルナビの表示問題を修正

### DIFF
--- a/lib/Baser/View/Helper/BcPageHelper.php
+++ b/lib/Baser/View/Helper/BcPageHelper.php
@@ -67,7 +67,7 @@ class BcPageHelper extends Helper {
  */
 	public function beforeRender($viewFile) {
 		//if ($this->request->params['controller'] == 'pages' && ($this->request->params['action'] == 'display' || $this->request->params['action'] == 'smartphone_display') && isset($this->request->params['pass'][0])) {
-		if ($this->request->params['controller'] == 'pages' && preg_match('/_display$/', $this->request->params['action']) && isset($this->request->params['pass'][0])) {
+		if ($this->request->params['controller'] == 'pages' && preg_match('/(^|_)display$/', $this->request->params['action']) && isset($this->request->params['pass'][0])) {
 			// @TODO ページ機能が.html拡張子なしに統合できたらコメントアウトされたものに切り替える
 			//$this->request->data = $this->Page->findByUrl('/'.impload('/',$this->request->params['pass'][0]));
 			$param = Configure::read('BcRequest.pureUrl');


### PR DESCRIPTION
以前はモバイルのmobile_displayアクションが判定から漏れていたのが、
下記の修正の際に逆にPC用のdisplayアクションだけ判定漏れするようになってしまったようです。
https://github.com/baserproject/basercms/commit/a9d5ed09657be3642de9ca9d19c84239a6d289bd

レビューお願いします。
