### PR TITLE
fixed #8435 認証プレフィックスの利用例をセッションキーを共用する設定に書き換える

### DIFF
--- a/lib/Baser/Config/setting.php
+++ b/lib/Baser/Config/setting.php
@@ -128,7 +128,7 @@ $config['BcAuthPrefix'] = array(
 	  'loginAction'	=> '/users/login',
 	  'logoutAction'=> '/users/logout',
 	  'toolbar'		=> true,
-	  'sessionKey'	=> 'Front',
+	  'sessionKey'	=> 'User',
 	), */
 	// マイページ（例）
 /* 'mypage' => array(
@@ -140,7 +140,7 @@ $config['BcAuthPrefix'] = array(
 	  'loginAction'	=> '/mypage/members/login',
 	  'logoutAction'=> '/mypage/members/logout',
 	  'toolbar'		=> false,
-	  'sessionKey'	=> 'Mypage',
+	  'sessionKey'	=> 'User',
 	), */
 	// モバイルマイページ（例）
 /* 'mobile_mypage' => array(
@@ -153,7 +153,7 @@ $config['BcAuthPrefix'] = array(
 	  'logoutAction'=> '/m/mypage/users/logout',
 	  'toolbar'		=> false,
 	  'userScope'	=> array(),
-	  'sessionKey'	=> 'MobileMypage',
+	  'sessionKey'	=> 'User',
 	) */
 );
 /**


### PR DESCRIPTION
確認お願いします。