### PR TITLE
Travis-CIで実行するPHPのバージョンに5.6,HHVM,7.0を追加

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,17 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - 5.6
+  - hhvm
+  - 7.0
+
+matrix:
+    allow_failures:
+        - php: hhvm
+        - php: 7.0
 
 before_script:
-  - phpenv config-add travis.php.ini
+  - bash -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpenv config-add travis.php.ini; fi;'
   - mysql -u root -e "CREATE DATABASE basercms CHARACTER SET utf8;"
   - mysql -u root -e "GRANT ALL PRIVILEGES ON basercms.* TO basercms@localhost IDENTIFIED BY 'basercms'"
   - mysql -u basercms --password="basercms" -e "SHOW DATABASES;"


### PR DESCRIPTION
追加したバージョン全てでテストは通りましたが、
念のためHHVMとPHP7.0は失敗しても問題ない設定にしてます。

本当は5.2も追加したかったんですがcomposer対応してないのでどうしようもない感じです。
あとデータベースも増やさないとですね。