### PR TITLE
BcBaserHelperのmainImage()でクラス名の指定とidの無効化ができる拡張

### DIFF
--- a/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
@@ -1468,7 +1468,45 @@ class BcBaserHelperTest extends BaserTestCase {
 	public function testMainImage() {
 		$this->markTestIncomplete('このテストは、まだ実装されていません。');
 	}
-	
+
+/**
+ * メインイメージの取得でidやclassを指定するオプション
+ */
+	public function testMainImageIdClass()
+	{
+		$num = 2;
+		$idName = 'testIdName';
+		$className = 'testClassName';
+
+		//getMainImageを叩いてULを入手(default)
+		ob_start();
+		$this->BcBaser->mainImage(array('all' => true, 'num' => $num));
+		$tags = ob_get_clean();
+		$check = preg_match('|<ul id="MainImage">|', $tags) === 1;
+		$this->assertTrue($check);
+
+
+		//getMainImageを叩いてULを入手(id指定)
+		ob_start();
+		$this->BcBaser->mainImage(array('all' => true, 'num' => $num, 'id' => $idName));
+		$tags = ob_get_clean();
+		$check = preg_match('|<ul id="' . $idName . '">|', $tags) === 1;
+		$this->assertTrue($check);
+
+		//getMainImageを叩いてULを入手(class指定・id非表示)
+		ob_start();
+		$this->BcBaser->mainImage(array('all' => true, 'num' => $num, 'id' => false, 'class' => $className));
+		$tags = ob_get_clean();
+		$check = preg_match('|<ul class="' . $className . '">|', $tags) === 1;
+		$this->assertTrue($check);
+		//getMainImageを叩いてULを入手(全てなし)
+		ob_start();
+		$this->BcBaser->mainImage(array('all' => true, 'num' => $num, 'id' => false, 'class' => false));
+		$tags = ob_get_clean();
+		$check = preg_match('|<ul>|', $tags) === 1;
+		$this->assertTrue($check);
+	}
+
 /**
  * テーマのURLを取得する
  */

--- a/lib/Baser/View/Helper/BcBaserHelper.php
+++ b/lib/Baser/View/Helper/BcBaserHelper.php
@@ -1899,6 +1899,7 @@ END_FLASH;
  *	- `all`: 全ての画像を出力する。
  *	- `num`: 指定した番号の画像を出力する。all を true とした場合は、出力する枚数となる。
  *	- `id` : all を true とした場合、UL タグの id 属性を指定できる。
+ *	- `class` : all を true とした場合、UL タグの class 属性を指定できる。
  *	※ その他の、パラメーターは、 BcBaserHelper->_getThemeImage() を参照
  * @return void
  */
@@ -1907,13 +1908,16 @@ END_FLASH;
 		$options = array_merge(array(
 			'num' => 1,
 			'all' => false,
-			'id' => 'MainImage'
+			'id' => 'MainImage',
+			'class' => false
 			), $options);
 		if ($options['all']) {
 			$id = $options['id'];
+			$class = $options['class'];
 			$num = $options['num'];
 			unset($options['all']);
 			unset($options['id']);
+			unset($options['class']);
 			$tag = '';
 			for ($i = 1; $i <= $num; $i++) {
 				$options['num'] = $i;
@@ -1922,7 +1926,14 @@ END_FLASH;
 					$tag .= '<li>' . $themeImage . '</li>' . "\n";
 				}
 			}
-			echo '<ul id="' . $id . '">' . "\n" . $tag . "\n" . '</ul>';
+			$ulAttr = '';
+			if ($id !== false) {
+				$ulAttr .= ' id="' . $id . '"';
+			}
+			if ($class !== false) {
+				$ulAttr .= ' class="' . $class . '"';
+			}
+			echo '<ul' . $ulAttr. '>' . "\n" . $tag . "\n" . '</ul>';
 		} else {
 			echo $this->_getThemeImage('main_image', $options);
 		}
@@ -2058,7 +2069,8 @@ END_FLASH;
 		}
 		return $tag;
 	}
-	
+
+
 /**
  * 現在のテーマのURLを取得する
  * 


### PR DESCRIPTION
現在のmainImage()で生成されるHTMLが、idのみしかつかなくて自由度が少なく、CSS指定などで不自由があるのでclass属性がつけられるようにしました。またidも無効化出来るようにしました。よろしくお願いします。