### PR TITLE
fixed #3325 固定ページで、文法エラーとなるPHPコードをソースに書くと編集画面が開けなくなる 修正

### DIFF
--- a/lib/Baser/Model/Page.php
+++ b/lib/Baser/Model/Page.php
@@ -136,6 +136,10 @@ class Page extends AppModel {
 		'description' => array(
 			array('rule' => array('maxLength', 255),
 				'message' => '説明文は255文字以内で入力してください。')
+		),
+		'contents' => array(
+			array('rule' => array('phpValidSyntax'),
+				'message' => 'PHPの構文エラーです')
 		)
 	);
 
@@ -1228,4 +1232,24 @@ class Page extends AppModel {
 		return $datas;
 	}
 
+/**
+ * PHP構文チェック
+ *
+ * @param array $check チェック対象文字列
+ * @return bool
+ */
+	public function phpValidSyntax($check) {
+		if(empty($check[key($check)])) {
+			return true;
+		}
+
+		$command = sprintf('echo %s | php -l 2> /dev/null', escapeshellarg($check[key($check)]));
+		exec($command, $output, $returnVar);
+
+		if($returnVar === 0) {
+			return true;
+		}
+
+		return false;
+	}
 }

--- a/lib/Baser/Test/Case/Model/PageTest.php
+++ b/lib/Baser/Test/Case/Model/PageTest.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * ページモデルのテスト
  *
@@ -76,6 +75,30 @@ class PageTest extends BaserTestCase {
 			array('/servce.css', false),
 			array('/', true),
 			array('/hoge', false)
+		);
+	}
+
+/**
+ * PHP構文チェック
+ *
+ * @param array $code PHPのコード
+ * @param bool $expected 期待値
+ * @return void
+ * @dataProvider phpValidSyntaxDataProvider
+ */
+	public function testPhpValidSyntax($code, $expected) {
+		$this->assertEquals($expected, $this->Page->phpValidSyntax($code));
+	}
+
+/**
+ * testPhpValidSyntax用データプロバイダ
+ *
+ * @return array
+ */
+	public function phpValidSyntaxDataProvider() {
+		return array(
+			array(array('contents' => '<?php $this->BcBaser->setTitle(\'test\');'), true),
+			array(array('contents' => '<?php echo "test'), false)
 		);
 	}
 }


### PR DESCRIPTION
確認お願いします。