### PR TITLE
BcManagerComponentのバグ修正

### DIFF
--- a/lib/Baser/Controller/Component/BcManagerComponent.php
+++ b/lib/Baser/Controller/Component/BcManagerComponent.php
@@ -1187,6 +1187,8 @@ class BcManagerComponent extends Component {
  * @access public
  */
 	public function deployTheme($theme = null) {
+		$Folder = new Folder(BASER_CONFIGS . 'theme');
+		
 		if ($theme) {
 			if (is_array($theme)) {
 				$sources = $theme;
@@ -1194,7 +1196,6 @@ class BcManagerComponent extends Component {
 				$sources = array($theme);
 			}
 		} else {
-			$Folder = new Folder(BASER_CONFIGS . 'theme');
 			$files = $Folder->read();
 			$sources = $files[0];
 		}

--- a/lib/Baser/Test/Case/Model/PageTest.php
+++ b/lib/Baser/Test/Case/Model/PageTest.php
@@ -388,8 +388,8 @@ class PageTest extends BaserTestCase {
 
 	public function createContentDataProvider() {
 		return array(
-			array(1, 'index', null, 'index', '/index', '', null, null, true, '検索用データを正しく生成できません'),
-			array(1, 'index', null, 'タイトル', '/index', '', null, null, true, '検索用データを正しく生成できません'),
+			array(1, 'index', null, 'index', '/index', "\n", null, null, true, '検索用データを正しく生成できません'),
+			array(1, 'index', null, 'タイトル', '/index', "\n", null, null, true, '検索用データを正しく生成できません'),
 		);
 	}
 

--- a/lib/Baser/Test/Case/Model/PageTest.php
+++ b/lib/Baser/Test/Case/Model/PageTest.php
@@ -349,7 +349,8 @@ class PageTest extends BaserTestCase {
 				'type' => 'ページ',
 				'category' => '',
 				'title' => $title,
-				'detail' => "\n",
+				'detail' => '
+',
 // 				'detail' => ' 
 
 // <section class="mainHeadline">

--- a/lib/Baser/Test/Case/Model/PageTest.php
+++ b/lib/Baser/Test/Case/Model/PageTest.php
@@ -349,7 +349,7 @@ class PageTest extends BaserTestCase {
 				'type' => 'ページ',
 				'category' => '',
 				'title' => $title,
-				'detail' => ' ',
+				'detail' => "\n",
 // 				'detail' => ' 
 
 // <section class="mainHeadline">
@@ -388,8 +388,8 @@ class PageTest extends BaserTestCase {
 
 	public function createContentDataProvider() {
 		return array(
-			array(1, 'index', null, 'index', '/index', "\n", null, null, true, '検索用データを正しく生成できません'),
-			array(1, 'index', null, 'タイトル', '/index', "\n", null, null, true, '検索用データを正しく生成できません'),
+			array(1, 'index', null, 'index', '/index', '', null, null, true, '検索用データを正しく生成できません'),
+			array(1, 'index', null, 'タイトル', '/index', '', null, null, true, '検索用データを正しく生成できません'),
 		);
 	}
 

--- a/lib/Baser/Test/Case/Model/PageTest.php
+++ b/lib/Baser/Test/Case/Model/PageTest.php
@@ -349,7 +349,7 @@ class PageTest extends BaserTestCase {
 				'type' => 'ページ',
 				'category' => '',
 				'title' => $title,
-				'detail' => '
+				'detail' => ' 
 ',
 // 				'detail' => ' 
 


### PR DESCRIPTION
deployTheme()で引数$themeを指定した場合に、
$Folderが初期化されていないため、
1208行目の$Folder->delete($targetPath) でエラーが出るバグ