### PR TITLE
fixes #7304 メールのReply-Toの設定がおかしい 問題を修正

### DIFF
--- a/lib/Baser/Controller/BcAppController.php
+++ b/lib/Baser/Controller/BcAppController.php
@@ -749,7 +749,6 @@ class BcAppController extends Controller {
  * @param	mixed	$body	本文
  * @options	array
  * @return	boolean			送信結果
- * @access	public
  */
 	public function sendMail($to, $title = '', $body = '', $options = array()) {
 		$options = array_merge(array(
@@ -892,10 +891,23 @@ class BcAppController extends Controller {
 				$formalName = Configure::read('BcApp.title');
 			}
 		}
-
 		$cakeEmail->from($from, $fromName);
-		$cakeEmail->replyTo($from);
-		$cakeEmail->returnPath($from);
+
+		//Reply-To
+		if (!empty($options['replyTo'])) {
+			$replyTo = $options['replyTo'];
+		} else {
+			$replyTo = $from;
+		}
+		$cakeEmail->replyTo($replyTo);
+
+		//Return-Path
+		if (!empty($options['returnPath'])) {
+			$returnPath = $options['returnPath'];
+		} else {
+			$returnPath = $from;
+		}
+		$cakeEmail->returnPath($returnPath);
 
 		//$sender
 		if (!empty($options['sender'])) {

--- a/lib/Baser/Plugin/Mail/Controller/MailController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailController.php
@@ -535,9 +535,9 @@ class MailController extends MailAppController {
 			$data['other']['mode'] = 'user';
 			$options = array(
 				'fromName'	=> $mailContent['sender_name'],
-				'reply'		=> $fromAdmin,
+				'from'		=> $fromAdmin,
 				'template'	=> 'Mail.' . $mailContent['mail_template'],
-				'reply'		=> $fromAdmin,
+				'replyTo'		=> $fromAdmin,
 				'attachments'	=> $attachments
 			);
 			$this->sendMail($userMail, $mailContent['subject_user'], $data, $options);
@@ -548,7 +548,7 @@ class MailController extends MailAppController {
 			$data['other']['mode'] = 'admin';
 			$options = array(
 				'fromName' => $mailContent['sender_name'],
-				'reply' => $userMail,
+				'replyTo' => $userMail,
 				'from' => $fromAdmin,
 				'template' => 'Mail.' . $mailContent['mail_template'],
 				'bcc' => $mailContent['sender_2'],


### PR DESCRIPTION
ひとまずリファクタリングは置いておいて修正です。
$optionsの'replyTo'の設定がない場合はfromと同じにしました。
※近くにあったのでReturn-Pathもついでに設定できるようにしておきました。

確認お願いします。
