### PR TITLE
HHVM用にテストコードを調整

### DIFF
--- a/lib/Baser/Test/Case/Config/SessionTest.php
+++ b/lib/Baser/Test/Case/Config/SessionTest.php
@@ -74,7 +74,7 @@ class SessionTest extends BaserTestCase {
 		require APP . 'Config' . DS . 'session.php';
 		CakeSession::start();
 		
-		$this->assertEquals($expects, array(ini_get('session.use_cookies'), ini_get('session.use_trans_sid')));
+		$this->assertEquals($expects, array(intval(ini_get('session.use_cookies')), intval(ini_get('session.use_trans_sid'))));
 	}
 /**
  * Session設定用データプロバイダ
@@ -130,7 +130,7 @@ class SessionTest extends BaserTestCase {
 		require APP . 'Config' . DS . 'session.php';
 		CakeSession::start();
 		
-		$this->assertEquals($expects, ini_get('session.cookie_secure'));
+		$this->assertEquals($expects, intval(ini_get('session.cookie_secure')));
 	}
 
 /**


### PR DESCRIPTION
ini_get()の返り値がstringとして厳密に比較されていたようです。