### PR TITLE
fixed #8437 ログイン時のページリンクに関わるBcBaserHelperの一部のメソッドのテストが失敗する

### DIFF
--- a/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
@@ -1066,7 +1066,7 @@ class BcBaserHelperTest extends BaserTestCase {
 		// リンクあり
 		$expected = '<a href="/admin/pages/edit/1" class="tool-menu">編集する</a>';
 		$this->_View->viewVars['user'] = array('User' => array('id' => 1));
-		$this->_View->viewVars['authPrefix'] = Configure::read('Routing.prefixes.0');
+		$this->_View->viewVars['currentUserAuthPrefixes'] = array(Configure::read('Routing.prefixes.0'));
 		$this->BcBaser->setPageEditLink(1);
 		ob_start();
 		$this->BcBaser->editLink();
@@ -1083,7 +1083,7 @@ class BcBaserHelperTest extends BaserTestCase {
 		$this->assertEqual($this->BcBaser->existsEditLink(), false);
 		// 存在する
 		$this->_View->viewVars['user'] = array('User' => array('id' => 1));
-		$this->_View->viewVars['authPrefix'] = Configure::read('Routing.prefixes.0');
+		$this->_View->viewVars['currentUserAuthPrefixes'] = array(Configure::read('Routing.prefixes.0'));
 		$this->BcBaser->setPageEditLink(1);
 		$this->assertEqual($this->BcBaser->existsEditLink(), true);
 	}
@@ -1100,7 +1100,7 @@ class BcBaserHelperTest extends BaserTestCase {
 		$this->assertEqual($result, $expected);	
 		// リンクあり
 		$expected = '<a href="/" class="tool-menu">公開ページ</a>';
-		$this->_View->viewVars['authPrefix'] = Configure::read('Routing.prefixes.0');
+		$this->_View->viewVars['currentUserAuthPrefixes'] = array(Configure::read('Routing.prefixes.0'));
 		$this->_View->viewVars['publishLink'] = '/';
 		ob_start();
 		$this->BcBaser->publishLink();
@@ -1115,7 +1115,7 @@ class BcBaserHelperTest extends BaserTestCase {
 		// 存在しない
 		$this->assertEqual($this->BcBaser->existsPublishLink(), false);
 		// 存在する
-		$this->_View->viewVars['authPrefix'] = Configure::read('Routing.prefixes.0');
+		$this->_View->viewVars['currentUserAuthPrefixes'] = array(Configure::read('Routing.prefixes.0'));
 		$this->_View->viewVars['publishLink'] = '/';
 		$this->assertEqual($this->BcBaser->existsPublishLink(), true);
 	}

--- a/lib/Baser/View/Helper/BcBaserHelper.php
+++ b/lib/Baser/View/Helper/BcBaserHelper.php
@@ -1146,7 +1146,6 @@ class BcBaserHelper extends AppHelper {
  * @return bool リンクが存在する場合は true を返す
  */
 	public function existsPublishLink() {
-		$dump = Configure::read('Routing.prefixes.0');
 		return !empty($this->_View->viewVars['currentUserAuthPrefixes'])
 		&& in_array(Configure::read('Routing.prefixes.0'), $this->_View->viewVars['currentUserAuthPrefixes'])
 		&& !empty($this->_View->viewVars['publishLink']);

--- a/lib/Baser/View/Helper/BcBaserHelper.php
+++ b/lib/Baser/View/Helper/BcBaserHelper.php
@@ -1122,7 +1122,9 @@ class BcBaserHelper extends AppHelper {
  * @return bool 存在する場合は true を返す
  */
 	public function existsEditLink() {
-		return (!empty($this->_View->viewVars['currentUserAuthPrefixes']) && in_array(Configure::read('Routing.prefixes.0'), $this->_View->viewVars['currentUserAuthPrefixes']) && !empty($this->_View->viewVars['editLink']));
+		return !empty($this->_View->viewVars['currentUserAuthPrefixes'])
+			&& in_array(Configure::read('Routing.prefixes.0'), $this->_View->viewVars['currentUserAuthPrefixes'])
+			&& !empty($this->_View->viewVars['editLink']);
 	}
 
 /**
@@ -1144,7 +1146,10 @@ class BcBaserHelper extends AppHelper {
  * @return bool リンクが存在する場合は true を返す
  */
 	public function existsPublishLink() {
-		return (!empty($this->_View->viewVars['currentUserAuthPrefixes']) && in_array(Configure::read('Routing.prefixes.0'), $this->_View->viewVars['currentUserAuthPrefixes']) && !empty($this->_View->viewVars['publishLink']));
+		$dump = Configure::read('Routing.prefixes.0');
+		return !empty($this->_View->viewVars['currentUserAuthPrefixes'])
+		&& in_array(Configure::read('Routing.prefixes.0'), $this->_View->viewVars['currentUserAuthPrefixes'])
+		&& !empty($this->_View->viewVars['publishLink']);
 	}
 
 /**


### PR DESCRIPTION
テストが落ちていたので修正しました。