### PR TITLE
SecurityコンポーネントのblackHoleに吸い込まれた際の動作を修正

### DIFF
--- a/lib/Baser/View/Errors/error400.php
+++ b/lib/Baser/View/Errors/error400.php
@@ -20,7 +20,7 @@
 <p class="error">
 	<strong><?php echo __d('cake', 'Error'); ?>: </strong>
 	<?php printf(
-		__d('cake', 'The requested address %s was not found on this server.'),
+		__d('cake', 'The request sent to the address %s was invalid.'),
 		"<strong>'{$url}'</strong>"
 	); ?>
 </p>


### PR DESCRIPTION
最近よくSecurityコンポーネントのブラックホールに引っかかるもので。
現状いくつか問題点がありまして、それらを解消したつもりです。
### 1.404 Not Foundと区別しにくい

ステータスコードは400 Bad Requestにもかかわらず、画面に表示されるエラーメッセージがCakePHPのデフォルトのまま

> "The requested address /hoge/fuga was not found on this server."

になっている。
### 2.原因を特定しにくい

ブラックホールに吸い込まれた原因がエラーメッセージにはなく、
スタックトレースにエラーの種別を表す文字列が表示されるのみなのでわかりにくい。
### 3.コールバックメソッドがprotectedだと呼び出されない

SecurityComponent::$blackHoleCallbackに指定したメソッドが
protectedだとis_callable()でfalse判定になるので呼び出されない模様。
https://github.com/baserproject/basercms/blob/dev-3/lib/Cake/Controller/Component/SecurityComponent.php#L620
現状のBcAppController::_sslFail()はprotectedなので機能していないかも。

レビューお願いします。
