### PR TITLE
fixed #8177 Windows環境の自動テスト追加

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,43 @@
+build: false
+shallow_clone: false
+platform: 'x86'
+clone_folder: c:\projects\basercms
+
+environment:
+  global:
+    PHP: c:\tools\php
+    ROOT: c:\projects\basercms
+    APP: c:\projects\basercms\app
+    DB: 'sqlite'
+
+#cache:
+#  - C:\ProgramData\chocolatey\bin -> appveyor.yml
+#  - C:\ProgramData\chocolatey\lib -> appveyor.yml
+#  - C:\tools\php
+
+init:
+  - SET PATH=%PHP%;%PATH%
+  - git config --global core.autocrlf input
+
+install:
+  - cinst -y php
+  - cd %PHP%
+  - copy php.ini-production php.ini
+  - echo date.timezone="UTC" >> php.ini
+  - echo extension_dir=ext >> php.ini
+  - echo extension=php_openssl.dll >> php.ini
+  - echo extension=php_intl.dll >> php.ini
+  - echo extension=php_mbstring.dll >> php.ini
+  - echo extension=php_fileinfo.dll >> php.ini
+  - echo extension=php_gd2.dll >> php.ini
+  - echo extension=php_sqlite3.dll >> php.ini
+  - echo extension=php_pdo_sqlite.dll >> php.ini
+  - cd %ROOT%
+  - php -r "readfile('https://getcomposer.org/installer');" | php
+  - php composer.phar install --prefer-dist --no-interaction --dev
+  - cd %APP%
+  - php ./Console/cake.php bc_manager checkenv
+  - php ./Console/cake.php bc_manager install "http://localhost" %DB% "admin" "basercms" "webmaster@example.org" --host "localhost" --database "basercms" --login "basercms" --password "basercms" --prefix "mysite_" --smarturl "true"  --data "nada-icons.default"
+
+test_script:
+  - php ./Console/cake.php baser_test baser BcAll --debug

--- a/lib/Baser/Configure/BcThemeConfigReader.php
+++ b/lib/Baser/Configure/BcThemeConfigReader.php
@@ -107,7 +107,7 @@ class BcThemeConfigReader implements ConfigReaderInterface {
  * @return string
  */
 	public function createContents(array $data) {
-		$contents = '<?php' . "\n";
+		$contents = '<?php' . PHP_EOL;
 
 		foreach (self::$variables as $var => $name) {
 			$value = empty($data[$var]) ? '': $data[$var];

--- a/lib/Baser/Lib/TestSuite/BaserTestCase.php
+++ b/lib/Baser/Lib/TestSuite/BaserTestCase.php
@@ -64,8 +64,8 @@ class BaserTestCase extends CakeTestCase {
 			$baseUrl = Configure::read('App.baseUrl');
 			if($request->url === false) {
 				$request->here = $baseUrl . '/';
-			} elseif(preg_match('/^' . preg_quote($request->webroot, DS) . '/', $request->here)) {
-				$request->here = $baseUrl . '/' . preg_replace('/^' . preg_quote($request->webroot, DS) . '/', '', $request->here);
+			} elseif(preg_match('/^' . preg_quote($request->webroot, '/') . '/', $request->here)) {
+				$request->here = $baseUrl . '/' . preg_replace('/^' . preg_quote($request->webroot, '/') . '/', '', $request->here);
 			}
 			if($baseUrl) {
 				if(preg_match('/^\//', $baseUrl)) {

--- a/lib/Baser/Model/Page.php
+++ b/lib/Baser/Model/Page.php
@@ -1243,8 +1243,20 @@ class Page extends AppModel {
 			return true;
 		}
 
-		$command = sprintf('echo %s | php -l 2> /dev/null', escapeshellarg($check[key($check)]));
-		exec($command, $output, $returnVar);
+		if(isWindows()) {
+			$tmpName = tempnam(TMP, "syntax");
+			$tmp = new File($tmpName);
+			$tmp->open("w");
+			$tmp->write($check[key($check)]);
+			$tmp->close();
+			$command = sprintf("php -l %s 2> nul", escapeshellarg($tmpName));
+			exec($command, $output, $returnVar);
+			$tmp->delete();
+		} else {
+			$format = 'echo %s | php -l 2> /dev/null';
+			$command = sprintf($format, escapeshellarg($check[key($check)]));
+			exec($command, $output, $returnVar);
+		}
 
 		if($returnVar === 0) {
 			return true;

--- a/lib/Baser/Test/Case/Configure/BcThemeConfigReaderTest.php
+++ b/lib/Baser/Test/Case/Configure/BcThemeConfigReaderTest.php
@@ -50,6 +50,8 @@ class BcThemeConfigReaderTest extends BaserTestCase {
 
 EOF;
 
+		$contents = preg_replace("/\r\n|\r|\n/", PHP_EOL, $contents);
+
 		$data[] = array(
 			array(
 				'title' => 'タイトル',

--- a/lib/Baser/Test/Case/Model/PageTest.php
+++ b/lib/Baser/Test/Case/Model/PageTest.php
@@ -98,7 +98,7 @@ class PageTest extends BaserTestCase {
 	public function phpValidSyntaxDataProvider() {
 		return array(
 			array(array('contents' => '<?php $this->BcBaser->setTitle(\'test\');'), true),
-			array(array('contents' => '<?php echo "test'), false)
+			array(array('contents' => '<?php echo \'test'), false)
 		);
 	}
 }

--- a/lib/Baser/basics.php
+++ b/lib/Baser/basics.php
@@ -963,3 +963,11 @@ function base64UrlsafeDecode($val) {
 	return base64_decode($val);
 }
 
+/**
+ * 実行環境のOSがWindowsであるかどうかを返す
+ *
+ * @return bool
+ */
+function isWindows() {
+	return DIRECTORY_SEPARATOR == '\\';
+}


### PR DESCRIPTION
とりあえずSQLiteのみですがテスト通りましたのでPR出します。
https://ci.appveyor.com/project/n1215/basercms/build/1.0.21

#### appveyor.ymlを追加
ChocolateyによるPHPのインストールやComposerの結果をキャッシュしたかったんですが、
あまりうまくいかなかったのでひとまず保留しました。

#### テスト実行時エラーの修正
BaserTestCaseにてエラーが出ていたので修正

#### 落ちたテスト周りを修正
２つ落ちるテストがありました。
幸いにも（？）最近僕が書いたところでしたので。

* BcThemeConfigReader::createContents() 改行コードの相違でテストが落ちていた
* Page::phpValidSyntax() PHPの構文チェックコマンドをexecで実行する際に、コマンドラインの引数をエスケープする必要があった。そのための関数であるescapeshellarg()がWindowsで上手く使えなかったので、場合分けしてコードを一時ファイルに保存してチェックすることにした