### PR TITLE
getContentsNameとroutes.phpのテストにてスマホ・モバイル連動を考慮するように修正

### DIFF
--- a/lib/Baser/Lib/TestSuite/BaserTestCase.php
+++ b/lib/Baser/Lib/TestSuite/BaserTestCase.php
@@ -13,21 +13,24 @@
  */
 
 class BaserTestCase extends CakeTestCase {
-	
+
 /**
  * construct
  *
+ * @param string $name
+ * @param array $data
+ * @param string $dataName
  * @return void
  */
-	public function __construct($name = NULL, array $data = array(), $dataName = '') {
+	public function __construct($name = null, array $data = array(), $dataName = '') {
 		// =====================================================================
-		// Router::url() を内部的に利用するテストを実施した場合、Baser/Config/routes.php 
+		// Router::url() を内部的に利用するテストを実施した場合、Baser/Config/routes.php
 		// が呼び出され、そこで利用されている PluginContent モデルを利用する事になる。
 		// その際、fixture で接続先を test に切り替えた PluginContent を利用しないと
 		// missing table となってい、原因がつかみにくい為、利用していない場合は強制的に
 		// 利用する設定とした。
 		// =====================================================================
-		if(!isset($this->fixtures) || !in_array('baser.PluginContent', $this->fixtures)) {
+		if (!isset($this->fixtures) || !in_array('baser.PluginContent', $this->fixtures)) {
 			$this->fixtures[] = 'baser.PluginContent';
 		}
 		parent::__construct($name, $data, $dataName);
@@ -51,17 +54,52 @@ class BaserTestCase extends CakeTestCase {
  * ユーザーエージェント判定に利用される値をConfigureに設定
  * bootstrap.phpで行われている処理の代替
  *
- * @param string $key エージェントを表す文字列キー
+ * @param string $prefix エージェントのプレフィックス
  * @return void
  */
-	protected function _setAgent($key) {
-		$agent = Configure::read("BcAgent.{$key}");
-		if(empty($agent)) {
+	protected function _setAgent($prefix) {
+		$agent = Configure::read("BcAgent.{$prefix}");
+		if (empty($agent)) {
 			return;
 		}
-		Configure::write('BcRequest.agent', $key);
+		Configure::write('BcRequest.agent', $prefix);
 		Configure::write('BcRequest.agentPrefix', $agent['prefix']);
 		Configure::write('BcRequest.agentAlias', $agent['alias']);
 	}
-	
+
+/**
+ * エージェント判定に利用される値を消去する
+ *
+ * @return void
+ */
+	protected function _unsetAgent() {
+		Configure::delete('BcRequest.agent');
+		Configure::delete('BcRequest.agentPrefix');
+		Configure::delete('BcRequest.agentAlias');
+	}
+/**
+ * エージェントごとの固定ページの連動の判定に利用される値をConfigureに設定
+ *
+ * @param string $prefix エージェントのプレフィックス
+ * @return void
+ */
+	protected function _setAgentLink($prefix) {
+		$agent = Configure::read("BcAgent.{$prefix}");
+		if (empty($agent)) {
+			return;
+		}
+		Configure::write("BcSite.linked_pages_{$prefix}", '1');
+	}
+
+/**
+ * エージェントの連携の判定を全てOFFにする
+ *
+ * @return void
+ */
+	protected function _unsetAgentLinks() {
+		$prefixes = array('smartphone', 'mobile');
+		foreach ($prefixes as $prefix) {
+			Configure::write("BcSite.linked_pages_{$prefix}", '0');
+		}
+	}
 }

--- a/lib/Baser/Test/Case/Config/RoutesTest.php
+++ b/lib/Baser/Test/Case/Config/RoutesTest.php
@@ -60,11 +60,8 @@ class RoutesTest extends BaserTestCase {
  * @return array
  */
 	protected function _getParams($url) {
-		$request = new CakeRequest($url);
-		Router::setRequestInfo($request);
-		$params = Router::parse($request->url);
-		//Debugger::dump($params);
-		return $params;
+		$request = $this->_getRequest($url);
+		return $request->params;
 	}
 
 /**
@@ -156,23 +153,6 @@ class RoutesTest extends BaserTestCase {
 	}
 
 /**
- * ユーザーエージェント判定に利用される値をConfigureに設定
- * bootstrap.phpで行われている処理の代替
- *
- * @param string $key エージェントを表す文字列キー
- * @return void
- */
-    protected function _setAgent($key) {
-        $agent = Configure::read("BcAgent.{$key}");
-        if(empty($agent)) {
-            return;
-        }
-        Configure::write('BcRequest.agent', $key);
-        Configure::write('BcRequest.agentPrefix', $agent['prefix']);
-        Configure::write('BcRequest.agentAlias', $agent['alias']);
-    }
-
-/**
  * [モバイル]固定ページのルーティングテスト
  *
  * @param string $url URL
@@ -181,35 +161,36 @@ class RoutesTest extends BaserTestCase {
  *
  * @dataProvider mobilePageDisplayDataProvider
  */
-    public function testMobilePageDisplay($url, $pass) {
-        $this->_setAgent('mobile');
-        $params = $this->_getParams($url);
-        $expects = array(
-            'controller' => 'pages',
-            'action' => 'mobile_display',
-            'plugin' => null,
-            'prefix' => 'mobile',
-            'named' => array(),
-            'pass' => $pass,
-        );
-        $this->assertEquals($expects, $params);
-    }
+	public function testMobilePageDisplay($url, $pass) {
+		$this->_setAgent('mobile');
+		$this->_setAgentLink('mobile');
+		$params = $this->_getParams($url);
+		$expects = array(
+			'controller' => 'pages',
+			'action' => 'mobile_display',
+			'plugin' => null,
+			'prefix' => 'mobile',
+			'named' => array(),
+			'pass' => $pass,
+		);
+		$this->assertEquals($expects, $params);
+	}
 
 /**
  * [モバイル]固定ページ用データプロバイダ
  *
  * @return array
  *
- * @todo ページカテゴリを含むテスト追加。
+ * @todo ページカテゴリを含むテスト及びエージェント対応・連動設定を考慮したテストを追加。
  */
-    public function mobilePageDisplayDataProvider() {
-        return array(
-            array('/m/', array('index')),
-            array('/m/company', array('company')),
-            array('/m/service', array('service')),
-            array('/m/recruit', array('recruit'))
-        );
-    }
+	public function mobilePageDisplayDataProvider() {
+		return array(
+			array('/m/', array('index')),
+			array('/m/company', array('company')),
+			array('/m/service', array('service')),
+			array('/m/recruit', array('recruit'))
+		);
+	}
 
 /**
  * [スマートフォン]固定ページのルーティングテスト
@@ -220,35 +201,36 @@ class RoutesTest extends BaserTestCase {
  *
  * @dataProvider smartphonePageDisplayDataProvider
  */
-    public function testSmartphonePageDisplay($url, $pass) {
-        $this->_setAgent('smartphone');
-        $params = $this->_getParams($url);
-        $expects = array(
-            'controller' => 'pages',
-            'action' => 'smartphone_display',
-            'plugin' => null,
-            'prefix' => 'smartphone',
-            'named' => array(),
-            'pass' => $pass,
-        );
-        $this->assertEquals($expects, $params);
-    }
+	public function testSmartphonePageDisplay($url, $pass) {
+		$this->_setAgent('smartphone');
+		$this->_setAgentLink('smartphone');
+		$params = $this->_getParams($url);
+		$expects = array(
+			'controller' => 'pages',
+			'action' => 'smartphone_display',
+			'plugin' => null,
+			'prefix' => 'smartphone',
+			'named' => array(),
+			'pass' => $pass,
+		);
+		$this->assertEquals($expects, $params);
+	}
 
 /**
  * [スマートフォン]固定ページ用データプロバイダ
  *
  * @return array
  *
- * @todo ページカテゴリを含むテスト追加。
+ * @todo ページカテゴリを含むテスト及びエージェント対応・連動設定を考慮したテストを追加。
  */
-    public function smartphonePageDisplayDataProvider() {
-        return array(
-            array('/s/', array('index')),
-            array('/s/company', array('company')),
-            array('/s/service', array('service')),
-            array('/s/recruit', array('recruit'))
-        );
-    }
+	public function smartphonePageDisplayDataProvider() {
+		return array(
+			array('/s/', array('index')),
+			array('/s/company', array('company')),
+			array('/s/service', array('service')),
+			array('/s/recruit', array('recruit'))
+		);
+	}
 
 /**
  * プラグインコンテンツのルーティングテスト

--- a/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
@@ -891,16 +891,28 @@ class BcBaserHelperTest extends BaserTestCase {
  * ・ページの場合は、カテゴリ名（カテゴリがない場合は Default）
  * ・トップページは、Home
  *
- * @param string $agent エージェント
  * @param string $url URL
  * @param string $expects コンテンツ名
+ * @param string $ua リクエストのユーザーエージェント
+ * @param array $agents 対応する設定のエージェントのリスト
+ * @param array $linkedAgents 連動する設定のエージェントのリスト
  *
  * @dataProvider getContentsNameDataProvider
  */
-	public function testGetContensName($agent = null, $url, $expects) {
-		if(!empty($agent)) {
-			$this->_setAgent($agent);
+	public function testGetContentsName($url, $expects, $ua = null, array $agents = array(), array $linkedAgents = array()) {
+		//Configure周りの設定を全てOFF状態に
+		$this->_unsetAgent();
+		$this->_unsetAgentLinks();
+
+		if (!empty($ua) && !empty($agents) && in_array($ua, $agents)) {
+			   $this->_setAgent($ua);
 		}
+
+		//連携を設定
+		foreach ($linkedAgents as $linked) {
+			$this->_setAgentLink($linked);
+		}
+
 		$this->BcBaser->request = $this->_getRequest($url);
 		$this->assertEquals($expects, $this->BcBaser->getContentsName());
 	}
@@ -912,18 +924,39 @@ class BcBaserHelperTest extends BaserTestCase {
  */
 	public function getContentsNameDataProvider() {
 		return array(
-			array(null, '/', 'Home'),
-			array('mobile', '/m/', 'Home'),
-			array('smartphone', '/s/', 'Home'),
-			array(null, '/news', 'News'),
-			array('mobile', '/m/news', 'News'),
-			array('smartphone', '/s/news', 'News'),
-			array(null, '/contact', 'Contact'),
-			array('mobile', '/m/contact', 'Contact'),
-			array('smartphone', '/s/contact', 'Contact'),
-			array(null, '/company', 'Default'),
-			array('mobile', '/m/company', 'Default'),
-			array('smartphone', '/s/company', 'Default')
+			//PC
+			array('/', 'Home'),
+			array('/news', 'News'),
+			array('/contact', 'Contact'),
+			array('/company', 'Default'),
+
+			//モバイル　対応OFF 連動OFF
+
+			//スマートフォン 対応OFF　連動OFF
+
+			//モバイル　対応ON 連動OFF
+			array('/m/', 'Home', 'mobile', array('mobile')),
+			array('/m/news', 'News', 'mobile', array('mobile')),
+			array('/m/contact', 'Contact', 'mobile', array('mobile')),
+			array('/m/company', 'M', 'mobile', array('mobile')),
+
+			//スマートフォン 対応ON　連動OFF
+			array('/s/', 'Home', 'smartphone', array('smartphone')),
+			array('/s/news', 'News', 'smartphone', array('smartphone')),
+			array('/s/contact', 'Contact', 'smartphone', array('smartphone')),
+			array('/s/company', 'S', 'smartphone', array('smartphone')),
+
+			//モバイル　対応ON 連動ON
+			array('/m/', 'Home', 'mobile', array('mobile'), array('mobile')),
+			array('/m/news', 'News', 'mobile', array('mobile'), array('mobile')),
+			array('/m/contact', 'Contact', 'mobile', array('mobile'), array('mobile')),
+			array('/m/company', 'Default', 'mobile', array('mobile'), array('mobile')),
+
+			//スマートフォン 対応ON　連動ON
+			array('/s/', 'Home', 'smartphone', array('smartphone'), array('smartphone')),
+			array('/s/news', 'News', 'smartphone', array('smartphone'), array('smartphone')),
+			array('/s/contact', 'Contact', 'smartphone', array('smartphone'), array('smartphone')),
+			array('/s/company', 'Default', 'smartphone', array('smartphone'), array('smartphone'))
 		);
 	}
 	


### PR DESCRIPTION
スマホ・モバイルに対応する・連動する設定をシミュレートできるようにBaserTestCaseにメソッド追加しました。
確認お願いします。

P.S.routes.phpもテストが通るように修正しましたが、
詳細を詰め切れていないので考えが整理できたらケースを追加します。
