### PR TITLE
fixes #7294 コンソールからBcAppControllerを継承したクラスを呼び出すとエラーになる 修正

### DIFF
--- a/lib/Baser/Controller/BcAppController.php
+++ b/lib/Baser/Controller/BcAppController.php
@@ -20,6 +20,7 @@ App::uses('BcAuthConfigureComponent', 'Controller/Component');
 App::uses('File', 'Core.Utility');
 App::uses('ErrorHandler', 'Core.Error');
 App::uses('CakeEmail', 'Network/Email');
+App::uses('Controller', 'Controller');
 
 /**
  * Controller 拡張クラス


### PR DESCRIPTION
http://project.e-catchup.jp/issues/7294 の修正です。
よろしくお願いします。
