### PR TITLE
固定ページ本文のPHP文法チェックエラーの情報量を増やした

### DIFF
--- a/lib/Baser/Model/Page.php
+++ b/lib/Baser/Model/Page.php
@@ -138,8 +138,7 @@ class Page extends AppModel {
 				'message' => '説明文は255文字以内で入力してください。')
 		),
 		'contents' => array(
-			array('rule' => array('phpValidSyntax'),
-				'message' => 'PHPの構文エラーです')
+			array('rule' => array('phpValidSyntax'))
 		)
 	);
 
@@ -1249,19 +1248,19 @@ class Page extends AppModel {
 			$tmp->open("w");
 			$tmp->write($check[key($check)]);
 			$tmp->close();
-			$command = sprintf("php -l %s 2> nul", escapeshellarg($tmpName));
-			exec($command, $output, $returnVar);
+			$command = sprintf("php -l %s 2>&1", escapeshellarg($tmpName));
+			exec($command, $output, $exit);
 			$tmp->delete();
 		} else {
-			$format = 'echo %s | php -l 2> /dev/null';
+			$format = 'echo %s | php -l 2>&1';
 			$command = sprintf($format, escapeshellarg($check[key($check)]));
-			exec($command, $output, $returnVar);
+			exec($command, $output, $exit);
 		}
 
-		if($returnVar === 0) {
+		if($exit === 0) {
 			return true;
 		}
-
-		return false;
+		$message = 'PHPの構文エラーです： ' . PHP_EOL . implode(' ' . PHP_EOL, $output);
+		return $message;
 	}
 }

--- a/lib/Baser/Test/Case/Model/PageTest.php
+++ b/lib/Baser/Test/Case/Model/PageTest.php
@@ -80,25 +80,50 @@ class PageTest extends BaserTestCase {
 
 /**
  * PHP構文チェック
+ * 成功時
  *
- * @param array $code PHPのコード
- * @param bool $expected 期待値
+ * @param string $code PHPのコード
  * @return void
  * @dataProvider phpValidSyntaxDataProvider
  */
-	public function testPhpValidSyntax($code, $expected) {
-		$this->assertEquals($expected, $this->Page->phpValidSyntax($code));
+	public function testPhpValidSyntax($code) {
+		$this->assertTrue($this->Page->phpValidSyntax(array('contents' => $code)));
 	}
 
 /**
- * testPhpValidSyntax用データプロバイダ
+ * testPhpValidSyntax 成功時 用データプロバイダ
  *
  * @return array
  */
 	public function phpValidSyntaxDataProvider() {
 		return array(
-			array(array('contents' => '<?php $this->BcBaser->setTitle(\'test\');'), true),
-			array(array('contents' => '<?php echo \'test'), false)
+			array('<?php $this->BcBaser->setTitle(\'test\');'),
 		);
 	}
+
+/**
+ * PHP構文チェック
+ * 失敗時
+ *
+ * @param string $line エラーが起こる行
+ * @param string $code PHPコード
+ * @return void
+ * @dataProvider phpValidSyntaxWithInvalidDataProvider
+ */
+	public function testPhpValidSyntaxWithInvalid($line, $code) {
+		$this->assertContains("on line {$line}", $this->Page->phpValidSyntax(array('contents' => $code)));
+	}
+
+/**
+ * testPhpValidSyntax 失敗時 用データプロバイダ
+ *
+ * @return array
+ */
+	public function phpValidSyntaxWithInvalidDataProvider() {
+		return array(
+			array(1, '<?php echo \'test'),
+			array(2, '<?php echo \'test\';' . PHP_EOL . 'echo \'hoge')
+		);
+	}
+
 }


### PR DESCRIPTION
「PHPの構文エラーです」としか表示しておらずわかりにくかったので、PHPの吐き出すエラーを後ろに付け加えました。