### PR TITLE
fixed #8436 ブログ編集画面から遷移するテンプレート編集のURLが正しくない

### DIFF
--- a/lib/Baser/Plugin/Blog/Controller/BlogContentsController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogContentsController.php
@@ -227,12 +227,12 @@ class BlogContentsController extends BlogAppController {
  * @access public
  */
 	public function redirectEditBlog($template) {
-		$path = 'blog' . DS . $template;
+		$path = 'Blog' . DS . $template;
 		$target = WWW_ROOT . 'theme' . DS . $this->siteConfigs['theme'] . DS . $path;
-		$sorces = array(BASER_PLUGINS . 'blog' . DS . 'View' . DS . $path);
+		$sources = array(BASER_PLUGINS . 'Blog' . DS . 'View' . DS . $path);
 		if ($this->siteConfigs['theme']) {
 			if (!file_exists($target . DS . 'index' . $this->ext)) {
-				foreach ($sorces as $source) {
+				foreach ($sources as $source) {
 					if (is_dir($source)) {
 						$folder = new Folder();
 						$folder->create(dirname($target), 0777);


### PR DESCRIPTION
大文字小文字の違いなので、baserCMS2→3時の修正漏れかなと思います。
確認お願いします。