### PR TITLE
BcTextHelperTest::testDateTime()の修正

### DIFF
--- a/lib/Baser/Test/Case/View/Helper/BcTextHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcTextHelperTest.php
@@ -301,7 +301,7 @@ class BcTextHelperTest extends BaserTestCase {
 		$result = $this->Helper->dateTime('baser');
 
 		// PHPのバージョンによって結果が違うので分岐する
-		if (!isset($result)) {
+		if (empty($result)) {
 			$this->assertNull($result);
 		} else {
 			$expect = 'b/b/b';

--- a/lib/Baser/Test/Case/View/Helper/BcTextHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcTextHelperTest.php
@@ -286,8 +286,6 @@ class BcTextHelperTest extends BaserTestCase {
  * form::dateTimeで取得したデータを文字列データに変換するヘルパーのテスト
  */
 	public function testDateTime() {
-
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
 		
 		// 適当な時間を設定
 		$arrDate = array(
@@ -298,8 +296,6 @@ class BcTextHelperTest extends BaserTestCase {
 		$result = $this->Helper->dateTime($arrDate);
 		$expect = '2015/8/11';
 		$this->assertEquals($expect, $result);
-
-		// 異常系
 
 		// 文字列
 		$result = $this->Helper->dateTime('baser');

--- a/lib/Baser/Test/Case/View/Helper/BcTextHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcTextHelperTest.php
@@ -297,11 +297,6 @@ class BcTextHelperTest extends BaserTestCase {
 		$expect = '2015/8/11';
 		$this->assertEquals($expect, $result);
 
-		// 文字列
-		$result = $this->Helper->dateTime('baser');
-		$expect = '';
-		$this->assertEquals($expect, $result);
-
 		// 不正な日付（現在はそのまま出力してしまう仕様となっている）
 		$arrDate = array(
 			'year' 	=> 2015,

--- a/lib/Baser/Test/Case/View/Helper/BcTextHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcTextHelperTest.php
@@ -297,6 +297,18 @@ class BcTextHelperTest extends BaserTestCase {
 		$expect = '2015/8/11';
 		$this->assertEquals($expect, $result);
 
+		// 異常系 文字列を入力
+		$result = $this->Helper->dateTime('baser');
+
+		// PHPのバージョンによって結果が違うので分岐する
+		if (!isset($result)) {
+			$this->assertNull($result);
+		} else {
+			$expect = 'b/b/b';
+			$this->assertEquals($expect, $result);
+		}
+
+
 		// 不正な日付（現在はそのまま出力してしまう仕様となっている）
 		$arrDate = array(
 			'year' 	=> 2015,


### PR DESCRIPTION
異常系のテストをバージョン差異でエラーがでるため削除