### PR TITLE
[ブログウィジェット] get_recent_entries()にfindのfieldを追加

### DIFF
--- a/lib/Baser/Plugin/Blog/Controller/BlogController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogController.php
@@ -947,7 +947,7 @@ class BlogController extends BlogAppController {
 		$conditions = am($conditions, $this->BlogPost->getConditionAllowPublish());
 		// 毎秒抽出条件が違うのでキャッシュしない
 		$data['recentEntries'] = $this->BlogPost->find('all', array(
-			'fields' => array('no', 'name'),
+			'fields' => array('id', 'no', 'name', 'blog_category_id', 'user_id', 'posts_date'),
 			'conditions' => $conditions,
 			'limit' => $limit,
 			'order' => 'posts_date DESC',


### PR DESCRIPTION
[追加したフィールド]
id, user_id, blog_category_id, posts_date

[追加理由]
以前はget_recent_entries()では、"no","name"しか取得できず、
その投稿に関連する情報を取得できないため。
 id, user_id, blog_category_id, posts_dateを追加することで、
 ブログサイドバーをカスタマイズしやすくなると思います。