### PR TITLE
Feedプラグインにcategoriesを追加(categoryが複数指定できるWordPressなどの対応)

### DIFF
--- a/lib/Baser/Plugin/Feed/Model/Feed.php
+++ b/lib/Baser/Plugin/Feed/Model/Feed.php
@@ -207,6 +207,16 @@ class Feed extends FeedAppModel {
 			} else {
 				$tmp['category']['value'] = '';
 			}
+			$categories = $data->get_categories();
+			$categoryArray = array();
+			if ($categories) {
+				foreach ($categories as $category) {
+					$categoryArray[] = $category->get_term();
+				}
+				$tmp['categories']['value'] = $categoryArray;
+			} else {
+				$tmp['categories']['value'] = '';
+			}
 			$tmp['guid']['value'] = $data->get_id();
 			$tmp['guid']['attributes']['isPermaLink'] = $data->get_permalink();
 			$tmp['description']['value'] = $data->get_description();


### PR DESCRIPTION
Plugin FeedでWordPressのfeedを表示しようとしたときに複数のカテゴリーでもcategoryには1つしかはいらなかったので、複数の場合　categories　に複数入るようにしてみました。
*categoryは従来のままです