### PR TITLE
fixed #7724 ユーザーエージェント関連処理のリファクタリング

### DIFF
--- a/lib/Baser/Config/bootstrap.php
+++ b/lib/Baser/Config/bootstrap.php
@@ -79,7 +79,7 @@ define('BC_BASE_URL', baseUrl());
 /**
  * アセットフィルターを追加
  */
-Configure::write('Dispatcher.filters', array_merge(Configure::read('Dispatcher.filters'), array('BcAssetDispatcher', 'BcCacheDispatcher')));
+Configure::write('Dispatcher.filters', array_merge(Configure::read('Dispatcher.filters'), array('BcAssetDispatcher', 'BcCacheDispatcher', 'BcRequestFilter')));
 
 /**
  * クラスローダー設定
@@ -180,7 +180,7 @@ if (BC_INSTALLED) {
 		'types' => array('update'),
 		'file' => 'update',
 	));
-	
+
 /**
  * キャッシュ設定
  */
@@ -304,94 +304,7 @@ if (!isConsole()) {
 	$Session = new CakeSession();
 	$Session->start();
 }
-/**
- * パラメーター取得
- * モバイル判定・簡易リダイレクト
- */
-$agentSettings = Configure::read('BcAgent');
-if (!Configure::read('BcApp.mobile')) {
-	unset($agentSettings['mobile']);
-}
-if (!Configure::read('BcApp.smartphone')) {
-	unset($agentSettings['smartphone']);
-}
-$agentOn = false;
-if ($agentSettings) {
-	foreach ($agentSettings as $key => $setting) {
-		$agentOn = false;
-		if (!empty($url)) {
-			$parameters = explode('/', $url);
-			if ($parameters[0] == $setting['alias']) {
-				$agentOn = true;
-			}
-		}
-		if (!$agentOn && $setting['autoRedirect']) {
-			$agentAgents = $setting['agents'];
-			$agentAgents = implode('||', $agentAgents);
-			$agentAgents = preg_quote($agentAgents, '/');
-			$regex = '/' . str_replace('\|\|', '|', $agentAgents) . '/i';
-			if (isset($_SERVER['HTTP_USER_AGENT']) && preg_match($regex, $_SERVER['HTTP_USER_AGENT'])) {
-				$getParams = str_replace(BC_BASE_URL . $parameter, '', $_SERVER['REQUEST_URI']);
-				if ($getParams == '/' || $getParams == '/index.php') {
-					$getParams = '';
-				}
 
-				$redirect = true;
-
-				// URLによる AUTO REDIRECT 設定
-				if (isset($_GET[$setting['prefix'] . '_auto_redirect'])) {
-					if ($_GET[$setting['prefix'] . '_auto_redirect'] == 'on') {
-						$_SESSION[$setting['prefix'] . '_auto_redirect'] = 'on';
-					} elseif ($_GET[$setting['prefix'] . '_auto_redirect'] == 'off') {
-						$_SESSION[$setting['prefix'] . '_auto_redirect'] = 'off';
-					}
-				}
-
-				if (isset($_SESSION[$setting['prefix'] . '_auto_redirect'])) {
-					if ($_SESSION[$setting['prefix'] . '_auto_redirect'] == 'off') {
-						$redirect = false;
-					}
-				}
-
-				if (isset($_GET[$setting['prefix']])) {
-					if ($_GET[$setting['prefix']] == 'on') {
-						$redirect = true;
-					} elseif ($_GET[$setting['prefix']] == 'off') {
-						$redirect = false;
-					}
-				}
-
-				if ($redirect) {
-					$redirectUrl = FULL_BASE_URL . BC_BASE_URL . $setting['alias'] . '/' . $parameter . $getParams;
-					header("HTTP/1.1 301 Moved Permanently");
-					header("Location: " . $redirectUrl);
-					exit();
-				}
-			}
-		}
-		if ($agentOn) {
-			Configure::write('BcRequest.agent', $key);
-			Configure::write('BcRequest.agentPrefix', $setting['prefix']);
-			Configure::write('BcRequest.agentAlias', $setting['alias']);
-			break;
-		}
-	}
-}
-if ($agentOn) {
-	//======================================================================
-	// /m/files/... へのアクセスの場合、/files/... へ自動リダイレクト
-	// CMSで作成するページ内のリンクは、モバイルでアクセスすると、
-	// 自動的に、/m/ 付のリンクに書き換えられてしまう為、
-	// files内のファイルへのリンクがリンク切れになってしまうので暫定対策。
-	//======================================================================
-	$param = preg_replace('/^' . Configure::read('BcRequest.agentAlias') . '\//', '', $parameter);
-	if (preg_match('/^files/', $param)) {
-		$redirectUrl = FULL_BASE_URL . '/' . $param;
-		header("HTTP/1.1 301 Moved Permanently");
-		header("Location: " . $redirectUrl);
-		exit();
-	}
-}
 /**
  * Viewのキャッシュ設定・ログの設定
  */

--- a/lib/Baser/Model/BcAgent.php
+++ b/lib/Baser/Model/BcAgent.php
@@ -1,0 +1,298 @@
+<?php
+/**
+ * BcAgent
+ *
+ * ユーザーエージェント
+ *
+ * baserCMS :  Based Website Development Project <http://basercms.net>
+ * Copyright 2008 - 2014, baserCMS Users Community <http://sites.google.com/site/baserusers/>
+ *
+ * @copyright		Copyright 2008 - 2014, baserCMS Users Community
+ * @link			http://basercms.net baserCMS Project
+ * @package			Baser.Model
+ * @since			baserCMS v 3.1.0-beta
+ * @license			http://basercms.net/license/index.html
+ */
+
+/**
+ * Class BcAgent
+ */
+class BcAgent {
+
+/**
+ * キャッシュ用
+ * @var static[]
+ */
+	protected static $_agents = array();
+
+/**
+ * 名前
+ * @var string
+ */
+	public $name;
+
+/**
+ * エイリアス
+ * @var string
+ */
+	public $alias;
+
+/**
+ * プレフィックス
+ * @var string
+ */
+	public $prefix;
+
+/**
+ * 自動リダイレクト
+ * @var bool
+ */
+	public $autoRedirect;
+
+/**
+ * 自動リンク
+ * @var bool
+ */
+	public $autoLink;
+
+/**
+ * ユーザーエージェントの判定キーワード
+ * @var array
+ */
+	public $userAgents;
+
+/**
+ * セッションIDを付与するかどうか
+ * @var bool
+ */
+	public $sessionId;
+
+/**
+ * 名前をキーとしてインスタンスを探す
+ *
+ * @param string $name 名前
+ * @return BcAgent|null
+ */
+	public static function find($name) {
+		$key = "BcAgent.{$name}";
+		if (Configure::check($key)) {
+			return null;
+		}
+		return new static($name, Configure::read($key));
+	}
+
+/**
+ * 設定ファイルに存在する全てのインスタンスを返す
+ *
+ * @return BcAgent[]
+ */
+	public static function findAll() {
+		if (!empty(static::$_agents)) {
+			return static::$_agents;
+		}
+
+		$configs = Configure::read("BcAgent");
+
+		foreach ($configs as $name => $config) {
+			static::$_agents[] = new static($name, $config);
+		}
+
+		return static::$_agents;
+	}
+
+/**
+ * URL用aliasをキーとしてインスタンスを返す
+ *
+ * @param string $alias URL用エイリアス
+ * @return BcAgent|null
+ */
+	public static function findByAlias($alias) {
+		$agents = static::findAll();
+
+		foreach ($agents as $agent) {
+			if ($agent->alias === $alias) {
+				return $agent;
+			}
+		}
+		return null;
+	}
+
+/**
+ * 現在の環境のHTTP_USER_AGENTの値に合致するインスタンスを返す
+ *
+ * @return BcAgent|null
+ */
+	public static function findCurrent() {
+		$agents = static::findAll();
+
+		$userAgent = env('HTTP_USER_AGENT');
+		if (empty($userAgent)) {
+			return null;
+		}
+
+		foreach ($agents as $agent) {
+			if ($agent->userAgentMatches($userAgent)) {
+				return $agent;
+			}
+		}
+		return null;
+	}
+
+/**
+ * URL文字列からエイリアス文字列を取得
+ *
+ * @param string $url URL文字列
+ * @return string|null
+ */
+	public static function extractAlias($url) {
+		if (empty($url)) {
+			return null;
+		}
+
+		$params = explode('/', $url);
+		$agent = static::findByAlias($params[0]);
+
+		if (is_null($agent)) {
+			return null;
+		}
+
+		return $agent->alias;
+	}
+
+/**
+ * コンストラクタ
+ *
+ * @param string $name 名前
+ * @param array $config 設定の配列
+ */
+	public function __construct($name, array $config) {
+		$this->name = $name;
+		$config = array_merge($this->_getDefaultConfig(), $config);
+		$this->_setConfig($config);
+	}
+
+/**
+ * 設定
+ *
+ * @param array $config 設定の配列
+ * @return void
+ */
+	protected function _setConfig(array $config) {
+		$this->alias = $config['alias'];
+		$this->prefix = $config['prefix'];
+		$this->autoRedirect = $config['autoRedirect'];
+		$this->autoLink = $config['autoLink'];
+		$this->userAgents = $config['agents'];
+		$this->sessionId = $config['sessionId'];
+	}
+
+/**
+ * デフォルトの設定値を取得
+ *
+ * @return array
+ */
+	protected function _getDefaultConfig() {
+		return array(
+			'alias' => '',
+			'prefix' => '',
+			'autoRedirect' => true,
+			'autoLink' => true,
+			'userAgents' => array(),
+			'sessionId' => false
+		);
+	}
+
+/**
+ * エージェント用の設定が有効かどうかを判定
+ *
+ * @return bool
+ */
+	public function isEnabled() {
+		return (bool)Configure::read("BcApp.{$this->name}");
+	}
+
+/**
+ * URLがエージェント用かどうかを判定
+ *
+ * @param CakeRequest $request リクエスト
+ * @return bool
+ */
+	public function urlMatches($request) {
+		if (!$this->isEnabled()) {
+			return false;
+		}
+		$parameters = explode('/', $request->url);
+		return $parameters[0] === $this->alias;
+	}
+
+/**
+ * ユーザーエージェントの判定用正規表現を取得
+ *
+ * @return string
+ */
+	public function getUserAgentRegex() {
+		$regex = '/' . str_replace('\|\|', '|', preg_quote(implode('||', $this->userAgents), '/')) . '/i';
+		return $regex;
+	}
+
+/**
+ * ユーザーエージェントがキーワードを含むかどうかを判定
+ *
+ * @param string $userAgent ユーザーエージェント文字列
+ * @return bool
+ */
+	public function userAgentMatches($userAgent) {
+		$regex = $this->getUserAgentRegex();
+		return (bool)preg_match($regex, $userAgent);
+	}
+
+/**
+ * 与えられたリクエストに対して自動リダイレクトすべきかどうかを返す
+ *
+ * @param CakeRequest $request リクエスト
+ * @return bool
+ */
+	public function shouldRedirects(CakeRequest $request) {
+		if (!$this->isEnabled() || !$this->autoRedirect || $this->urlMatches($request)) {
+			return false;
+		}
+
+		// URLによる AUTO REDIRECT 設定
+		$autoRedirectKey = "{$this->prefix}_auto_redirect";
+
+		if (isset($request->query[$autoRedirectKey])
+			&& in_array($request->query[$autoRedirectKey], array('on', 'off'))) {
+			CakeSession::write($autoRedirectKey, $request->query[$autoRedirectKey]);
+		}
+
+		if (isset($request->query[$this->prefix])) {
+			switch($request->query[$this->prefix]) {
+				case 'on':
+					return true;
+				case 'off':
+					return false;
+			}
+		}
+
+		return CakeSession::read($autoRedirectKey) !== 'off';
+	}
+
+/**
+ * リクエストをリダイレクトするURLを生成
+ *
+ * @param CakeRequest $request リクエスト
+ * @return string
+ */
+	public function makeRedirectUrl(CakeRequest $request) {
+		$hereWithQuery = $request->here(false);
+		$alias = static::extractAlias($request->url);
+
+		if (is_null($alias)) {
+			return "{$this->alias}{$hereWithQuery}";
+		}
+
+		$replacedUrl = preg_replace('/^\/' . $alias . '/', $this->alias, $hereWithQuery);
+
+		return $replacedUrl;
+	}
+} 

--- a/lib/Baser/Routing/Filter/BcAssetDispatcher.php
+++ b/lib/Baser/Routing/Filter/BcAssetDispatcher.php
@@ -22,12 +22,18 @@
 App::uses('AssetDispatcher', 'Routing/Filter');
 
 /**
- * Default priority for all methods in this filter
- * This filter should run before the request gets parsed by router
+ * BcAssetDispatcher class
  *
  * @package Baser.Routing.Filter
  */
 class BcAssetDispatcher extends AssetDispatcher {
+
+/**
+ * Default priority for all methods in this filter
+ * This filter should run before the request gets parsed by router
+ * @var int
+ */
+	public $priority = 4;
 
 /**
  * Checks if a requested asset exists and sends it to the browser

--- a/lib/Baser/Routing/Filter/BcRequestFilter.php
+++ b/lib/Baser/Routing/Filter/BcRequestFilter.php
@@ -1,0 +1,224 @@
+<?php
+/**
+ * BcRequestFilter
+ *
+ * CakeRequestに検出器を追加するためのフィルター
+ *
+ * （例）$request->is('admin')
+ *      $request->is('smartphone')
+ * 		$request->is(array('smartphone', 'mobile')) // OR
+ * 		$request->isAll(array('smartphone', 'page_display')) // AND
+ *
+ * baserCMS :  Based Website Development Project <http://basercms.net>
+ * Copyright 2008 - 2014, baserCMS Users Community <http://sites.google.com/site/baserusers/>
+ *
+ * @copyright		Copyright 2008 - 2014, baserCMS Users Community
+ * @link			http://basercms.net baserCMS Project
+ * @package			Baser.Routing.Filter
+ * @since			baserCMS v 3.1.0-beta
+ * @license			http://basercms.net/license/index.html
+ */
+
+app::uses('BcAgent', 'Model');
+app::uses('DispatcherFilter', 'Routing');
+
+/**
+ * Class BcRequestFilter
+ */
+class BcRequestFilter extends DispatcherFilter {
+
+/**
+ * Default priority for all methods in this filter
+ * This filter should run before the request gets parsed by router
+ * @var int
+ */
+	public $priority = 6;
+
+/**
+ * beforeDispatch Event
+ *
+ * @param CakeEvent $event イベント
+ * @return void|CakeResponse
+ */
+	public function beforeDispatch(CakeEvent $event) {
+		$request = $event->data['request'];
+		$response = $event->data['response'];
+		$this->addDetectors($request);
+
+		//アセットならスキップ
+		if ($this->isAsset($request)) {
+			Configure::write('BcRequest.asset', true);
+			return;
+		}
+
+		$agent = BcAgent::findCurrent();
+
+		if (!is_null($agent)) {
+			if (!$request->is('admin') && $agent->shouldRedirects($request)) {
+				$response->header('Location', $request->base . '/' . $agent->makeRedirectUrl($request));
+				$response->statusCode(302);
+				return $response;
+			}
+
+			/*
+			 * =========================================================
+			 * /m/files/... へのアクセスの場合、/files/... へ自動リダイレクト
+			 * CMSで作成するページ内のリンクは、モバイルでアクセスすると、
+			 * 自動的に、/m/ 付のリンクに書き換えられてしまう為、
+			 * files内のファイルへのリンクがリンク切れになってしまうので暫定対策。
+			 *
+			 * 2014/12/30 nakae bootstrap.phpから移行
+			 * =========================================================
+			 */
+			$param = preg_replace('/^' . $agent->alias . '\//', '', $request->url);
+			if (preg_match('/^files/', $param)) {
+				$response->statusCode(301);
+				$response->header('Location', "{$request->base}/{$param}");
+				return $response;
+			}
+
+			if ($agent->urlMatches($request)) {
+				Configure::write('BcRequest.agent', $agent->name);
+				Configure::write('BcRequest.agentPrefix', $agent->prefix);
+				Configure::write('BcRequest.agentAlias', $agent->alias);
+			}
+		}
+
+		//bootstrapから移動する
+		//Configure::write('BcRequest.isUpdater', $this->isUpdate($request));
+		//Configure::write('BcRequest.isMaintenance', $this->isMaintenance($request));
+	}
+
+/**
+ * リクエスト検出器の設定を取得
+ *
+ * @return array
+ */
+	public function getDetectorConfigs() {
+		$configs = array();
+
+		$configs['admin'] = array('callback' => array($this, 'isAdmin'));
+		$configs['asset'] = array('callback' => array($this, 'isAsset'));
+		$configs['console'] = array('callback' => array($this, 'isConsole'));
+		$configs['install'] = array('callback' => array($this, 'isInstall'));
+		$configs['maintenance'] = array('callback' => array($this, 'isMaintenance'));
+		$configs['update'] = array('callback' => array($this, 'isUpdate'));
+		$configs['page_display'] = array('callback' => array($this, 'isPageDisplay'));
+
+		$agents = BcAgent::findAll();
+		foreach ($agents as $agent) {
+			$configs[$agent->name] = array('callback' => array($agent, 'urlMatches'));
+			$configs["from_{$agent->name}"] = array('env' => 'HTTP_USER_AGENT', 'pattern' => $agent->getUserAgentRegex());
+		}
+
+		return $configs;
+	}
+
+/**
+ * リクエスト検出器を追加する
+ *
+ * @param CakeRequest $request リクエスト
+ * @return void
+ */
+	public function addDetectors(CakeRequest $request) {
+		foreach ($this->getDetectorConfigs() as $name => $callback) {
+			$request->addDetector($name, $callback);
+		}
+	}
+
+/**
+ * 管理画面のURLかどうかを判定
+ *
+ * @param CakeRequest $request リクエスト
+ * @return bool
+ */
+	public function isAdmin(CakeRequest $request) {
+		$adminPrefix = Configure::read('BcAuthPrefix.admin.alias');
+		$regex = '/^' . $adminPrefix . '($|\/)/';
+		return (bool)preg_match($regex, $request->url);
+	}
+
+/**
+ * アセットのURLかどうかを判定
+ *
+ * @param CakeRequest $request リクエスト
+ * @return bool
+ */
+	public function isAsset(CakeRequest $request) {
+		$dirs = array('css', 'js', 'img');
+		$exts = array('css', 'js', 'gif', 'jpg', 'jpeg', 'png', 'ico', 'svg', 'swf');
+
+		$dirRegex = implode('|', $dirs);
+		$extRegex = implode('|', $exts);
+
+		$assetRegex = '/^(' . $dirRegex . ')\/.+\.(' . $extRegex . ')$/';
+		$themeAssetRegex = '/^theme\/[^\/]+?\/(' . $dirRegex . ')\/.+\.(' . $extRegex . ')$/';
+
+		$uri = $request->url;
+		return preg_match($assetRegex, $uri) || preg_match($themeAssetRegex, $uri);
+	}
+
+/**
+ * コンソールからの実行かどうかを判定
+ *
+ * @param CakeRequest $request リクエスト
+ * @return bool
+ */
+	public function isConsole(CakeRequest $request) {
+		return defined('CAKEPHP_SHELL') && CAKEPHP_SHELL;
+	}
+
+/**
+ * インストール用のURLかどうかを判定
+ *
+ * @param CakeRequest $request リクエスト
+ * @return bool
+ */
+	public function isInstall(CakeRequest $request) {
+		$slug = 'install';
+		return $request->url === $slug;
+	}
+
+/**
+ * メンテナンス用のURLかどうかを判定
+ *
+ * @param CakeRequest $request リクエスト
+ * @return bool
+ */
+	public function isMaintenance(CakeRequest $request) {
+		$slug = 'maintenance';
+		return in_array($request->url, array($slug, "{$slug}/", "{$slug}/index"));
+	}
+
+/**
+ * アップデート用のURLかどうかを判定
+ *
+ * @param CakeRequest $request リクエスト
+ * @return bool
+ */
+	public function isUpdate(CakeRequest $request) {
+		$slug = Configure::read('BcApp.updateKey');
+		return in_array($request->url, array($slug, "{$slug}/", "{$slug}/index"));
+	}
+
+/**
+ * 固定ページ表示用のURLかどうかを判定
+ * [注]ルーターによるURLパース後のみ
+ *
+ * @param CakeRequest $request リクエスト
+ * @return bool
+ */
+	public function isPageDisplay(CakeRequest $request) {
+		$params = explode('/', $request->url);
+
+		$agent = BcAgent::findByAlias($params[0]);
+
+		if (is_null($agent)) {
+			$action = 'display';
+		} else {
+			$action = "{$agent->prefix}_display";
+		}
+		return $request->params['controller'] === 'pages'
+			&& $request->params['action'] === $action;
+	}
+}

--- a/lib/Baser/Test/Case/Model/BcAgentTest.php
+++ b/lib/Baser/Test/Case/Model/BcAgentTest.php
@@ -1,0 +1,183 @@
+<?php
+
+/**
+ * BcAgentクラスのテスト
+ *
+ * baserCMS :  Based Website Development Project <http://basercms.net>
+ * Copyright 2008 - 2014, baserCMS Users Community <http://sites.google.com/site/baserusers/>
+ *
+ * @copyright		Copyright 2008 - 2014, baserCMS Users Community
+ * @link			http://basercms.net baserCMS Project
+ * @since			baserCMS v 3.1.0-beta
+ * @license			http://basercms.net/license/index.html
+ */
+App::uses('BcAgent', 'Model');
+
+/**
+ * BcAgentTest class
+ * 
+ * @package Baser.Test.Case.Model
+ */
+class BcAgentTest extends BaserTestCase {
+
+/**
+ * @var BcAgent
+ */
+	public $agent;
+
+/**
+ * set up
+ *
+ * @return void
+ */
+	public function setUp() {
+		parent::setUp();
+		$this->agent = new BcAgent('smartphone', array(
+			'alias' => 's',
+			'prefix' => 'smartphone',
+			'autoRedirect' => true,
+			'autoLink' => true,
+			'agents' => array(
+				'iPhone',			// Apple iPhone
+				'iPod',				// Apple iPod touch
+				'Android',			// 1.5+ Android
+				'dream',			// Pre 1.5 Android
+				'CUPCAKE',			// 1.5+ Android
+				'blackberry9500',	// Storm
+				'blackberry9530',	// Storm
+				'blackberry9520',	// Storm v2
+				'blackberry9550',	// Storm v2
+				'blackberry9800',	// Torch
+				'webOS',			// Palm Pre Experimental
+				'incognito',		// Other iPhone browser
+				'webmate'			// Other iPhone browser
+			)
+		));
+
+		Configure::write("BcApp.smartphone", true);
+	}
+
+/**
+ * URLがエージェント用かどうかを判定
+ *
+ * @param bool $expect 期待値
+ * @param string $url URL文字列
+ * @return void
+ * @dataProvider urlMatchesDataProvider
+ */
+	public function testUrlMatches($expect, $url) {
+		$this->assertEquals($expect, $this->agent->urlMatches(new CakeRequest($url)));
+	}
+
+/**
+ * urlMatches用データプロバイダ
+ *
+ * @return array
+ */
+	public function urlMatchesDataProvider() {
+		return array(
+			array(false, '/'),
+			array(false, '/service'),
+			array(true, '/s'),
+			array(true, '/s/'),
+			array(true, '/s/service'),
+			array(false, '/m/' ),
+			array(false, '/m/service')
+		);
+	}
+
+/**
+ * URLがエージェント用かどうかを判定
+ *
+ * @param bool $expect 期待値
+ * @param string $userAgent ユーザーエージェントの文字列
+ * @return void
+ * @dataProvider userAgentMatchesDataProvider
+ */
+	public function testUserAgentMatches($expect, $userAgent) {
+		$this->assertEquals($expect, $this->agent->userAgentMatches($userAgent));
+	}
+
+/**
+ * userAgentMatches用データプロバイダ
+ *
+ * @return array
+ */
+	public function userAgentMatchesDataProvider() {
+		return array(
+			array(true, 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_0 like Mac OS X) AppleWebKit/600.1.3 (KHTML, like Gecko) Version/8.0 Mobile/12A4345d Safari/600.1.4'),
+			array(true, 'iPod'),
+			array(true, 'Mozilla/5.0 (Linux; Android 4.2.1; en-us; Nexus 5 Build/JOP40D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19'),
+			array(true, 'Mozilla/5.0 (Linux; U; Android 4.0; en-us; LT28at Build/6.1.C.1.111) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'),
+			array(false, 'DoCoMo')
+		);
+	}
+
+/**
+ * 与えられたリクエストに対して自動リダイレクトすべきかどうかを返す
+ *
+ * @param bool $expect 期待値
+ * @param string $url URL文字列
+ * @param array $query クエリパラメータの配列
+ * @return void
+ * @dataProvider shouldRedirectsDataProvider
+ */
+	public function testShouldRedirects($expect, $url, array $query = null) {
+		$request = new CakeRequest($url, false);
+		$request->query = $query;
+		$this->assertEquals($expect, $this->agent->shouldRedirects($request));
+	}
+
+/**
+ * shouldRedirects用データプロバイダ
+ *
+ * @return array
+ */
+	public function shouldRedirectsDataProvider() {
+		return array(
+			array(false, '/s/'),
+			array(false, '/s/news/index'),
+			array(false, '/s/service', array('smartphone' => 'on')),
+			array(true, '/'),
+			array(true, '/news/index'),
+			array(true, '/service'),
+			array(false, '/news/index', array('smartphone' => 'off')),
+			array(true, '/m/'),
+			array(true, '/m/service/index'),
+			array(false, '/m/service/index', array('smartphone' => 'off'))
+		);
+	}
+
+/**
+ * リクエストをリダイレクトするURLを生成
+ *
+ * @param string $expect 期待値
+ * @param string $url URL文字列
+ * @param array $query クエリパラメータの配列
+ * @return void
+ * @dataProvider makeRedirectUrlDataProvider
+ */
+	public function testMakeRedirectUrl($expect, $url, $query = null) {
+		$request = new CakeRequest($url, false);
+		$request->query = $query;
+		$this->assertEquals($expect, $this->agent->makeRedirectUrl($request));
+	}
+
+/**
+ * makeRedirectUrl用データプロバイダ
+ *
+ * @return array
+ */
+	public function makeRedirectUrlDataProvider() {
+		return array(
+			array('s/', '/'),
+			array('s/news/index', '/news/index'),
+			array('s/service', '/service'),
+			array('s/service?hoge=fuga', '/service', array('hoge' => 'fuga')),
+			array('s/', '/m/'),
+			array('s/news/index', '/m/news/index'),
+			array('s/service', '/m/service'),
+			array('s/service/?hoge=fuga', '/m/service/', array('hoge' => 'fuga'))
+		);
+	}
+}

--- a/lib/Baser/Test/Case/Routing/Filter/BcRequestFilterTest.php
+++ b/lib/Baser/Test/Case/Routing/Filter/BcRequestFilterTest.php
@@ -1,0 +1,231 @@
+<?php
+
+/**
+ * BcRequestFilterクラスのテスト
+ *
+ * baserCMS :  Based Website Development Project <http://basercms.net>
+ * Copyright 2008 - 2014, baserCMS Users Community <http://sites.google.com/site/baserusers/>
+ *
+ * @copyright		Copyright 2008 - 2014, baserCMS Users Community
+ * @link			http://basercms.net baserCMS Project
+ * @since			baserCMS v 3.1.0-beta
+ * @license			http://basercms.net/license/index.html
+ */
+App::uses('BcRequestFilter', 'Routing/Filter');
+
+/**
+ * BcRequestFilterTest class
+ *
+ * @package Baser.Test.Case.Routing.Filter
+ */
+class BcRequestFilterTest extends BaserTestCase {
+
+/**
+ * フィクスチャ
+ * @var array
+ */
+	public $fixtures = array(
+		'baser.Page.Page'
+	);
+
+/**
+ * BcRequestFilter
+ * @var BcRequestFilter
+ */
+	public $requestFilter;
+
+/**
+ * set up
+ *
+ * @return void
+ */
+	public function setUp() {
+		parent::setUp();
+		$this->requestFilter = new BcRequestFilter();
+	}
+
+/**
+ * 管理画面のURLかどうかを判定
+ *
+ * @param bool $expect 期待値
+ * @param string $url URL文字列
+ * @return void
+ * @dataProvider isAdminDataProvider
+ */
+	public function isAdmin($expect, $url) {
+		$request = new CakeRequest($url);
+		$this->assertEquals($expect, $this->requestFilter->isAdmin($request));
+	}
+
+/**
+ * isAdmin用データプロバイダ
+ *
+ * @return array
+ */
+	public function isAdminDataProvider() {
+		return array(
+			array(true, '/admin'),
+			array(true, '/admin/'),
+			array(true, '/admin/users/login'),
+			array(false, '/'),
+			array(false, '/s/'),
+			array(false, '/news/index'),
+			array(false, '/service')
+		);
+	}
+
+/**
+ * アセットのURLかどうかを判定
+ *
+ * @param bool $expect 期待値
+ * @param string $url URL文字列
+ * @return void
+ * @dataProvider isAssetDataProvider
+ */
+	public function testIsAsset($expect, $url) {
+		$request = new CakeRequest($url);
+		$this->assertEquals($expect, $this->requestFilter->isAsset($request));
+	}
+
+/**
+ * isAsset用データプロバイダ
+ *
+ * @return array
+ */
+	public function isAssetDataProvider() {
+		return array(
+			array(false, '/'),
+			array(false, '/about'),
+			array(false, '/img/test.html' ),
+			array(false, '/js/test.php'),
+			array(false, '/css/file.cgi'),
+			array(true, '/img/image.png'),
+			array(true, '/js/startup.js'),
+			array(true, '/css/main.css'),
+			array(false, '/theme/example_theme/img/test.html'),
+			array(false, '/theme/example_theme/js/test.php'),
+			array(false, '/theme/example_theme/css/file.cgi'),
+			array(true, '/theme/example_theme/img/image.png'),
+			array(true, '/theme/example_theme/js/startup.js'),
+			array(true, '/theme/example_theme/css/main.css')
+		);
+	}
+
+/**
+ * インストール用のURLかどうかを判定
+ *
+ * @param bool $expect 期待値
+ * @param string $url URL文字列
+ * @return void
+ * @dataProvider isInstallDataProvider
+ */
+	public function testIsInstall($expect, $url) {
+		$request = new CakeRequest($url);
+		$this->assertEquals($expect, $this->requestFilter->isInstall($request));
+	}
+
+/**
+ * isInstall用データプロバイダ
+ *
+ * @return array
+ */
+	public function isInstallDataProvider() {
+		return array(
+			array(true, '/install'),
+			array(false, '/install/'),
+			array(false, '/install/index'),
+			array(false, '/'),
+			array(false, '/service')
+		);
+	}
+
+/**
+ * メンテナンス用のURLかどうかを判定
+ *
+ * @param bool $expect 期待値
+ * @param string $url URL文字列
+ * @return void
+ * @dataProvider isMaintenanceDataProvider
+ */
+	public function testIsMaintenance($expect, $url) {
+		$request = new CakeRequest($url);
+		$this->assertEquals($expect, $this->requestFilter->isMaintenance($request));
+	}
+
+/**
+ * isMaintenance用データプロバイダ
+ *
+ * @return array
+ */
+	public function isMaintenanceDataProvider() {
+		return array(
+			array(true, '/maintenance'),
+			array(true, '/maintenance/'),
+			array(true, '/maintenance/index'),
+			array(false, '/'),
+			array(false, '/service'),
+			array(false, '/admin/')
+		);
+	}
+
+/**
+ * アップデート用のURLかどうかを判定
+ *
+ * @param bool $expect 期待値
+ * @param string $url URL文字列
+ * @return void
+ * @dataProvider isUpdateDataProvider
+ */
+	public function testIsUpdate($expect, $url) {
+		$request = new CakeRequest($url);
+		$this->assertEquals($expect, $this->requestFilter->isUpdate($request));
+	}
+
+/**
+ * isUpdate用データプロバイダ
+ *
+ * @return array
+ */
+	public function isUpdateDataProvider() {
+		$slug = Configure::read('BcApp.updateKey');
+		return array(
+			array(true, "/{$slug}"),
+			array(true, "/{$slug}/"),
+			array(true, "/{$slug}/index"),
+			array(false, '/'),
+			array(false, '/service'),
+			array(false, '/admin/')
+		);
+	}
+
+/**
+ * 固定ページ表示用のURLかどうかを判定
+ * [注]ルーターによるURLパース後のみ
+ *
+ * @param bool $expect 期待値
+ * @param string $url URL文字列
+ * @return void
+ * @dataProvider isPageDisplayDataProvider
+ */
+	public function testIsPageDisplay($expect, $url) {
+		$request = $this->_getRequest($url);
+		$this->assertEquals($expect, $this->requestFilter->isPageDisplay($request));
+	}
+
+/**
+ * isPageDisplay用データプロバイダ
+ *
+ * @return array
+ */
+	public function isPageDisplayDataProvider() {
+		return array(
+			array(false, '/admin/'),
+			array(false, '/news/index'),
+			array(true, '/'),
+			array(true, '/service'),
+			array(true, '/company'),
+			array(true, '/recruit')
+		);
+	}
+
+} 


### PR DESCRIPTION
変更が大きくなってしまって申し訳ないのですが、２つのクラスの追加がメインです。
例によって命名と配置場所は思案中です。

###Model/BcAgentクラス
設定ファイルのBcAgentのエージェントごとの配列と１対１対応するオブジェクトとして導入
主に可読性/テスト可能性の向上のため

###Routing/Filter/BcRequestFilterクラス
CakeRequestに便利な検出器を追加
ConfigureのBcRequestに記録される処理を肩代わりできる
例) $request->is('admin'), $request->is('smartphone'), $request->is('from_smartphone')

bootstrapの処理の一部をbeforeDispatchメソッドに移行
* Configureの書込各種処理
* ユーザーエージェントのリダイレクト処理の抽象レベルを読みやすい程度に