### PR TITLE
fixes #6521 サイト基本設定-SMTP設定のヘルプ用バルーンチップの表示修正

### DIFF
--- a/lib/Baser/View/SiteConfigs/admin/form.php
+++ b/lib/Baser/View/SiteConfigs/admin/form.php
@@ -459,35 +459,35 @@ h2 {}
 				<?php echo $this->BcForm->input('SiteConfig.smtp_host', array('type' => 'text', 'size' => 35, 'maxlength' => 255, 'autocomplete' => 'off')) ?>
 				<?php echo $this->BcForm->error('SiteConfig.smtp_host') ?>
 				<?php echo $this->Html->image('admin/icn_help.png', array('id' => 'helpSmtpHost', 'class' => 'btn help', 'alt' => 'ヘルプ')) ?>
-				<div id="helptextSmtpHost" class="helptext">メールの送信にSMTPサーバーを利用する場合指定します。</div>
+				<span id="helptextSmtpHost" class="helptext">メールの送信にSMTPサーバーを利用する場合指定します。</span>
 				</p>
 				<p>
 				<?php echo $this->BcForm->label('SiteConfig.smtp_port', 'ポート') ?>
 				<?php echo $this->BcForm->input('SiteConfig.smtp_port', array('type' => 'text', 'size' => 35, 'maxlength' => 255, 'autocomplete' => 'off')) ?>
 				<?php echo $this->BcForm->error('SiteConfig.smtp_port') ?>
 				<?php echo $this->Html->image('admin/icn_help.png', array('class' => 'btn help', 'alt' => 'ヘルプ')) ?>
-				<div class="helptext">メールの送信にSMTPサーバーを利用する場合指定します。入力を省略した場合、25番ポートを利用します。</div>
+				<span class="helptext">メールの送信にSMTPサーバーを利用する場合指定します。入力を省略した場合、25番ポートを利用します。</span>
 				</p>
 				<p>
 				<?php echo $this->BcForm->label('SiteConfig.smtp_user', 'ユーザー') ?>
 				<?php echo $this->BcForm->input('SiteConfig.smtp_user', array('type' => 'text', 'size' => 35, 'maxlength' => 255, 'autocomplete' => 'off')) ?>
 				<?php echo $this->BcForm->error('SiteConfig.smtp_user') ?>
 				<?php echo $this->Html->image('admin/icn_help.png', array('id' => 'helpSmtpUsername', 'class' => 'btn help', 'alt' => 'ヘルプ')) ?>
-				<div id="helptextSmtpUsername" class="helptext">メールの送信にSMTPサーバーを利用する場合指定します。</div>
+				<span id="helptextSmtpUsername" class="helptext">メールの送信にSMTPサーバーを利用する場合指定します。</span>
 				</p>
 				<p>
 				<?php echo $this->BcForm->label('SiteConfig.smtp_password', 'パスワード') ?>
 				<?php echo $this->BcForm->input('SiteConfig.smtp_password', array('type' => 'password', 'size' => 35, 'maxlength' => 255, 'autocomplete' => 'off')) ?>
 				<?php echo $this->BcForm->error('SiteConfig.smtp_password') ?>
 				<?php echo $this->Html->image('admin/icn_help.png', array('id' => 'helpSmtpPassword', 'class' => 'btn help', 'alt' => 'ヘルプ')) ?>
-				<div id="helptextSmtpPassword" class="helptext">メールの送信にSMTPサーバーを利用する場合指定します。</div>
+				<span id="helptextSmtpPassword" class="helptext">メールの送信にSMTPサーバーを利用する場合指定します。</span>
 				</p>
 				<p>
 				<?php echo $this->BcForm->label('SiteConfig.smtp_tls', 'TLS暗号化') ?>
 				<?php echo $this->BcForm->input('SiteConfig.smtp_tls', array('type' => 'radio', 'options' => $this->BcText->booleanDoList('TLS暗号化を利用'))) ?>
 				<?php echo $this->BcForm->error('SiteConfig.smtp_tls') ?>
 				<?php echo $this->Html->image('admin/icn_help.png', array('id' => 'helpSmtpTls', 'class' => 'btn help', 'alt' => 'ヘルプ')) ?>
-				<div id="helptextSmtpTls" class="helptext">SMTPサーバーがTLS暗号化を利用する場合指定します。</div>
+				<span id="helptextSmtpTls" class="helptext">SMTPサーバーがTLS暗号化を利用する場合指定します。</span>
 				</p>
 				<p>
 					<?php echo $this->BcForm->button('メール送信テスト', array('type' => 'button', 'class' => 'button-small', 'id' => 'BtnCheckSendmail')) ?>　<span id=ResultCheckSendmail></span>


### PR DESCRIPTION
pタグ内にブロック要素のdivタグが入っていたので、pタグが途中で閉じられてdivタグが外に出てしまい、ブラウザが解釈したDOMの構造が意図しないものになっていました。

divをインライン要素のspanに置換しました。
レビューお願いします。
