### PR TITLE
fixes #4891 ブログカテゴリの追加が許可されてない場合でも記事編集画面にカテゴリ追加ボタンが表示されている 問題を修正

### DIFF
--- a/lib/Baser/Plugin/Blog/Controller/BlogAppController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogAppController.php
@@ -21,6 +21,8 @@ App::uses('BcPluginAppController', 'Controller');
  * ブログコントローラー基底クラス
  *
  * @package			Blog.Controller
+ * @property BlogPost $BlogPost
+ * @property BlogCategory $BlogCategory
  */
 class BlogAppController extends BcPluginAppController {
 

--- a/lib/Baser/Plugin/Blog/Controller/BlogCategoriesController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogCategoriesController.php
@@ -20,6 +20,8 @@
  * カテゴリコントローラー
  *
  * @package Blog.Controller
+ * @property BlogContent $BlogContent
+ * @property BlogCategory $BlogCategory
  */
 class BlogCategoriesController extends BlogAppController {
 

--- a/lib/Baser/Plugin/Blog/Model/BlogCategory.php
+++ b/lib/Baser/Plugin/Blog/Model/BlogCategory.php
@@ -285,13 +285,11 @@ class BlogCategory extends BlogAppModel {
 /**
  * 新しいカテゴリが追加できる状態かチェックする
  * 
- * @param int $userGroupId
- * @param boolean $rootEditable
- * @return boolean
- * @access public
+ * @param int $userGroupId ユーザーグループID
+ * @param bool $rootEditable ドキュメントルートの書き込み権限の有無
+ * @return bool
  */
 	public function checkNewCategoryAddable($userGroupId, $rootEditable) {
-		$newCatAddable = false;
 		$ownerCats = $this->find('count', array(
 			'conditions' => array(
 				'OR' => array(
@@ -300,10 +298,20 @@ class BlogCategory extends BlogAppModel {
 				)
 		)));
 
-		if ($ownerCats || $rootEditable) {
-			$newCatAddable = true;
+		if (ClassRegistry::isKeySet('Permission')) {
+			$Permission = ClassRegistry::getObject('Permission');
+		} else {
+			$Permission = ClassRegistry::init('Permission');
 		}
-		return $newCatAddable;
+
+		$ajaxAddUrl = preg_replace('|^/index.php|', '', Router::url(array('plugin' => 'blog', 'controller' => 'blog_categories', 'action' => 'ajax_add')));
+		$hasUrlPermission = $Permission->check($ajaxAddUrl, $userGroupId);
+
+		if (($ownerCats || $rootEditable) && $hasUrlPermission) {
+			return true;
+		}
+
+		return false;
 	}
 
 }

--- a/lib/Baser/Plugin/Blog/View/BlogPosts/admin/form.php
+++ b/lib/Baser/Plugin/Blog/View/BlogPosts/admin/form.php
@@ -219,7 +219,9 @@ $(function(){
 			<th class="col-head"><?php echo $this->BcForm->label('BlogPost.blog_category_id', 'カテゴリー') ?></th>
 			<td class="col-input">
 				<?php echo $this->BcForm->input('BlogPost.blog_category_id', array('type' => 'select', 'options' => $categories, 'escape' => false)) ?>&nbsp;
-				<?php echo $this->BcForm->button('新しいカテゴリを追加', array('id' => 'BtnAddBlogCategory')) ?>
+				<?php if($newCatAddable): ?>
+					<?php echo $this->BcForm->button('新しいカテゴリを追加', array('id' => 'BtnAddBlogCategory')) ?>
+				<?php endif ?>
 				<?php $this->BcBaser->img('admin/ajax-loader-s.gif', array('style' => 'vertical-align:middle;display:none', 'id' => 'BlogCategoryLoader', 'class' => 'loader')) ?>
 				<?php echo $this->BcForm->error('BlogPost.blog_category_id') ?>
 			</td>


### PR DESCRIPTION
BlogCategory::checkNewCategoryAddable()のカテゴリオーナーの設定に依る旧来の判定値が真
　　　　かつ
カテゴリ追加アクションBlogCategoriesController::ajax_add()のURLに対するアクセス権がある

という場合のみ真値を返すようにメソッドを修正しました。

View側では、BlogAppController::beforeFilterですでにView変数$newCatAddableがセットされていたのでそちらを利用しています。

確認お願いします。
