### PR TITLE
メール送信時のbccメールアドレス検証と、送信されるメールアドレスが異なる点の修正

### DIFF
--- a/lib/Baser/Controller/BcAppController.php
+++ b/lib/Baser/Controller/BcAppController.php
@@ -852,7 +852,7 @@ class BcAppController extends Controller {
 			}
 			foreach ($bcc as $val) {
 				if (Validation::email(trim($val))) {
-					$cakeEmail->addBcc($val);
+					$cakeEmail->addBcc(trim($val));
 				}
 			}
 			unset($bcc);


### PR DESCRIPTION
検証される文字列と、実際に利用される文字列が異なっているので修正しています。
よろしくお願いします。