### PR TITLE
fixes #4891 カテゴリ追加権限がない場合、記事編集画面のカテゴリ追加ボタンを非表示に変更

### DIFF
--- a/lib/Baser/Plugin/Blog/Controller/BlogCategoriesController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogCategoriesController.php
@@ -20,6 +20,8 @@
  * カテゴリコントローラー
  *
  * @package Blog.Controller
+ * @property BlogContent $BlogContent
+ * @property BlogCategory $BlogCategory
  */
 class BlogCategoriesController extends BlogAppController {
 

--- a/lib/Baser/Plugin/Blog/Controller/BlogPostsController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogPostsController.php
@@ -322,6 +322,10 @@ class BlogPostsController extends BlogAppController {
 			'empty' => '指定しない'
 		));
 
+		$Permission = ClassRegistry::init('Permission');
+		$blogCategoryAddUrl = preg_replace('|^/index.php|', '', Router::url(array('plugin' => 'blog', 'controller' => 'blog_categories', 'action' => 'ajax_add', $blogContentId)));
+		$categoryAddable = $Permission->check($blogCategoryAddUrl, $user['user_group_id']);
+
 		$editorOptions = array('editorDisableDraft' => true);
 		if (!empty($this->siteConfigs['editor_styles'])) {
 			App::uses('CKEditorStyleParser', 'Vendor');
@@ -335,6 +339,7 @@ class BlogPostsController extends BlogAppController {
 
 		$this->set('editable', true);
 		$this->set('categories', $categories);
+		$this->set('categoryAddable', $categoryAddable);
 		$this->set('previewId', 'add_' . mt_rand(0, 99999999));
 		$this->set('editorOptions', $editorOptions);
 		$this->set('users', $this->BlogPost->User->getUserList(array('User.id' => $user['id'])));
@@ -418,6 +423,10 @@ class BlogPostsController extends BlogAppController {
 			'empty' => '指定しない'
 		));
 
+		$Permission = ClassRegistry::init('Permission');
+		$blogCategoryAddUrl = preg_replace('|^/index.php|', '', Router::url(array('plugin' => 'blog', 'controller' => 'blog_categories', 'action' => 'ajax_add', $blogContentId)));
+		$categoryAddable = $Permission->check($blogCategoryAddUrl, $user['user_group_id']);
+
 		if ($this->request->data['BlogPost']['status']) {
 			$this->set('publishLink', '/' . $this->blogContent['BlogContent']['name'] . '/archives/' . $this->request->data['BlogPost']['no']);
 		}
@@ -436,6 +445,7 @@ class BlogPostsController extends BlogAppController {
 		$this->set('currentCatOwnerId', $currentCatOwner);
 		$this->set('editable', $editable);
 		$this->set('categories', $categories);
+		$this->set('categoryAddable', $categoryAddable);
 		$this->set('previewId', $this->request->data['BlogPost']['id']);
 		$this->set('users', $this->BlogPost->User->getUserList());
 		$this->set('editorOptions', $editorOptions);

--- a/lib/Baser/Plugin/Blog/View/BlogPosts/admin/form.php
+++ b/lib/Baser/Plugin/Blog/View/BlogPosts/admin/form.php
@@ -219,7 +219,9 @@ $(function(){
 			<th class="col-head"><?php echo $this->BcForm->label('BlogPost.blog_category_id', 'カテゴリー') ?></th>
 			<td class="col-input">
 				<?php echo $this->BcForm->input('BlogPost.blog_category_id', array('type' => 'select', 'options' => $categories, 'escape' => false)) ?>&nbsp;
-				<?php echo $this->BcForm->button('新しいカテゴリを追加', array('id' => 'BtnAddBlogCategory')) ?>
+				<?php if($categoryAddable): ?>
+					<?php echo $this->BcForm->button('新しいカテゴリを追加', array('id' => 'BtnAddBlogCategory')) ?>
+				<?php endif; ?>
 				<?php $this->BcBaser->img('admin/ajax-loader-s.gif', array('style' => 'vertical-align:middle;display:none', 'id' => 'BlogCategoryLoader', 'class' => 'loader')) ?>
 				<?php echo $this->BcForm->error('BlogPost.blog_category_id') ?>
 			</td>


### PR DESCRIPTION
[問題点 #4891 ブログカテゴリの追加が許可されてない場合でも記事編集画面にカテゴリ追加ボタンが表示されている](http://project.e-catchup.jp/issues/4891)
の修正です。レビューお願いします。
