### PR TITLE
fixed #8434 キャッシュとアセットのディスパッチャーが二重登録されていて挙動がわかりにくい

### DIFF
--- a/app/Config/bootstrap.php
+++ b/app/Config/bootstrap.php
@@ -90,10 +90,15 @@
  *
  * ));
  */
-Configure::write('Dispatcher.filters', array(
+
+
+// CUSTOMIZE DELETE 2014/04/19 n1215
+// >>>
+/*Configure::write('Dispatcher.filters', array(
 	'AssetDispatcher',
 	'CacheDispatcher'
-));
+));*/
+// <<<
 
 /**
  * Configures default file logging options

--- a/lib/Baser/Config/bootstrap.php
+++ b/lib/Baser/Config/bootstrap.php
@@ -78,9 +78,22 @@ if (!defined('BC_DEPLOY_PATTERN')) {
 define('BC_BASE_URL', baseUrl());
 
 /**
- * アセットフィルターを追加
+ * ディスパッチャーフィルターを追加
  */
-Configure::write('Dispatcher.filters', array_merge(Configure::read('Dispatcher.filters'), array('BcAssetDispatcher', 'BcCacheDispatcher', 'BcRequestFilter')));
+$filters = Configure::read('Dispatcher.filters');
+if (!is_array($filters)) {
+	$filters = array();
+}
+Configure::write('Dispatcher.filters',
+	array_merge(
+		$filters,
+		array(
+			'BcAssetDispatcher',
+			'BcCacheDispatcher',
+			'BcRequestFilter'
+		)
+	)
+);
 
 /**
  * クラスローダー設定


### PR DESCRIPTION
Dispatcher.filtersに登録されているディスパッチャー

名前：優先度
BcAssetDispatcher: 4
BcRequestFilter: 6 
AssetDispatcher: 9  << 被り
CacheDispatcher: 9  <<  被り
BcCacheDispatcher : 10

のうち被っているCakeの元のAssetとCacheを外しました。
それぞれのディスパッチャーの優先度も振りなおしても良さそうですね。