### PR TITLE
マルチチェックボックスの最初の項目のみ半角スペースが空くため、チェックされた全ての項目に半角スペースを追加。

### DIFF
--- a/lib/Baser/Plugin/Mail/View/Helper/MaildataHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MaildataHelper.php
@@ -96,7 +96,10 @@ class MaildataHelper extends BcTextHelper {
 				}
 
 				$out = '';
-				foreach ($value as $data) {
+				foreach ($value as $key => $data) {
+					if ($key != 0) {
+						$out .= " ";
+					}
 					if (isset($options[$data])) {
 						$out .= "・" . $options[$data] . PHP_EOL;
 					}


### PR DESCRIPTION
メールプラグインでマルチチェックボックスを使用し、
複数チェックボックス項目を選択し送信されたメールにおいて、
最初の項目のみ半角スペースが空いてしまいます。

原因としては、HelperのMaildataHelperのcontrolメソッドで、
先頭に半角スペースを付加しリターンしているためです。

ですが、このcontrollメソッドの半角スペースを削除してはいけないみたいなので、
チェックされた項目全てに半角スペースが付加されるように修正しました。