### PR TITLE
fixes Errorページで、ビュー側からページタイトルを設定できない点を調整

### DIFF
--- a/lib/Baser/View/Helper/BcBaserHelper.php
+++ b/lib/Baser/View/Helper/BcBaserHelper.php
@@ -320,7 +320,7 @@ class BcBaserHelper extends AppHelper {
  * @return string コンテンツタイトル
  */
 	public function getContentsTitle() {
-		if ($this->_View->name === 'CakeError' || empty($this->_View->pageTitle)) {
+		if (empty($this->_View->pageTitle)) {
 			return '';
 		}
 


### PR DESCRIPTION
例: /theme/THEME_NAME/Errors/ 内に配置したビューファイル側から、以下のようにタイトルを設定できない点の調整になります。

```
$this->BcBaser->setTitle('Error');
$this->pageTitle = 'Error';
```
