### PR TITLE
fixes #7580 ファイルのフィールドを含むフォームで入力確認ボタンを押したときにエラーになる 問題を修正

### DIFF
--- a/lib/Baser/Plugin/Mail/View/Helper/MailformHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MailformHelper.php
@@ -181,4 +181,21 @@ class MailformHelper extends BcFreezeHelper {
 		return $out;
 	}
 
+
+/**
+ * create
+ * ファイル添付の対応のためにデフォルト値を変更
+ *
+ * @param array $model
+ * @param array $options
+ * @return string
+ */
+	public function create($model = null, $options = array()) {
+		if (!isset($options['type'])) {
+			$options['type'] = 'file';
+		}
+
+		return parent::create($model, $options);
+	}
+
 }

--- a/lib/Baser/View/Helper/BcFormHelper.php
+++ b/lib/Baser/View/Helper/BcFormHelper.php
@@ -1363,8 +1363,6 @@ DOC_END;
  * @return string
  */
 	public function file($fieldName, $options = array()) {
-
-		$options = $this->_initInputField($fieldName, $options);
 		$entity = $this->entity();
 		$modelName = array_shift($entity);
 		$field = $this->field();


### PR DESCRIPTION
SecurityComponentのvalidatePost周りの調整です。
確認お願いします。

http://project.e-catchup.jp/issues/7580
