### PR TITLE
fixes #6943 Feed詳細設定の編集保存時にエラーとなってしまう 問題を修正

### DIFF
--- a/lib/Baser/Plugin/Feed/Controller/FeedConfigsController.php
+++ b/lib/Baser/Plugin/Feed/Controller/FeedConfigsController.php
@@ -20,6 +20,9 @@
  * フィード設定コントローラー
  *
  * @package Feed.Controller
+ * @property Feed $Feed
+ * @property FeedConfig $FeedConfig
+ * @property FeedDetail $FeedDetail
  */
 class FeedConfigsController extends FeedAppController {
 
@@ -37,7 +40,7 @@ class FeedConfigsController extends FeedAppController {
  * @var array
  * @access public
  */
-	public $uses = array("Feed.FeedConfig", "Feed.FeedDetail", "Feed.RssEx");
+	public $uses = array("Feed.FeedConfig", "Feed.FeedDetail", "Feed.Feed");
 
 /**
  * ヘルパー
@@ -357,10 +360,10 @@ class FeedConfigsController extends FeedAppController {
 		if ($url) {
 			if (strpos($url, 'http') === false) {
 				// 実際のキャッシュではSSLを利用しているかどうかわからないので、両方削除する
-				clearCache($this->RssEx->__createCacheHash('', 'http://' . $_SERVER['HTTP_HOST'] . $this->base . $url), 'views', '.rss');
-				clearCache($this->RssEx->__createCacheHash('', 'https://' . $_SERVER['HTTP_HOST'] . $this->base . $url), 'views', '.rss');
+				clearCache($this->Feed->createCacheHash('', 'http://' . $_SERVER['HTTP_HOST'] . $this->base . $url), 'views', '.rss');
+				clearCache($this->Feed->createCacheHash('', 'https://' . $_SERVER['HTTP_HOST'] . $this->base . $url), 'views', '.rss');
 			} else {
-				clearCache($this->RssEx->__createCacheHash('', $url), 'views', '.rss');
+				clearCache($this->Feed->createCacheHash('', $url), 'views', '.rss');
 			}
 		} else {
 			clearViewCache(null, 'rss');

--- a/lib/Baser/Plugin/Feed/Controller/FeedDetailsController.php
+++ b/lib/Baser/Plugin/Feed/Controller/FeedDetailsController.php
@@ -20,6 +20,9 @@
  * フィード詳細コントローラー
  *
  * @package Feed.Controller
+ * @property Feed $Feed
+ * @property FeedConfig $FeedConfig
+ * @property FeedDetail $FeedDetail
  */
 class FeedDetailsController extends FeedAppController {
 
@@ -37,7 +40,7 @@ class FeedDetailsController extends FeedAppController {
  * @var array
  * @access public
  */
-	public $uses = array('Feed.FeedDetail', 'Feed.FeedConfig', 'Feed.RssEx');
+	public $uses = array('Feed.FeedDetail', 'Feed.FeedConfig', 'Feed.Feed');
 
 /**
  * ヘルパー
@@ -190,10 +193,10 @@ class FeedDetailsController extends FeedAppController {
 		clearViewCache('/feed/cachetime/' . $feedConfigId);
 		if (strpos($url, 'http') === false) {
 			// 実際のキャッシュではSSLを利用しているかどうかわからないので、両方削除する
-			clearCache($this->RssEx->__createCacheHash('', 'http://' . $_SERVER['HTTP_HOST'] . $this->base . $url), 'views', '.rss');
-			clearCache($this->RssEx->__createCacheHash('', 'https://' . $_SERVER['HTTP_HOST'] . $this->base . $url), 'views', '.rss');
+			clearCache($this->Feed->createCacheHash('', 'http://' . $_SERVER['HTTP_HOST'] . $this->base . $url), 'views', '.rss');
+			clearCache($this->Feed->createCacheHash('', 'https://' . $_SERVER['HTTP_HOST'] . $this->base . $url), 'views', '.rss');
 		} else {
-			clearCache($this->RssEx->__createCacheHash('', $url), 'views', '.rss');
+			clearCache($this->Feed->createCacheHash('', $url), 'views', '.rss');
 		}
 	}
 

--- a/lib/Baser/Plugin/Feed/Model/Feed.php
+++ b/lib/Baser/Plugin/Feed/Model/Feed.php
@@ -245,5 +245,15 @@ class Feed extends FeedAppModel {
 
 		return md5($hashSource) . $ext;
 	}
-	
+
+/**
+ * URL文字列に対しキャッシュファイルのハッシュを生成して返す
+ *
+ * @param string $ext 拡張子
+ * @param string $url URL文字列
+ * @return string
+ */
+	public function createCacheHash($ext = '', $url) {
+		return $this->_createCacheHash($ext, $url);
+	}
 }


### PR DESCRIPTION
RssExクラスで行われていた処理の代替として、
保存時にFeedモデルで行われているキャッシュファイル名用のハッシュ生成処理を借りて調整しました。
メソッドのアクセシビリティがprotectedだったのでpublicのラッパ追加してます。

レビューお願いします。
