### PR TITLE
fixes #8034 3.0.7開発版でスマートフォンが動作していない

### DIFF
--- a/lib/Baser/Lib/BcAgent.php
+++ b/lib/Baser/Lib/BcAgent.php
@@ -108,6 +108,23 @@ class BcAgent {
 	}
 
 /**
+ * HTTPリクエストのURLのプレフィックスに合致するインスタンスを返す
+ *
+ * @param CakeRequest $request URLをチェックするリクエスト
+ * @return BcAgent|null
+ */
+	public static function findByUrl(CakeRequest $request) {
+		$agents = static::findAll();
+
+		foreach ($agents as $agent) {
+			if (preg_match('/^' . $agent->alias . '\//', $request->url)) {
+				return $agent;
+			}
+		}
+		return null;
+	}
+
+/**
  * 現在の環境のHTTP_USER_AGENTの値に合致するインスタンスを返す
  *
  * @return BcAgent|null


### PR DESCRIPTION
ConfigureのBcRequest以下のキーに書き込む条件を間違っていました。
この部分は特に$_SERVER['HTTP_USER_AGENT']の値にかかわらず、
単純にURLのプリフィックスが対応するエージェントを探してその情報を書き出せばよかったんですね。