### PR TITLE
fixed #8392 メールプラグインのCSVダウンロードで値の先頭に半角スペースが入る 修正

### DIFF
--- a/lib/Baser/Plugin/Mail/Model/Message.php
+++ b/lib/Baser/Plugin/Mail/Model/Message.php
@@ -844,7 +844,7 @@ class Message extends MailAppModel {
 				if($mailField['MailField']['type'] == 'file') {
 					$inData[$mailField['MailField']['field_name'] . ' (' . $mailField['MailField']['name'] . ')'] = $message[$this->alias][$mailField['MailField']['field_name']];
 				} else {
-					$inData[$mailField['MailField']['field_name'] . ' (' . $mailField['MailField']['name'] . ')'] = $Maildata->control(
+					$inData[$mailField['MailField']['field_name'] . ' (' . $mailField['MailField']['name'] . ')'] = $Maildata->toDisplayString(
 						$mailField['MailField']['type'],
 						$message[$this->alias][$mailField['MailField']['field_name']],
 						$Mailfield->getOptions($mailField['MailField'])


### PR DESCRIPTION
MailDataHelper::control()の出力文字列の先頭のスペースを取り払ったメソッドを新たに作成しました。
確認お願いします。