### PR TITLE
fixes #7216 baserCMS新規インストール時にプラグインの優先順位が正しく設定されない 修正

### DIFF
--- a/lib/Baser/Controller/Component/BcManagerComponent.php
+++ b/lib/Baser/Controller/Component/BcManagerComponent.php
@@ -290,6 +290,7 @@ class BcManagerComponent extends Component {
 		$corePlugins = Configure::read('BcApp.corePlugins');
 
 		$result = true;
+		$priority = intval($Plugin->getMax('priority')) + 1;
 		foreach ($corePlugins as $corePlugin) {
 			$data = array();
 			include BASER_PLUGINS . $corePlugin . DS . 'config.php';
@@ -298,10 +299,12 @@ class BcManagerComponent extends Component {
 			$data['Plugin']['version'] = $version;
 			$data['Plugin']['status'] = true;
 			$data['Plugin']['db_inited'] = true;
+			$data['Plugin']['priority'] = $priority;
 			$Plugin->create($data);
 			if (!$Plugin->save()) {
 				$result = false;
 			}
+			$priority++;
 		}
 		return $result;
 	}

--- a/lib/Baser/Controller/PluginsController.php
+++ b/lib/Baser/Controller/PluginsController.php
@@ -161,10 +161,10 @@ class PluginsController extends AppController {
 		//並び替えモードの場合はDBにデータが登録されていないプラグインを表示しない
 		if (!empty($this->passedArgs['sortmode'])) {
 			$sortmode = true;
-			$pluginInfo = Hash::sort($availables, '{n}.Plugin.priority', 'asc', 'numeric');
+			$pluginInfos = Hash::sort($availables, '{n}.Plugin.priority', 'asc', 'numeric');
 		} else {
 			$sortmode = false;
-			$pluginInfo = Hash::sort($availables, '{n}.Plugin.priority', 'asc', 'numeric') + $unavailables;
+			$pluginInfos = Hash::sort($availables, '{n}.Plugin.priority', 'asc', 'numeric') + $unavailables;
 		}
 
 		// 表示設定


### PR DESCRIPTION
修正しないことにはプラグインの新機能が全く確認できないので先にプルリク送ります。
ついでに一覧画面の並び順も修正しました。
確認お願いします。
