### PR TITLE
fixed #8224 CakePHPのPagesコントローラーのデフォルトの挙動を無効にする

### DIFF
--- a/app/Config/routes.php
+++ b/app/Config/routes.php
@@ -31,17 +31,6 @@
  */
 	require BASER_CONFIGS . 'routes.php';
 // <<<
-	
-/**
- * Here, we are connecting '/' (base path) to controller called 'Pages',
- * its action called 'display', and we pass a param to select the view file
- * to use (in this case, /app/View/Pages/home.ctp)...
- */
-	Router::connect('/', array('controller' => 'pages', 'action' => 'display', 'home'));
-/**
- * ...and connect the rest of 'Pages' controller's URLs.
- */
-	Router::connect('/pages/*', array('controller' => 'pages', 'action' => 'display'));
 
 /**
  * Load all plugin routes. See the CakePlugin documentation on


### PR DESCRIPTION
CakePHPが用意していた
* PageControllerのルーティング  /pages/*
* トップページのルーティング /
を無効化しました。
両方固定ページのルーティングで処理されるはずなので。

確認お願いします。