### PR TITLE
BcUploadBehaviorTest::testSaveTmpFilesの修正

### DIFF
--- a/lib/Baser/Test/Case/Model/Behavior/BcUploadBehaviorTest.php
+++ b/lib/Baser/Test/Case/Model/Behavior/BcUploadBehaviorTest.php
@@ -153,7 +153,6 @@ class BcUploadBehaviorTest extends BaserTestCase {
  */
 	public function testSaveTmpFiles() {
 
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
 		$this->initTestSaveFiles();
 
 		$data = $this->EditorTemplate->saveTmpFiles('hoge', 1);

--- a/lib/Baser/Test/Case/Model/Behavior/BcUploadBehaviorTest.php
+++ b/lib/Baser/Test/Case/Model/Behavior/BcUploadBehaviorTest.php
@@ -155,10 +155,10 @@ class BcUploadBehaviorTest extends BaserTestCase {
 
 		$this->initTestSaveFiles();
 
-		$data = $this->EditorTemplate->saveTmpFiles('hoge', 1);
+		$data = $this->EditorTemplate->saveTmpFiles(array('hoge'), 1);
 		$tmpId = $this->BcUploadBehavior->tmpId;
 
-		$this->assertEquals('hoge', $data, 'saveTmpFiles()の返り値が正しくありません');
+		$this->assertEquals(array('hoge'), $data, 'saveTmpFiles()の返り値が正しくありません');
 		$this->assertEquals(1, $tmpId, 'tmpIdが正しく設定されていません');
 
 		$this->deleteDummyOnTestSaveFiles();


### PR DESCRIPTION
エラーメッセージ　Fatal error: Cannot use string offset as an array に対応