### PR TITLE
fixes ブログ記事のアイキャッチ画像に大きい画像を登録した際に、管理側のコンテンツ表示領域をはみ出してしまう点を調整

### DIFF
--- a/lib/Baser/webroot/css/admin/contents.css
+++ b/lib/Baser/webroot/css/admin/contents.css
@@ -442,6 +442,7 @@ table.sub-menu{
 }
 .contents-body .form-table td img {
 	vertical-align: baseline;
+	max-width: 100%;
 }
 .contents-body .form-table .checkbox {
 	float:left;


### PR DESCRIPTION
管理システム側の表示が崩れて見えるので調整してみました。
