### PR TITLE
Travisのビルドを高速化

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,11 @@ php:
 
 sudo: false
 
+cache:
+  directories:
+    - vendors
+    - $HOME/.composer/cache
+
 matrix:
     allow_failures:
         - php: hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ php:
   - hhvm
   - 7.0
 
+sudo: false
+
 matrix:
     allow_failures:
         - php: hhvm

--- a/lib/Baser/Controller/Component/BcManagerComponent.php
+++ b/lib/Baser/Controller/Component/BcManagerComponent.php
@@ -1608,7 +1608,7 @@ class BcManagerComponent extends Component {
 			'apacheRewrite'		=> $rewriteInstalled,
 		);
 		$check = array(
-			'encodingOk'	=> (eregi('UTF-8', $status['encoding']) ? true : false),
+			'encodingOk'	=> (preg_match('/UTF-8/i', $status['encoding']) ? true : false),
 			'gdOk'			=> $status['phpGd'],
 			'pdoOk'			=> $status['phpPdo'],
 			'xmlOk'			=> $status['phpXml'],


### PR DESCRIPTION
ビルドのジョブが増えてきたので。

sudo: false と書くだけでDockerベースの高速なスタックを使ってくれるらしいので変えてみました。
参考：http://postd.cc/faster-builds-with-container-based-infrastructure/
また、Composerのデータをキャッシュさせるようにしました。

数回実行してみた印象は、ビルド開始までの待ち時間が減り、テスト実行時間の振れ幅は増えたというところです。
総実行時間はビルド待ち時間とComposerの短縮分で減ったかなと。

なお、コンテナのPHP7環境が5.3で非推奨となったeregi()関数をサポートしていないらしく、
インストール前のcheckenvがこけたのでpreg_match()とi修飾子に入れ替えています。
http://php.net/manual/ja/function.eregi.php