### PR TITLE
fixes #7281 DBのbaserCMSのバージョンが空の場合エラーになる　修正

### DIFF
--- a/lib/Baser/Controller/BcAppController.php
+++ b/lib/Baser/Controller/BcAppController.php
@@ -184,6 +184,7 @@ class BcAppController extends Controller {
 				$this->siteConfigs = Configure::read('BcSite');
 				if (empty($this->siteConfigs['version'])) {
 					$this->siteConfigs['version'] = $this->getBaserVersion();
+					$SiteConfig = ClassRegistry::init('SiteConfig');
 					$SiteConfig->saveKeyValue($this->siteConfigs);
 				}
 			} catch (Exception $ex) {


### PR DESCRIPTION
一つ変数が足りませんでした。
この分岐を確実に通るわけではないようなので、手元の環境では無理やりbaserのバージョンを消さないと再現しませんでした。

アップデート時のエラーのもう一件の報告については原因未確認です。
