### PR TITLE
WIP　インストール時のDB名のサーバ側のバリデーションを追加（HTTPリクエスト時）

### DIFF
--- a/lib/Baser/Model/Installation.php
+++ b/lib/Baser/Model/Installation.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * インストール時のデータ検証用モデル
+ * DB接続はしない
+ *
+ * baserCMS :  Based Website Development Project <http://basercms.net>
+ * Copyright 2008 - 2015, baserCMS Users Community <http://sites.google.com/site/baserusers/>
+ *
+ * @copyright		Copyright 2008 - 2015, baserCMS Users Community
+ * @link			http://basercms.net baserCMS Project
+ * @package			Baser.Model
+ * @since			baserCMS v 3.1.0-dev
+ * @license			http://basercms.net/license/index.html
+ */
+class Installation extends Model {
+
+/**
+ * クラス名
+ *
+ * @var string
+ * @access public
+ */
+	public $name = 'Installation';
+
+/**
+ * use table
+ * 
+ * @var bool
+ * @access public
+ */
+	public $useTable = false;
+
+/**
+ * バリデーション
+ *
+ * @var array
+ * @access public
+ */
+	public $validate = array(
+		'dbName' => array(
+			array(
+				'rule' => 'notEmpty',
+				'message' => 'データベース名を入力してください。',
+				'required' => true
+			),
+			array(
+				'rule' => 'alphaNumericPlus',
+				'message' => 'データベース名を半角英数字、ハイフン、アンダースコアのみで入力してください',
+			)
+		)
+	);
+
+/**
+ * 英数チェックプラス
+ *
+ * ハイフンアンダースコアを許容
+ *
+ * @param array $check チェック対象配列
+ * @return bool
+ */
+	public function alphaNumericPlus($check) {
+		if (!$check[key($check)]) {
+			return true;
+		}
+		return (bool)preg_match("/^[a-zA-Z0-9\-_]+$/", $check[key($check)]);
+	}
+
+}

--- a/lib/Baser/View/Installations/admin/step3.php
+++ b/lib/Baser/View/Installations/admin/step3.php
@@ -25,11 +25,11 @@ $(document).ready( function() {
 	$('#checkdb,#btnnext,#btnback').click( function array() {
 
 		if (this.id=='btnnext') {
-			$("#buttonclicked").val('createdb');
+			$("#InstallationButtonClicked").val('createdb');
 		} else if (this.id == 'btnback') {
-			$("#buttonclicked").val('back');
+			$("#InstallationButtonClicked").val('back');
 		} else if (this.id == 'checkdb'){
-			$("#buttonclicked").val('checkdb');
+			$("#InstallationButtonClicked").val('checkdb');
 		}
 		
 		if (this.id != 'btnback' &&
@@ -43,6 +43,9 @@ $(document).ready( function() {
 				return false;
 			} else if ($("#InstallationDbName").val() == "") {
 				alert("データベース名を入力してください。");
+				return false;
+			} else if (!$("#InstallationDbName").val().match(/^[a-zA-z0-9_\-]+$/)) {
+				alert("データベース名は英数字とハイフン・アンダースコアの組み合わせにしてください。（例）basercms");
 				return false;
 			} else if ($("#InstallationDbPrefix").val() == "") {
 				alert("他のアプリケーションと重複しないプレフィックスを入力してください。（例）mysite_");
@@ -180,7 +183,7 @@ $(document).ready( function() {
 						<small>プレフィックス</small> </div>
 					<div class="float-left"> <?php echo $this->BcForm->input('Installation.dbPort', array('type' => 'text', 'maxlength' => '5', 'size' => 5)); ?><br />
 						<small>ポート</small> </div>
-					<?php echo $this->BcForm->input('buttonclicked', array('style' => 'display:none', 'type' => 'hidden')); ?>
+					<?php echo $this->BcForm->input('Installation.buttonClicked', array('style' => 'display:none', 'type' => 'hidden')); ?>
 					<br style="clear:both" /><br />
 					<small>※ プレフィックスは英数字とアンダースコアの組み合わせとし末尾はアンダースコアにしてください。<br />
 						※ ホスト名、データベース名、ポートは実際の環境に合わせて書き換えてください。</small></li>


### PR DESCRIPTION
http://project.e-catchup.jp/issues/2653

DB名にドットを含めない方向で調整していますが、ご意見を頂きたいので一度PRを出します。
※コンソールは手を付けてません

現状のインストール処理においては、JavaScriptのみでDB名その他の入力値のバリデーションを行っているようですね。

しかし、クライアント側のバリデーションはいくらでも回避できます。
インストールページにアクセスするユーザは管理者のみであり、常にJavaScriptが有効化されたブラウザからインストール作業を行うという仮定が成立するならば問題ないはずですが、楽観的すぎるように感じます。

ブラウザでなくても、HTTPリクエストを発することはできますし、ブラウザでもJavaScriptを改変することができます。つまりJavaScriptによるバリデーションはユーザーエクスペリエンスのためのオマケでしかなく、厳密に正当な入力を担保するためには、いかなる場合もサーバ側でのバリデーションが不可欠です。

バリデーション用にModelを追加しています。（データベースを利用しないので、BcAppModelではなく、CakePHPのModelを継承しています）
コンソールからの実行時も同様にこのモデルを利用しようと思います。