### PR TITLE
Support hasMany File Upload

### DIFF
--- a/lib/Baser/Test/Case/View/Helper/BcFormHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcFormHelperTest.php
@@ -186,4 +186,70 @@ class BcFormHelperTest extends BaserTestCase {
 		$this->assertTags($result, $expected);
 	}
 
+/**
+ * ファイルアップロードフィールドのテスト（hasMany対応）
+ *
+ * @return void
+ */
+	public function testFileUploadFieldHasManyField() {
+		$fieldName = 'Contact.0.upload';
+		$this->BcForm->setEntity($fieldName);
+
+		// 通常
+		$result = $this->BcForm->file($fieldName);
+
+		$expected = array(
+			'div'	=> array('class' => 'upload-file'),
+			array('input'	=> array('type' => 'file', 'name' => 'data[Contact][0][upload]', 'id' => 'Contact0Upload')),
+			'/div'
+		);
+		$this->assertTags($result, $expected);
+	}
+
+/**
+ * ファイルアップロードフィールドのテスト（hasMany対応）
+ *
+ * データと画像が既に存在する場合について
+ *
+ * @return void
+ */
+	public function testFileUploadFieldHasManyFieldWithImageFile() {
+		$fieldName = 'Contact.0.eye_catch';
+		$this->BcForm->setEntity($fieldName);
+		$this->BcForm->BcUpload->request->data = array(
+			'Contact' => array(
+				array(
+					'id' => '1',
+					'eye_catch' => 'template1.jpg',
+					'modified' => '2013-07-21 01:41:12', 'created' => '2013-07-21 00:53:42',
+				),
+			)
+		);
+
+		$result = $this->BcForm->file($fieldName);
+
+		$expected = array(
+			'div'	=> array('class' => 'upload-file'),
+			array('input' => array('type' => 'file', 'name' => 'data[Contact][0][eye_catch]', 'id' => 'Contact0EyeCatch')),
+			'&nbsp;',
+			array('input' => array('type' => 'hidden', 'name' => 'data[Contact][0][eye_catch_delete]', 'id' => 'Contact0EyeCatchDelete_', 'value' => '0')),
+			array('input' => array('type' => 'checkbox', 'name' => 'data[Contact][0][eye_catch_delete]', 'value' => '1', 'id' => 'Contact0EyeCatchDelete')),
+			'label' => array('for' => 'Contact0EyeCatchDelete'),
+			'削除する',
+			'/label',
+			array('input'	=> array('type' => 'hidden', 'name' => 'data[Contact][0][eye_catch_]', 'id' => 'Contact0EyeCatch')),
+			array('br' => true),
+			'a' => array('href' => 'preg:/' . preg_quote('/files/template1.jpg?', '/') . '\d+/', 'rel' => 'colorbox', 'title' => ''),
+			array('img' => array('src' => 'preg:/' . preg_quote('/files/template1.jpg?', '/') . '\d+/', 'alt' => '')),
+			'/a',
+			array('br' => true),
+			'span' => array('class' => 'file-name'),
+			'template1.jpg',
+			'/span',
+			'/div'
+		);
+
+		$this->assertTags($result, $expected);
+	}
+
 }

--- a/lib/Baser/Test/Case/View/Helper/BcFormHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcFormHelperTest.php
@@ -53,7 +53,7 @@ class Contact extends CakeTestModel {
  * FormHelperTest class
  *
  * @package		Baser.Test.Case.View.Helper
- * @property	BcFormHelper $Form
+ * @property	BcFormHelper $BcForm
  */
 class BcFormHelperTest extends BaserTestCase {
 
@@ -140,9 +140,50 @@ class BcFormHelperTest extends BaserTestCase {
 		);
 		$this->assertTags($result, $expected);
 
-		// TODO データと画像が既に存在する場合についてテストを記述する
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
-		
 	}
-	
+
+/**
+ * ファイルアップロードフィールドのテスト
+ *
+ * データと画像が既に存在する場合について
+ *
+ * @return void
+ */
+	public function testFileUploadFieldWithImageFile() {
+		$fieldName = 'Contact.eye_catch';
+		$this->BcForm->setEntity($fieldName);
+		$this->BcForm->BcUpload->request->data = array(
+			'Contact' => array(
+				'id' => '1',
+				'eye_catch' => 'template1.jpg',
+				'modified' => '2013-07-21 01:41:12', 'created' => '2013-07-21 00:53:42',
+			)
+		);
+
+		$result = $this->BcForm->file($fieldName);
+
+		$expected = array(
+			'div'	=> array('class' => 'upload-file'),
+			array('input' => array('type' => 'file', 'name' => 'data[Contact][eye_catch]', 'id' => 'ContactEyeCatch')),
+			'&nbsp;',
+			array('input' => array('type' => 'hidden', 'name' => 'data[Contact][eye_catch_delete]', 'id' => 'ContactEyeCatchDelete_', 'value' => '0')),
+			array('input' => array('type' => 'checkbox', 'name' => 'data[Contact][eye_catch_delete]', 'value' => '1', 'id' => 'ContactEyeCatchDelete')),
+			'label' => array('for' => 'ContactEyeCatchDelete'),
+			'削除する',
+			'/label',
+			array('input'	=> array('type' => 'hidden', 'name' => 'data[Contact][eye_catch_]', 'id' => 'ContactEyeCatch')),
+			array('br' => true),
+			'a' => array('href' => 'preg:/' . preg_quote('/files/template1.jpg?', '/') . '\d+/', 'rel' => 'colorbox', 'title' => ''),
+			array('img' => array('src' => 'preg:/' . preg_quote('/files/template1.jpg?', '/') . '\d+/', 'alt' => '')),
+			'/a',
+			array('br' => true),
+			'span' => array('class' => 'file-name'),
+			'template1.jpg',
+			'/span',
+			'/div'
+		);
+
+		$this->assertTags($result, $expected);
+	}
+
 }

--- a/lib/Baser/Test/Case/View/Helper/BcUploadHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcUploadHelperTest.php
@@ -64,6 +64,25 @@ class BcUploadHelperTest extends BaserTestCase {
 	}
 
 /**
+ * ファイルへのリンクタグを出力する(hasMany対応)
+ */
+	public function testFileLinkHasManyField() {
+		$this->BcUpload->request->data = array(
+			'EditorTemplate' => array(
+				array(
+					'id' => '1',
+					'name' => '画像（左）とテキスト',
+					'image' => 'template1.jpg',
+					'description' => '説明文',
+					'modified' => '2013-07-21 01:41:12', 'created' => '2013-07-21 00:53:42',
+				),
+			)
+		);
+		$result = $this->BcUpload->fileLink('EditorTemplate.0.image');
+		$this->assertRegExp('/<a href=\"\/files\/editor\/template1\.jpg/', $result);
+	}
+
+/**
  * アップロードした画像のタグを出力する
  */
 	public function testUploadImage() {

--- a/lib/Baser/View/Helper/BcFormHelper.php
+++ b/lib/Baser/View/Helper/BcFormHelper.php
@@ -1363,13 +1363,11 @@ DOC_END;
  */
 	public function file($fieldName, $options = array()) {
 		$entity = $this->entity();
-		$modelName = array_shift($entity);
+		$modelName = $this->model();
 		$field = $this->field();
 		$Model = ClassRegistry::init($modelName);
-		if (empty($Model->Behaviors->BcUpload)) {
-			return parent::file($fieldName, $options);
-		}
-		
+		$fieldName = implode('.', $entity);
+
 		$options = array_merge(array(
 			'imgsize' => 'midium', // 画像サイズ
 			'rel' => '', // rel属性
@@ -1399,28 +1397,28 @@ DOC_END;
 
 		$fileLinkTag = $this->BcUpload->fileLink($fieldName, $linkOptions);
 		$fileTag = parent::file($fieldName, $options);
-		
+
 		if (empty($options['value'])) {
 			$value = $this->value($fieldName);
 		} else {
 			$value = $options['value'];
 		}
-		
+
 		$delCheckTag = '';
 		if ($fileLinkTag && $linkOptions['delCheck'] && empty($value['session_key'])) {
-			$delCheckTag = $this->checkbox($modelName . '.' . $field . '_delete') . $this->label($modelName . '.' . $field . '_delete', '削除する');
+			$delCheckTag = $this->checkbox($fieldName . '_delete') . $this->label($fieldName . '_delete', '削除する');
 		}
 		$hiddenValue = $this->value($fieldName . '_');
 		$fileValue = $this->value($fieldName);
 
 		if($fileLinkTag) {
 			if (is_array($fileValue) && empty($fileValue['tmp_name']) && $hiddenValue) {
-				$hiddenTag = $this->hidden($modelName . '.' . $field . '_', array('value' => $hiddenValue));
+				$hiddenTag = $this->hidden($fieldName . '_', array('value' => $hiddenValue));
 			} else {
 				if (is_array($fileValue)) {
 					$fileValue = null;
 				}
-				$hiddenTag = $this->hidden($modelName . '.' . $field . '_', array('value' => $fileValue));
+				$hiddenTag = $this->hidden($fieldName . '_', array('value' => $fileValue));
 			}
 		}
 		

--- a/lib/Baser/View/Helper/BcUploadHelper.php
+++ b/lib/Baser/View/Helper/BcUploadHelper.php
@@ -79,8 +79,10 @@ class BcUploadHelper extends BcAppHelper {
 		if(strpos($fieldName, '.') === false) {
 			throw new BcException('BcUploadHelper を利用するには、$fieldName に、モデル名とフィールド名をドットで区切って指定する必要があります。');
 		}
-		list($modelName, $field) = explode('.', $fieldName);
-		
+		$this->setEntity($fieldName);
+		$modelName = $this->model();
+		$field = $this->field();
+
 		$tmp = false;
 		$entity = $this->entity();
 		$Model = ClassRegistry::init($modelName);
@@ -231,7 +233,9 @@ class BcUploadHelper extends BcAppHelper {
 			return false;
 		}
 
-		list($modelName, $field) = explode('.', $fieldName);
+		$this->setEntity($fieldName);
+		$modelName = $this->model();
+		$field = $this->field();
 		$Model = ClassRegistry::init($modelName);
 
 		$settings = $Model->Behaviors->BcUpload->settings[$modelName];


### PR DESCRIPTION
`BcUploadHelper`および、`BcFormHelper::file()`メソッドのhasMany対応パッチです。

任意個数の画像をアップロードするような要件のあるプラグインを作成する際に必要になる、hasManyリレーションで取得したデータに対しても、アップロードフォームを表示できるようにしています。

```
 $this->BcForm->file('Foo.0.image');
```
