### PR TITLE
Vagrantの開発マシンにunzipを追加

### DIFF
--- a/vagrant_cookbooks/yum-packages/recipes/default.rb
+++ b/vagrant_cookbooks/yum-packages/recipes/default.rb
@@ -2,7 +2,7 @@ execute "yum" do
   command "yum -y update"
 end
 
-packages = %w{ntpdate vim-enhanced git curl gd}
+packages = %w{ntpdate vim-enhanced git curl gd unzip}
 packages.each do |packagename|
   package packagename do
     action :install


### PR DESCRIPTION
プラグインをアップロードしようとしたところunzipが入っていなかったので追加しておきます。