### PR TITLE
fixes #7943 カテゴリ別管理グループ利用時、固定ページカテゴリ編集時に、設定している親カテゴリが外れてしまう点を改修

### DIFF
--- a/lib/Baser/Model/PageCategory.php
+++ b/lib/Baser/Model/PageCategory.php
@@ -166,14 +166,16 @@ class PageCategory extends AppModel {
 				}
 
 				if (isset($options['ownerId'])) {
-					$ownerIdConditions = array(
-						array('PageCategory.owner_id' => null),
-						array('PageCategory.owner_id' => $options['ownerId']),
-					);
-					if (isset($conditions['OR'])) {
-						$conditions['OR'] = am($conditions['OR'], $ownerIdConditions);
-					} else {
-						$conditions['OR'] = $ownerIdConditions;
+					if (!BcUtil::isAdminUser()) {
+						$ownerIdConditions = array(
+							array('PageCategory.owner_id' => null),
+							array('PageCategory.owner_id' => $options['ownerId']),
+						);
+						if (isset($conditions['OR'])) {
+							$conditions['OR'] = am($conditions['OR'], $ownerIdConditions);
+						} else {
+							$conditions['OR'] = $ownerIdConditions;
+						}
 					}
 				}
 


### PR DESCRIPTION
レビューよろしくお願いします。
発生条件はredmineのチケットに記載しました。
http://project.e-catchup.jp/issues/7943
