### PR TITLE
fixes #6308 URLの拡張子をrssにすると発生するCakePHPのエラーを修正しbaserCMSのエラー画面を表示するようにした

### DIFF
--- a/lib/Baser/View/Helper/BcBaserHelper.php
+++ b/lib/Baser/View/Helper/BcBaserHelper.php
@@ -316,17 +316,11 @@ class BcBaserHelper extends AppHelper {
  * @return string コンテンツタイトル
  */
 	public function getContentsTitle() {
-
-		$contentsTitle = '';
-		if ($this->_View->pageTitle) {
-			$contentsTitle = $this->_View->pageTitle;
-		}
-		if ($this->_View->name != 'CakeError') {
-			return $contentsTitle;
-		} else {
+		if ($this->_View->name === 'CakeError' || empty($this->_View->pageTitle)) {
 			return '';
 		}
-		
+
+		return $this->_View->pageTitle;
 	}
 
 /**


### PR DESCRIPTION
baserCMSのエラー処理以前にこけてCakePHPのエラーが表示されていたのは
BcBaserHelper::getContentsTitle()内で取得する$this->_view->pageTitleが
未定義になっていてマジックメソッドでpageTitleHelperが探されていたせいのようです。
そこだけ書き直しました。

この修正でbaserCMSのNot Found（デバッグモードではController Not Found）のエラー画面が出るようになっています。

レビューお願いします。
