### PR TITLE
ブログカテゴリが親子構造の場合、パンくず箇所に階層構造が反映されるように変更

### DIFF
--- a/lib/Baser/Plugin/Blog/Controller/BlogController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogController.php
@@ -254,7 +254,7 @@ class BlogController extends BlogAppController {
 				if (count($blogCategories) > 1) {
 					foreach ($blogCategories as $key => $blogCategory) {
 						if ($key < count($blogCategories) - 1) {
-							$crumbs[] = array('name' => $blogCategory['BlogCategory']['title'], 'url' => '/' . $this->blogContent['BlogContent']['name'] . '/archives/category/' . $blogCategory['BlogCategory']['name']);
+							$this->crumbs[] = array('name' => $blogCategory['BlogCategory']['title'], 'url' => '/' . $this->blogContent['BlogContent']['name'] . '/archives/category/' . $blogCategory['BlogCategory']['name']);
 						}
 					}
 				}


### PR DESCRIPTION
ブログカテゴリアーカイブ表示の際に、パンくずリストに所属カテゴリのみ表示されていたため、子カテゴリに属する際は親カテゴリも表示するようにしました。
レビューよろしくお願いします！
