### PR TITLE
fixes 固定ページプレビュー時、レイアウトが外れてプレビューされる場合がある点を修正

### DIFF
--- a/lib/Baser/Controller/PagesController.php
+++ b/lib/Baser/Controller/PagesController.php
@@ -847,6 +847,9 @@ class PagesController extends AppController {
 		$this->theme = $this->siteConfigs['theme'];
 		if(!empty($page['Page']['page_category_id'])) {
 			$this->layout = $this->Page->PageCategory->field('layout_template', array('PageCategory.id' => $page['Page']['page_category_id']));
+			if (!$this->layout) {
+				$this->layout = $this->siteConfigs['root_layout_template'];
+			}
 		}
 		$this->render(TMP . 'pages_preview_' . $id . $this->ext);
 		@unlink(TMP . 'pages_preview_' . $id . $this->ext);


### PR DESCRIPTION
- ページカテゴリのデータにレイアウト指定がない場合に起こる
- レイアウト指定がないカテゴリが生成される場面は、固定ページテンプレート読込時

レビューよろしくお願いします。
