### PR TITLE
fix #9122 ブラウザヒストリーバック（戻るボタン）対応コードをHelperで出力するように変更

### DIFF
--- a/lib/Baser/Config/theme/m-single/Elements/mail_form.php
+++ b/lib/Baser/Config/theme/m-single/Elements/mail_form.php
@@ -17,7 +17,8 @@ $prefix = '';
 if (Configure::read('BcRequest.agent')) {
 	$prefix = '/' . Configure::read('BcRequest.agentAlias');
 }
-echo $this->BcForm->hidden('AjaxGetTokenUrl', array('value' => $this->BcBaser->getUrl($prefix . '/' . $mailContent['MailContent']['name'] . '/ajax_get_token')));
+// ブラウザのヒストリーバック（戻るボタン）対応
+$this->Mail->token();
 ?>
 
 
@@ -28,14 +29,6 @@ $(function(){
     $("#MessageMode").val(mode);
     return true;
   });
-});
-// Firefox対策
-$(window).unload(function(){});
-$(window).load(function(){
-	$.ajaxSetup({cache: false});
-	$.get($("#AjaxGetTokenUrl").val(), function(result) {
-		$('input[name="data[_Token][key]"]').val(result);
-	});
 });
 </script>
 

--- a/lib/Baser/Plugin/Mail/View/Elements/mail_form.php
+++ b/lib/Baser/Plugin/Mail/View/Elements/mail_form.php
@@ -17,7 +17,8 @@ $prefix = '';
 if (Configure::read('BcRequest.agent')) {
 	$prefix = '/' . Configure::read('BcRequest.agentAlias');
 }
-echo $this->BcForm->hidden('AjaxGetTokenUrl', array('value' => $this->BcBaser->getUrl($prefix . '/' . $mailContent['MailContent']['name'] . '/ajax_get_token')));
+// ブラウザのヒストリーバック（戻るボタン）対応
+$this->Mail->token();
 ?>
 
 
@@ -27,14 +28,6 @@ $(function(){
 		var mode = $(this).attr('id').replace('BtnMessage', '');
 		$("#MessageMode").val(mode);
 		return true;
-	});
-});
-// Firefox対策
-$(window).unload(function(){});
-$(window).load(function(){
-	$.ajaxSetup({cache: false});
-	$.get($("#AjaxGetTokenUrl").val(), function(result) {
-		$('input[name="data[_Token][key]"]').val(result);
 	});
 });
 </script>

--- a/lib/Baser/Plugin/Mail/View/Elements/mail_token.php
+++ b/lib/Baser/Plugin/Mail/View/Elements/mail_token.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * baserCMS :  Based Website Development Project <http://basercms.net>
+ * Copyright 2008 - 2015, baserCMS Users Community <http://sites.google.com/site/baserusers/>
+ *
+ * @copyright		Copyright 2008 - 2015, baserCMS Users Community
+ * @link			http://basercms.net baserCMS Project
+ * @package			Mail.View
+ * @since			baserCMS v 0.1.0
+ * @license			http://basercms.net/license/index.html
+ */
+$prefix = '';
+if (Configure::read('BcRequest.agent')) {
+	$prefix = '/' . Configure::read('BcRequest.agentAlias');
+}
+?>
+<script type="text/javascript">
+$(document).ready(function(){
+	$('input[type="submit"]').attr('disabled', 'disabled');
+});
+$(window).unload(function(){});
+$(window).load(function(){
+	var getTokenUrl = '<?php echo $this->BcBaser->getUrl($prefix . '/' . $mailContent['MailContent']['name'] . '/ajax_get_token') ?>';
+	$.ajaxSetup({cache: false});
+	$.get(getTokenUrl, function(result) {
+		$('input[name="data[_Token][key]"]').val(result);
+		$('input[type="submit"]').removeAttr('disabled');
+	});
+});
+</script>

--- a/lib/Baser/Plugin/Mail/View/Helper/MailHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MailHelper.php
@@ -246,5 +246,23 @@ class MailHelper extends AppHelper {
 		$link = array_merge(array('plugin' => '', 'controller' => $contentsName,  'action' => 'index'), $datas);
 		$this->BcBaser->link($title, $link, $options);
 	}
-	
+
+/**
+ * ブラウザの戻るボタン対応コードを作成
+ * 
+ * @return string
+ */
+	public function getToken() {
+		return $this->BcBaser->element('mail_token');
+	}
+
+/**
+ * ブラウザの戻るボタン対応コードを出力
+ * 
+ * @return void
+ */
+	public function token() {
+		echo $this->getToken();
+	}
+
 }


### PR DESCRIPTION
mail_form.phpに記述のないフォームは通常動作（ヒストリーバックが効かない）とすることで
既存テーマとの互換性を取りたいとおもいます。

よろしくお願いします。
