### PR TITLE
ブログ記事へのコメントの公開状態を変更した際にDbLogsに保存される内容が、公開・非公開が反対になっている点を修正

### DIFF
--- a/lib/Baser/Plugin/Blog/Controller/BlogCommentsController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogCommentsController.php
@@ -351,7 +351,7 @@ class BlogCommentsController extends BlogAppController {
  * @return boolean 
  */
 	protected function _changeStatus($id, $status) {
-		$statusTexts = array(0 => '公開状態', 1 => '非公開状態');
+		$statusTexts = array(0 => '非公開状態', 1 => '公開状態');
 		$data = $this->BlogComment->find('first', array('conditions' => array('BlogComment.id' => $id), 'recursive' => -1));
 		$data['BlogComment']['status'] = $status;
 		$this->BlogComment->set($data);


### PR DESCRIPTION
問題なければ取込お願いします。
