### PR TITLE
fix #9920 メールフォームにてタイプを自動補完郵便番号に設定すると最大値（文字数）が7文字に固定される

### DIFF
--- a/lib/Baser/Plugin/Mail/webroot/js/admin/mail_fields/form.js
+++ b/lib/Baser/Plugin/Mail/webroot/js/admin/mail_fields/form.js
@@ -94,7 +94,6 @@ $(function(){
 				$("#RowRows").hide();
 				$("#MailFieldRows").val('');
 				$("#RowMaxlength").show();
-				$("#MailFieldMaxlength").val('7');
 				$("#RowSource").show();
 				$("#RowAutoConvert").show();
 				$("#MailFieldAutoConvert").val('CONVERT_HANKAKU');


### PR DESCRIPTION
7文字固定だと、ハイフン入りの郵便番号の入力(XXX-XXXXの8文字)に対応できないので、7文字での固定の設定は不要と思われます。

よろしくお願いします！
