### PR TITLE
Travis-CIで実行するPHPのバージョンに5.2を追加

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 5.2
   - 5.3
   - 5.4
   - 5.5
@@ -18,7 +19,7 @@ before_script:
   - mysql -u root -e "CREATE DATABASE basercms CHARACTER SET utf8;"
   - mysql -u root -e "GRANT ALL PRIVILEGES ON basercms.* TO basercms@localhost IDENTIFIED BY 'basercms'"
   - mysql -u basercms --password="basercms" -e "SHOW DATABASES;"
-  - composer install --dev
+  - bash -c 'if [ "$TRAVIS_PHP_VERSION" != "5.2" ]; then composer install --dev; fi;'
   - cd app
   - php ./Console/cake.php bc_manager checkenv
   - php ./Console/cake.php bc_manager install "http://localhost" "mysql" "admin" "basercms" "webmaster@example.org" --host "localhost" --database "basercms" --login "basercms" --password "basercms" --prefix "mysite_"  --port "3306"  --smarturl "true"  --data "nada-icons.default"

--- a/lib/Baser/Lib/BcAgent.php
+++ b/lib/Baser/Lib/BcAgent.php
@@ -72,7 +72,7 @@ class BcAgent {
 		if (!Configure::check($key)) {
 			return null;
 		}
-		return new static($name, Configure::read($key));
+		return new self($name, Configure::read($key));
 	}
 
 /**
@@ -84,7 +84,7 @@ class BcAgent {
 		$configs = Configure::read("BcAgent");
 		$agents = array();
 		foreach ($configs as $name => $config) {
-			$agents[] = new static($name, $config);
+			$agents[] = new self($name, $config);
 		}
 
 		return $agents;
@@ -97,7 +97,7 @@ class BcAgent {
  * @return BcAgent|null
  */
 	public static function findByAlias($alias) {
-		$agents = static::findAll();
+		$agents = self::findAll();
 
 		foreach ($agents as $agent) {
 			if ($agent->alias === $alias) {
@@ -114,7 +114,7 @@ class BcAgent {
  * @return BcAgent|null
  */
 	public static function findByUrl(CakeRequest $request) {
-		$agents = static::findAll();
+		$agents = self::findAll();
 
 		foreach ($agents as $agent) {
 			if (preg_match('/^' . $agent->alias . '\//', $request->url)) {
@@ -130,7 +130,7 @@ class BcAgent {
  * @return BcAgent|null
  */
 	public static function findCurrent() {
-		$agents = static::findAll();
+		$agents = self::findAll();
 
 		$userAgent = env('HTTP_USER_AGENT');
 		if (empty($userAgent)) {
@@ -157,7 +157,7 @@ class BcAgent {
 		}
 
 		$params = explode('/', $url);
-		$agent = static::findByAlias($params[0]);
+		$agent = self::findByAlias($params[0]);
 
 		if (is_null($agent)) {
 			return null;
@@ -292,7 +292,7 @@ class BcAgent {
  */
 	public function makeRedirectUrl(CakeRequest $request) {
 		$hereWithQuery = $request->here(false);
-		$alias = static::extractAlias($request->url);
+		$alias = self::extractAlias($request->url);
 
 		if (is_null($alias)) {
 			return "{$this->alias}{$hereWithQuery}";

--- a/lib/Baser/Plugin/Blog/Test/Case/BlogAllTest.php
+++ b/lib/Baser/Plugin/Blog/Test/Case/BlogAllTest.php
@@ -25,7 +25,7 @@ class BlogAllTest extends CakeTestSuite {
 	public static function suite() {
 		$suite = new CakeTestSuite('Baser Blog All Tests');
 
-		//$path = __DIR__ . DS;
+		//$path = dirname(__FILE__) . DS;
 		//$suite->addTestFile($path . 'BlogAllModelTest.php');
 
 		return $suite;

--- a/lib/Baser/Plugin/Feed/Test/Case/FeedAllModelTest.php
+++ b/lib/Baser/Plugin/Feed/Test/Case/FeedAllModelTest.php
@@ -20,7 +20,7 @@ class FeedAllModelTest extends CakeTestSuite {
  */
 	public static function suite() {
 		$suite = new CakeTestSuite('All Feed Model tests');
-		$suite->addTestDirectory(__DIR__ . DS . 'Model' . DS);
+		$suite->addTestDirectory(dirname(__FILE__) . DS . 'Model' . DS);
 		return $suite;
 	}
 

--- a/lib/Baser/Plugin/Feed/Test/Case/FeedAllTest.php
+++ b/lib/Baser/Plugin/Feed/Test/Case/FeedAllTest.php
@@ -25,7 +25,7 @@ class FeedAllTest extends CakeTestSuite {
 	public static function suite() {
 		$suite = new CakeTestSuite('Feed Plugin All Tests');
 
-		$path = __DIR__ . DS;
+		$path = dirname(__FILE__) . DS;
 
 		$suite->addTestFile($path . 'FeedAllModelTest.php');
 		return $suite;

--- a/lib/Baser/Plugin/Mail/Test/Case/MailAllControllerTest.php
+++ b/lib/Baser/Plugin/Mail/Test/Case/MailAllControllerTest.php
@@ -20,8 +20,9 @@ class MailAllControllerTest extends CakeTestSuite {
  */
 	public static function suite() {
 		$suite = new CakeTestSuite('All Helper tests');
-		$suite->addTestDirectory(__DIR__ . DS . 'Controller' . DS);
-		$suite->addTestDirectory(__DIR__ . DS . 'Controller' . DS . 'Component' . DS);
+		$path = dirname(__FILE__) . DS;
+		$suite->addTestDirectory($path . 'Controller' . DS);
+		$suite->addTestDirectory($path . 'Controller' . DS . 'Component' . DS);
 		return $suite;
 	}
 

--- a/lib/Baser/Plugin/Mail/Test/Case/MailAllHelpersTest.php
+++ b/lib/Baser/Plugin/Mail/Test/Case/MailAllHelpersTest.php
@@ -20,7 +20,7 @@ class MailAllHelpersTest extends CakeTestSuite {
  */
 	public static function suite() {
 		$suite = new CakeTestSuite('All Helper tests');
-		$suite->addTestDirectory(__DIR__ . DS . 'View' . DS . 'Helper' . DS);
+		$suite->addTestDirectory(dirname(__FILE__) . DS . 'View' . DS . 'Helper' . DS);
 		return $suite;
 	}
 

--- a/lib/Baser/Plugin/Mail/Test/Case/MailAllModelTest.php
+++ b/lib/Baser/Plugin/Mail/Test/Case/MailAllModelTest.php
@@ -20,8 +20,9 @@ class MailAllModelTest extends CakeTestSuite {
  */
 	public static function suite() {
 		$suite = new CakeTestSuite('All Helper tests');
-		$suite->addTestDirectory(__DIR__ . DS . 'Model' . DS);
-		$suite->addTestDirectory(__DIR__ . DS . 'Model' . DS . 'Behavior' . DS);
+		$path = dirname(__FILE__) . DS;
+		$suite->addTestDirectory($path . 'Model' . DS);
+		$suite->addTestDirectory($path . 'Model' . DS . 'Behavior' . DS);
 		return $suite;
 	}
 

--- a/lib/Baser/Plugin/Mail/Test/Case/MailAllTest.php
+++ b/lib/Baser/Plugin/Mail/Test/Case/MailAllTest.php
@@ -25,7 +25,7 @@ class MailAllTest extends CakeTestSuite {
 	public static function suite() {
 		$suite = new CakeTestSuite('Baser All Tests');
 
-		$path = __DIR__ . DS;
+		$path = dirname(__FILE__) . DS;
 
 		$suite->addTestFile($path . 'MailAllControllerTest.php');
 		$suite->addTestFile($path . 'MailAllModelTest.php');


### PR DESCRIPTION
環境変数で条件分岐して5.2の時はcomposer installをスキップしています。
PHPUnitはTravisに元々入ってるものを使って動きました。

また、一部でPHP5.3で追加された機能の利用があったので修正しました。
* BcAgentクラスで静的遅延束縛(static)を利用 →特に継承予定はないのでselfに変更
* プラグインのテストスイートのクラスで__DIR__を利用　→dirname(__FILE__)に変更