### PR TITLE
完了画面に直接アクセスした場合に404ではなく入力画面にリダイレクトするよう変更

### DIFF
--- a/lib/Baser/Plugin/Mail/Controller/MailController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailController.php
@@ -350,7 +350,7 @@ class MailController extends MailAppController {
 			$this->notFound();
 		}
 		if (!$this->Session->read('Mail.valid')) {
-			$this->notFound();
+			$this->redirect(array('action' => 'index', $id));
 		}
 
 		if (!$this->request->data) {


### PR DESCRIPTION
メールプラグインの調整後、挙動が変わっていたのでリダイレクトするよう変更しています。
調整後の挙動が正しいようであればリジェクトお願いします。