### PR TITLE
BcAuthConfigureにてCake1系のスコープ形式しか受け付けていない箇所をCake2系の形式でも受け入れるよう修正

### DIFF
--- a/lib/Baser/Controller/Component/BcAuthConfigureComponent.php
+++ b/lib/Baser/Controller/Component/BcAuthConfigureComponent.php
@@ -63,7 +63,8 @@ class BcAuthConfigureComponent extends Component {
 			'username'			=> 'name',
 			'password'			=> 'password',
 			'serial'			=> '',
-			'loginAction'		=> ''
+			'loginAction'		=> '',
+			'scope'				=> array()
 			), $config);
 		extract($config);
 
@@ -113,16 +114,18 @@ class BcAuthConfigureComponent extends Component {
 					'username' => $username,
 					'password' => $password
 				),
-				'serial' => $serial
+				'serial' => $serial,
+				'scope'  => $scope
 			)
 		);
 
 		// 認証プレフィックスによるスコープ設定
 		$UserModel = ClassRegistry::init($userModel);
 		if (isset($UserModel->belongsTo['UserGroup']) && !empty($config['auth_prefix']) && !isset($userScope)) {
-			$BcAuth->authenticate['Form']['scope'] = array('UserGroup.auth_prefix LIKE' => '%' . $config['auth_prefix'] . '%');
+			$BcAuth->authenticate['Form']['scope'] += array('UserGroup.auth_prefix LIKE' => '%' . $config['auth_prefix'] . '%');
 		} elseif (isset($userScope)) {
-			$BcAuth->authenticate['Form']['scope'] = $userScope;
+			if (is_string($userScope)) $userScope = array($userScope);
+			$BcAuth->authenticate['Form']['scope'] += $userScope;
 		}
 
 		if(empty($sessionKey)) {

--- a/lib/Baser/Test/Case/Controller/Component/BcAuthConfigureComponentTest.php
+++ b/lib/Baser/Test/Case/Controller/Component/BcAuthConfigureComponentTest.php
@@ -106,6 +106,7 @@ class BcAuthConfigureComponentTest extends BaserTestCase {
 			'serial'			=> 'serial',
 			'loginAction'		=> $loginAction,
 			'userScope'		=> $userScope,
+			'scope'			=> array(),
 			'auth_prefix' => $auth_prefix
 		);
 
@@ -135,6 +136,7 @@ class BcAuthConfigureComponentTest extends BaserTestCase {
 					'userModel' => 'User',
 					'fields' => array('username' => 'basercms', 'password' => 'basercms'),
 					'serial' => 'serial',
+					'scope' => array()
 				),
 			),
 			'sessionKey' => null,
@@ -154,9 +156,10 @@ class BcAuthConfigureComponentTest extends BaserTestCase {
 
 		// userScope
 		if (!empty($userScope)) {
-			$expected['authenticate']['Form']['scope'] = $userScope;
+			if (is_string($userScope)) $userScope = array($userScope);
+			$expected['authenticate']['Form']['scope'] += $userScope;
 		} else if (!empty($auth_prefix)) {
-			$expected['authenticate']['Form']['scope'] = array('UserGroup.auth_prefix LIKE' => '%' . $auth_prefix .'%');
+			$expected['authenticate']['Form']['scope'] += array('UserGroup.auth_prefix LIKE' => '%' . $auth_prefix .'%');
 		}
 
 		// Session Auth.redirect
@@ -173,12 +176,12 @@ class BcAuthConfigureComponentTest extends BaserTestCase {
 
 	public function settingCheckValueDataProvider() {
 		return array(
-			array('login', 'pre', 'userScope', 'auth_prefix'),
-			array(null, 'pre', 'userScope', 'auth_prefix'),
-			array(null, null, 'userScope', 'auth_prefix'),
-			array('login', 'pre', null, 'auth_prefix'),
-			array('login', 'pre', null, null),
-			array('login', '/admin', 'userScope', 'auth_prefix'),
+			array('login', 'pre', array('userScope'), 'auth_prefix'),
+			array(null, 'pre', array('userScope'), 'auth_prefix'),
+			array(null, null, array('userScope'), 'auth_prefix'),
+			array('login', 'pre', array(), 'auth_prefix'),
+			array('login', 'pre', array(), null),
+			array('login', '/admin', array('userScope'), 'auth_prefix'),
 		);
 	}
 


### PR DESCRIPTION
ご検討ください！