### PR TITLE
固定ページの検索インデックス作成時の処理をプラグインから実行する時にプラグイン名が有効になってしまうのでパラメータを追加

### DIFF
--- a/lib/Baser/Model/Page.php
+++ b/lib/Baser/Model/Page.php
@@ -425,7 +425,7 @@ class Page extends AppModel {
 		$_data['Content']['title'] = $data['title'];
 		$parameters = explode('/', preg_replace("/^\//", '', $data['url']));
 
-		$detail = $this->requestAction(array('admin' => false, 'controller' => 'pages', 'action' => 'display'), array('pass' => $parameters, 'return'));
+		$detail = $this->requestAction(array('admin' => false, 'plugin' => false, 'controller' => 'pages', 'action' => 'display'), array('pass' => $parameters, 'return'));
 
 		$detail = preg_replace('/<!-- BaserPageTagBegin -->.*?<!-- BaserPageTagEnd -->/is', '', $detail);
 		$_data['Content']['detail'] = $data['description'] . ' ' . $detail;


### PR DESCRIPTION
通常処理では問題はないのですが、別のプラグインから処理実行時に動作しないので追加して欲しいです。
