### PR TITLE
Add mod_ssl to installed packages.

### DIFF
--- a/vagrant_cookbooks/httpd/recipes/default.rb
+++ b/vagrant_cookbooks/httpd/recipes/default.rb
@@ -1,4 +1,4 @@
-packages = %w{httpd httpd-devel php php-cli php-pear php-pdo php-mysql php-pgsql php-sqlite php-curl php-gd php-mbstring php-xml php-xmlrpc php-dom php-pecl-xdebug phpMyAdmin phpPgAdmin}
+packages = %w{httpd httpd-devel mod_ssl php php-cli php-pear php-pdo php-mysql php-pgsql php-sqlite php-curl php-gd php-mbstring php-xml php-xmlrpc php-dom php-pecl-xdebug phpMyAdmin phpPgAdmin}
 packages.each do |packagename|
   package packagename do
     action :install


### PR DESCRIPTION
# Purpose

To support SSL on developing basercms. We can't connect to basercms using SSL even if SSL support of basercms is enabled, because there is no `mod_ssl` installed on Virtual Machine.
# Changes

Add `mod_ssl` to packages installed by vagrant.

Sincerely.
