### PR TITLE
ブログ記事一覧のcategoryとtag絞込の場合に絞り込んだ対象名を取得する機能を追加

### DIFF
--- a/lib/Baser/Plugin/Blog/Controller/BlogController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogController.php
@@ -262,6 +262,7 @@ class BlogController extends BlogAppController {
 				$this->pageTitle = $blogCategories[count($blogCategories) - 1]['BlogCategory']['title'];
 				$template = $this->blogContent['BlogContent']['template'] . DS . 'archives';
 
+				$this->set('blogCategoryName', $blogCategories[count($blogCategories) - 1]['BlogCategory']['name']);
 				$this->set('blogArchiveType', $type);
 
 				break;
@@ -289,6 +290,7 @@ class BlogController extends BlogAppController {
 				$this->pageTitle = urldecode($tag);
 				$template = $this->blogContent['BlogContent']['template'] . DS . 'archives';
 
+				$this->set('blogTagName', $tag);
 				$this->set('blogArchiveType', $type);
 
 				break;

--- a/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
+++ b/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
@@ -980,4 +980,29 @@ class BlogHelper extends AppHelper {
 		$MailHelper->link($title, $contentsName, $datas, $options);
 	}
 
+/**
+ * 表示ページがカテゴリ別記事一覧だった場合、カテゴリ名を取得する
+ *
+ * @return string 表示ページのカテゴリ名
+ */
+	public function getCategoryName() {
+		if (!empty($this->_View->viewVars['blogCategoryName'])) {
+			return $this->_View->viewVars['blogCategoryName'];
+		} else {
+			return '';
+		}
+	}
+
+/**
+ * 表示ページがタグ別記事一覧だった場合、タグ名を取得する
+ *
+ * @return string 表示ページのタグ名
+ */
+	public function getTagName() {
+		if (!empty($this->_View->viewVars['blogTagName'])) {
+			return $this->_View->viewVars['blogTagName'];
+		} else {
+			return '';
+		}
+	}
 }


### PR DESCRIPTION
機能拡張になります。
archivesのカテゴリと、タグの際になんのカテゴリか、なんのタグか取得出来る機能の追加です。
blogPostに対してのgetCategoryメソッドと混同しそうな問題点はあるかと思います。

blogPostに対するヘルパと、blogContentに対するヘルパを明示的に分けたほうがいいんでしょうかね。