### PR TITLE
問題点 #8013 テーマの保存時に入力内容にシングルクォーテーションが含まれるとエラーになる 修正

### DIFF
--- a/lib/Baser/Config/bootstrap.php
+++ b/lib/Baser/Config/bootstrap.php
@@ -48,6 +48,7 @@ App::build(array(
 App::build(array(
 	'Event'				=> array(APP . 'Event', BASER_EVENTS),
 	'Routing/Filter'	=> array(BASER . 'Routing' . DS . 'Filter' . DS),
+	'Configure'			=> array(BASER . 'Configure' . DS),
 	'TestSuite'			=> array(BASER_TEST_SUITE),
 	'TestSuite/Reporter'=> array(BASER_TEST_SUITE . 'Reporter' . DS),
 	'TestSuite/Fixture' => array(BASER_TEST_SUITE . 'Fixture' . DS),

--- a/lib/Baser/Configure/BcThemeConfigReader.php
+++ b/lib/Baser/Configure/BcThemeConfigReader.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * BcThemeConfigReader
+ *
+ * baserCMS :  Based Website Development Project <http://basercms.net>
+ * Copyright 2008 - 2015, baserCMS Users Community <http://sites.google.com/site/baserusers/>
+ *
+ * @copyright		Copyright 2008 - 2015, baserCMS Users Community
+ * @link			http://basercms.net baserCMS Project
+ * @package			Baser.View.Helper
+ * @since			baserCMS v 3.0.7
+ * @license			http://basercms.net/license/index.html
+ */
+
+
+/**
+ * テーマの設定ファイルから設定を読み込む
+ *
+ * @package       Baser.Configure
+ */
+class BcThemeConfigReader implements ConfigReaderInterface {
+
+/**
+ * 設定ファイル名
+ */
+	const CONFIG_FILE_NAME = 'config.php';
+
+/**
+ * テーマディレクトリ
+ *
+ * @var string
+ */
+	protected $_path = null;
+
+/**
+ * 保存する変数
+ * @var array
+ */
+	static public $variables = array(
+		'title' => 'タイトル',
+		'description' => '説明',
+		'author' => '制作者',
+		'url' => 'URL'
+	);
+
+/**
+ * コンストラクタ
+ *
+ * @param string $path テーマディレクトリのパス. デフォルトは WWW_ROOT . 'theme' . DS
+ */
+	public function __construct($path = null) {
+		if (!$path) {
+			$path = WWW_ROOT . 'theme' . DS;
+		}
+
+		if (substr($path, -1) !== DS) {
+			$path .= DS;
+		}
+		$this->_path = $path;
+	}
+
+/**
+ * 指定されたテーマ名の設定ファイルを読み込む
+ *
+ * @param string $key テーマ名（ディレクトリ名）
+ * @return array 設定の連想配列
+ * @throws ConfigureException 指定されたテーマ名に対応するディレクトリや設定ファイルが存在しない時、または必要な変数が設定されていない時に例外を投げる
+ */
+	public function read($key) {
+		$file = $this->_getFilePath($key);
+		if (!is_file($file)) {
+			throw new ConfigureException(__d('テーマの設定ファイルが存在しません : %s', $file));
+		}
+
+		include $file;
+
+		$config = array();
+
+		foreach (self::$variables as $var => $name) {
+			if (!isset($$var)) {
+				throw new ConfigureException(__d('テーマの %s が設定されていません : %s', array($name, $file)));
+			}
+			$config[$var] = $$var;
+		}
+		return $config;
+	}
+
+/**
+ * 与えられた連想配列を設定ファイルにPHPコードとして保存する
+ * 追記ではなく上書きする
+ *
+ * @param string $key テーマ名（ディレクトリ名）
+ * @param array $data 保存する設定の連想配列
+ * @return int 保存されたバイト数
+ * @throws ConfigureException 指定されたテーマ名のディレクトリが存在しない時に例外を投げる
+ */
+	public function dump($key, $data) {
+		$contents = $this->createContents($data);
+		$filename = $this->_getFilePath($key);
+		return file_put_contents($filename, $contents);
+	}
+
+/**
+ * 与えられた連想配列からPHPコードを生成
+ *
+ * @param array $data 設定の連想配列
+ * @return string
+ */
+	public function createContents(array $data) {
+		$contents = '<?php' . "\n";
+
+		foreach (self::$variables as $var => $name) {
+			$value = empty($data[$var]) ? '': $data[$var];
+			$contents .= '$' . $var . ' = ' . var_export($value, true) . ';' . PHP_EOL;
+		}
+		return $contents;
+	}
+
+/**
+ * 与えられたテーマのディレクトリ名に対応する設定ファイルのパスを取得
+ *
+ * @param string $key テーマ名（ディレクトリ名）
+ * @return string 設定ファイルのフルパス
+ * @throws ConfigureException 指定されたテーマ名のディレクトリが存在しない時例外を投げる
+ */
+	protected function _getFilePath($key) {
+		$dir = $this->_path . $key;
+		if (!is_dir($dir)) {
+			throw new ConfigureException(__d('指定されたテーマ名のディレクトリが存在しません: %s', $dir));
+		}
+		return $dir . DS . self::CONFIG_FILE_NAME;
+	}
+
+}

--- a/lib/Baser/Configure/BcThemeConfigReader.php
+++ b/lib/Baser/Configure/BcThemeConfigReader.php
@@ -69,7 +69,7 @@ class BcThemeConfigReader implements ConfigReaderInterface {
 	public function read($key) {
 		$file = $this->_getFilePath($key);
 		if (!is_file($file)) {
-			throw new ConfigureException(__d('テーマの設定ファイルが存在しません : %s', $file));
+			throw new ConfigureException(__d('cake_dev', 'テーマの設定ファイルが存在しません : %s', $file));
 		}
 
 		include $file;
@@ -78,7 +78,7 @@ class BcThemeConfigReader implements ConfigReaderInterface {
 
 		foreach (self::$variables as $var => $name) {
 			if (!isset($$var)) {
-				throw new ConfigureException(__d('テーマの %s が設定されていません : %s', array($name, $file)));
+				throw new ConfigureException(__d('cake_dev', 'テーマの %s が設定されていません : %s', array($name, $file)));
 			}
 			$config[$var] = $$var;
 		}
@@ -126,7 +126,7 @@ class BcThemeConfigReader implements ConfigReaderInterface {
 	protected function _getFilePath($key) {
 		$dir = $this->_path . $key;
 		if (!is_dir($dir)) {
-			throw new ConfigureException(__d('指定されたテーマ名のディレクトリが存在しません: %s', $dir));
+			throw new ConfigureException(__d('cake_dev', '指定されたテーマ名のディレクトリが存在しません: %s', $dir));
 		}
 		return $dir . DS . self::CONFIG_FILE_NAME;
 	}

--- a/lib/Baser/Test/Case/BcAllConfigureTest.php
+++ b/lib/Baser/Test/Case/BcAllConfigureTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * run all baser configure tests
+ *
+ * baserCMS :  Based Website Development Project <http://basercms.net>
+ * Copyright 2008 - 2014, baserCMS Users Community <http://sites.google.com/site/baserusers/>
+ *
+ * @copyright		Copyright 2008 - 2014, baserCMS Users Community
+ * @link			http://basercms.net baserCMS Project
+ * @since			baserCMS v 3.1.0-beta
+ * @license			http://basercms.net/license/index.html
+ */
+
+/**
+ * @package Baser.Test.Case
+ */
+class BcAllConfigureTest extends PHPUnit_Framework_TestSuite {
+
+/**
+ * Suite define the tests for this suite
+ *
+ * @return void
+ */
+	public static function suite() {
+		$suite = new CakeTestSuite('All Configure tests');
+		$suite->addTestDirectory(BASER_TEST_CASES . DS . 'Configure' . DS);
+		return $suite;
+	}
+
+}

--- a/lib/Baser/Test/Case/BcAllTest.php
+++ b/lib/Baser/Test/Case/BcAllTest.php
@@ -32,7 +32,7 @@ class BcAllTest extends PHPUnit_Framework_TestSuite {
 //		$suite->addTestFile($path . 'BcAllBehaviorsTest.php');
 //		$suite->addTestFile($path . 'BcAllCacheTest.php');
 //		$suite->addTestFile($path . 'BcAllComponentsTest.php');
-//		$suite->addTestFile($path . 'BcAllConfigureTest.php');
+		$suite->addTestFile($path . 'BcAllConfigureTest.php');
 		$suite->addTestFile($path . 'BcAllConfigTest.php');
 //		$suite->addTestFile($path . 'BcAllCoreTest.php');
 //		$suite->addTestFile($path . 'BcAllControllerTest.php');

--- a/lib/Baser/Test/Case/Configure/BcThemeConfigReaderTest.php
+++ b/lib/Baser/Test/Case/Configure/BcThemeConfigReaderTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * BcThemeConfigReader Test
+ *
+ * baserCMS :  Based Website Development Project <http://basercms.net>
+ * Copyright 2008 - 2015, baserCMS Users Community <http://sites.google.com/site/baserusers/>
+ *
+ * @copyright		Copyright 2008 - 2015, baserCMS Users Community
+ * @link			http://basercms.net baserCMS Project
+ * @since			baserCMS v 3.0.7
+ * @license			http://basercms.net/license/index.html
+ */
+App::uses('BcThemeConfigReader', 'Configure');
+
+/**
+ * BcThemeConfigReader class
+ * 
+ * @package Baser.Test.Case.Network
+ */
+class BcThemeConfigReaderTest extends BaserTestCase {
+
+	public $fixtures = array('baser.Page.Page');
+
+/**
+ * createContents
+ *
+ * @param array $data データの配列
+ * @param string $expect PHPコード
+ * @return void
+ * @dataProvider createContentsDataProvider
+ */
+	public function testCreateContents($data, $expect) {
+		$reader = new BcThemeConfigReader();
+		$this->assertEquals($expect, $reader->createContents($data));
+	}
+
+/**
+ * createContents用のデータプロバイダ
+ *
+ * @return array
+ */
+	public function createContentsDataProvider() {
+		$data = array();
+		$contents = <<< EOF
+<?php
+\$title = 'タイトル';
+\$description = 'シングルクォーテーションを含む説明\'';
+\$author = '制作者';
+\$url = 'http://basercms.net';
+
+EOF;
+
+		$data[] = array(
+			array(
+				'title' => 'タイトル',
+				'description' => "シングルクォーテーションを含む説明'",
+				'author' => '制作者',
+				'url' => 'http://basercms.net'
+			),
+			$contents
+		);
+		return $data;
+	}
+}


### PR DESCRIPTION
https://github.com/baserproject/basercms/pull/234

の続きです。チケット切り忘れてたので追加しました。
http://project.e-catchup.jp/issues/8013

ConfigReaderInterfaceを実装しました。
ディレクトリはCakeに倣いConfigureに置きました。

Configureクラスからも使えるみたいですが、ややこしそうなので直に使っています。
使い方は下記のような感じです。引数や戻り値は連想配列にしてあります。

    $reader = new BcThemeConfigReader();
    $config = $reader->read($themeName);
    $reader->dump($themeName, array(
        'title' => 'hogehoge',
        'description' => 'hoge',
        'author' => 'hoge',
        'url' => 'http://example.com'
    ));