### PR TITLE
UserGroupTest::testIsAdminGlobalmenuUsedの修正

### DIFF
--- a/lib/Baser/Test/Case/Model/UserGroupTest.php
+++ b/lib/Baser/Test/Case/Model/UserGroupTest.php
@@ -257,7 +257,6 @@ class UserGroupTest extends BaserTestCase {
  * @dataProvider isAdminGlobalmenuUsedDataProvider
  */
 	public function testIsAdminGlobalmenuUsed($id, $expected, $message = null) {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
 		$result = $this->UserGroup->isAdminGlobalmenuUsed($id);
 		$this->assertEquals($expected, $result, $message);
 	}

--- a/lib/Baser/Test/Case/Model/UserGroupTest.php
+++ b/lib/Baser/Test/Case/Model/UserGroupTest.php
@@ -264,7 +264,7 @@ class UserGroupTest extends BaserTestCase {
 	public function isAdminGlobalmenuUsedDataProvider() {
 		return array(
 			array(1, true, 'システム管理者がグローバルメニューを利用できません'),
-			array(2, false, 'システム管理者以外のユーザーがグローバルメニューを利用できます'),
+			array(2, 0, 'システム管理者以外のユーザーがグローバルメニューを利用できます'),
 			array(99, false, '存在しないユーザーグループです'),
 		);
 	}


### PR DESCRIPTION
Travisで失敗したエラーを修正
ローカルでは、falseでも0でも成功しました