### PR TITLE
fixes #8398 初期データ読込ボタンを連打した場合でも実行されないようにした

### DIFF
--- a/lib/Baser/View/Themes/admin/index.php
+++ b/lib/Baser/View/Themes/admin/index.php
@@ -46,15 +46,27 @@ $(function(){
 				$(config.alertBox).fadeIn(500);
 			}
 		}
-	}
+	};
 	$.baserAjaxDataList.init();
+	
+	/**
+	 * 初期データ読込ボタンを押下した際の動作
+	 */
 	$("#BtnLoadDefaultDataPattern").click(function() {
-		if(confirm(
-			'初期データを読み込みます。よろしいですか？\n\n'+
-			'※ 初期データを読み込むと現在登録されている記事データや設定は全て上書きされますのでご注意ください。\n'+
-			'※ 管理ログは読み込まれず、ユーザー情報はログインしているユーザーのみに初期化されます。')) {
-			return true;
-		}
+		$('#ThemeLoadDefaultDataPatternFormDialog').dialog({
+			modal: true,
+			title: '初期データ読込',
+			width: 700,
+			buttons: {
+				"キャンセル": function() {
+					$(this).dialog("close");
+				},
+				"OK": function() {
+					$(this).dialog("close");
+					$("#ThemeLoadDefaultDataPatternForm").submit();
+				}
+			}
+		});
 		return false;
 	});
 	
@@ -77,6 +89,11 @@ $(function(){
 <div id="AjaxBatchUrl" style="display:none"><?php $this->BcBaser->url(array('controller' => 'themes', 'action' => 'ajax_batch')) ?></div>
 <div id="AlertMessage" class="message" style="display:none"></div>
 <div id="MessageBox" style="display:none"><div id="flashMessage" class="notice-message"></div></div>
+
+<div id="ThemeLoadDefaultDataPatternFormDialog" title="初期データ読込" class="display-none">
+	<p><strong>初期データを読み込みます。よろしいですか？</strong></p><br />
+	<p>※ 初期データを読み込むと現在登録されている記事データや設定は全て上書きされますのでご注意ください。<br />※ 管理ログは読み込まれず、ユーザー情報はログインしているユーザーのみに初期化されます。</p>
+</div>
 
 <div id="tabs">
 	<ul>


### PR DESCRIPTION
標準のアラートウィンドウの初期値変更はできないため、アラート用のウィンドウをjQuery-uiで生成し、選択初期値を キャンセル としました。
