### PR TITLE
fixed: 検索してデータを絞り、連番に並んでいない状態で順番を変更すると、ソート番号が重複する

### DIFF
--- a/lib/Baser/Model/BcAppModel.php
+++ b/lib/Baser/Model/BcAppModel.php
@@ -791,7 +791,6 @@ class BcAppModel extends Model {
 			$conditions[$this->alias . '.sort >='] = $targetSort;
 		}
 
-		$conditions = array_merge($conditions, $_conditions);
 		$datas = $this->find('all', array(
 			'conditions' => $conditions,
 			'fields' => array($this->alias . '.id', $this->alias . '.sort'),


### PR DESCRIPTION
引数から渡ってきたコンディションとマージしたコンディションを使用すると
番号を振り直す範囲が狭まってしまい、結果、ソート番号が重複する