### PR TITLE
basicsのテストを追加

### DIFF
--- a/lib/Baser/Event/BcEventListener.php
+++ b/lib/Baser/Event/BcEventListener.php
@@ -65,14 +65,24 @@ class BcEventListener extends Object implements CakeEventListener {
 	public function implementedEvents() {
 		
 		$events = array();
+		$options = array();
 		if ($this->events) {
-			foreach ($this->events as $registerEvent) {
+			foreach ($this->events as $key => $registerEvent) {
+				if(is_array($registerEvent)) {
+					$options = $registerEvent;
+					$registerEvent = $key;
+				}
 				$eventName = $this->layer . '.' . $registerEvent;
 				if (strpos($registerEvent, '.') !== false) {
 					$aryRegisterEvent = explode('.', $registerEvent);
 					$registerEvent = Inflector::variable(implode('_', $aryRegisterEvent));
 				}
-				$events[$eventName] = array('callable' => $registerEvent);
+				if($options) {
+					$options = array_merge(array('callable' => $registerEvent), $options);
+				} else {
+					$options = array('callable' => $registerEvent);
+				}
+				$events[$eventName] = $options;
 			}
 		}
 

--- a/lib/Baser/Test/Case/BcBasicsTest.php
+++ b/lib/Baser/Test/Case/BcBasicsTest.php
@@ -17,6 +17,18 @@
  */
 class BcBasicsTest extends BaserTestCase {
 
+/**
+ * Fixtures
+ * @var array 
+ */
+	public $fixtures = array(
+		'baser.Default.BlogContent',
+		'baser.Default.Page',
+		'baser.Default.Plugin',
+		'baser.Default.PluginContent',
+		'baser.Default.SiteConfig',
+	);
+
 	public function setUp() {
 		parent::setUp();
 	}
@@ -25,100 +37,734 @@ class BcBasicsTest extends BaserTestCase {
 		parent::tearDown();
 	}
 
-	public function testBaseUrl() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+/**
+ * WEBサイトのベースとなるURLを取得する
+ * TODO BC_DEPLOY_PATTERNで分岐した場合のテストの追加
+ * 
+ * @param	string $script App.baseUrlの値
+ * @param	string $script $_SERVER['SCRIPT_FILENAME']の値
+ * @param	string $expect 期待値
+ * @dataProvider baseUrlDataProvider
+ */
+	public function testBaseUrl($baseUrl, $script, $expect) {
+		// 初期化
+		Configure::write('App.baseUrl', $baseUrl);
+		$_SERVER['SCRIPT_FILENAME'] = WWW_ROOT . $script;
+
+		$result = baseUrl();
+		$this->assertEquals($expect, $result, 'WEBサイトのベースとなるURLを正しく取得できません');
+
 	}
 
+	public function baseUrlDataProvider() {
+		return array(
+			array('/hoge/test', 'test.php', '/hoge/test/'),
+			array(null, 'test.php', '/'),
+			array('/hoge/test', null, '/hoge/test/'),
+			array(null, null, '/'),
+		);
+	}
+
+
+/**
+ * ドキュメントルートを取得する
+ */
 	public function testDocRoot() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+		$_SERVER['SCRIPT_FILENAME'] = WWW_ROOT . 'test.php';
+
+		if(isConsole()) {
+			$expected = str_replace('app' . DS . 'Console' . DS . 'cake.php', '', $_SERVER['SCRIPT_NAME']);
+		
+		} else {	
+			$path = explode('/', $_SERVER['SCRIPT_NAME']);
+			krsort($path);
+			$expected = $_SERVER['SCRIPT_FILENAME'];
+			foreach ($path as $value) {
+				$reg = "/\/" . $value . "$/";
+				$expected = preg_replace($reg, '', $expected);
+			}
+		}
+		$result = docRoot();
+		$this->assertEquals($expected, $result);
 	}
 
+/**
+ * リビジョンを取得する
+ */
 	public function testRevision() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+		$version = 'baserCMS 3.0.6.1 beta';
+		$result = revision($version);
+		$this->assertEquals('1', $result, '正しくリビジョンを取得できません');
 	}
 
+/**
+ * バージョンを特定する一意の数値を取得する
+ */
 	public function testVerpoint() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+		$version = 'baserCMS 3.0.6.1';
+		$result = verpoint($version);
+		$this->assertEquals(3000006001, $result, '正しくバージョンを特定する一意の数値を取得できません');
+		
+		$version = 'baserCMS 3.0.6.1 beta';
+		$result = verpoint($version);
+		$this->assertEquals(false, $result, '正しくバージョンを特定する一意の数値を取得できません');
 	}
 
-	public function testDecodeContent() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+/**
+ * 拡張子を取得する
+ * 
+ * @param	string $content mimeタイプ
+ * @param	string $fileName ファイル名
+ * @param	string $expect 期待値
+ * @dataProvider decodeContentDataProvider
+ */
+	public function testDecodeContent($content, $fileName, $expect) {
+		$result = decodeContent($content, $fileName);
+		$this->assertEquals($expect, $result, '正しく拡張子を取得できません');
 	}
 
-	public function testGetUrlParamFromEnv() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	public function decodeContentDataProvider() {
+		return array(
+			array('image/jpeg', null, 'jpg'),
+			array(null, 'hoge.png', 'png'),
+			array(null, 'hoge', false),
+			array(null, null, false),
+		);
 	}
 
-	public function testGetUrlFromEnv() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+/**
+ * 環境変数よりURLパラメータを取得する
+ * 
+ * @param string $agentAlias BcRequest.agentAliasの値
+ * @param string $url URL
+ * @param string $expect 期待値
+ * @param string $message テスト失敗時に表示するメッセージ
+ * @dataProvider getUrlParamFromEnvDataProvider
+ */
+	public function testGetUrlParamFromEnv($agentAlias, $url, $expect, $message = null) {
+		Configure::write('BcRequest.agentAlias', $agentAlias);
+		$_GET['url'] = $url;
+		$result = getUrlParamFromEnv();
+		$this->assertEquals($expect, $result, $message);
 	}
 
-	public function testClearViewCache() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	public function getUrlParamFromEnvDataProvider() {
+		return array(
+			array(null, '/s/test/', 's/test/', 'URLパラメータのモバイルプレフィックスを正しく除外できません'),
+			array('s', '/s/test/', 'test/', 'URLパラメータのモバイルプレフィックスを正しく除外できません'),
+		);
 	}
 
-	public function testClearDataCache() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+/**
+ * 環境変数よりURLを取得する
+ * 
+ * @param string $url $_GET['url']の値
+ * @param string $request $_SERVER['REQUEST_URI']の値
+ * @param string $baseUrl App.BaseUrlの値
+ * @param string $expect 期待値
+ * @param string $message テスト失敗時に表示するメッセージ
+ * @dataProvider getUrlFromEnvDataProvider
+ */
+	public function testGetUrlFromEnv($get, $request, $baseUrl, $expect, $message = null) {
+		// 初期化
+		$_GET['url'] = $get;
+		$_SERVER['REQUEST_URI'] = $request;
+		Configure::write('App.baseUrl', $baseUrl);
+
+		$result = getUrlFromEnv();
+		$this->assertEquals($expect, $result, $message);
 	}
 
+	public function getUrlFromEnvDataProvider() {
+		return array(
+			array('/get/', null, null, 'get/', '$_GET["url"]からURLを正しく取得できません'),
+			array('/get/url/test', null, null, 'get/url/test', '$_GET["url"]からURLを正しく取得できません'),
+			array(null, '/req/', null, 'req/', '$_SERVER["REQUEST_URI"]からURLを正しく取得できません'),
+			array(null, '/req/test.php?a=aaa&b=bbb', null, 'req/test.php', '$_SERVER["REQUEST_URI"]からURLを正しく取得できません'),
+			array(null, baseUrl() . '/req/', null, 'req/', '$_SERVER["REQUEST_URI"]からURLを正しく取得できません'),
+			array(null, '/base/req/', '/base/', 'req/', '$_SERVER["REQUEST_URI"]からURLを正しく取得できません'),
+			array(null, '/base/req/', '/base/url/', 'req/', '$_SERVER["REQUEST_URI"]からURLを正しく取得できません'),
+		);
+	}
+
+/**
+ * モバイルプレフィックスは除外したURLを取得する
+ * 
+ * @param	string $url URL
+ * @param	string $expect 期待値
+ * @dataProvider getPureUrlDataProvider
+ */
+	public function testGetPureUrl($url, $expect) {
+		$request = new CakeRequest($url);
+		Configure::write('BcRequest.agentAlias', 'm');
+		$result = getPureUrl($request);
+		
+		$this->assertEquals($expect, $result, 'モバイルプレフィックスは除外したURLを正しく取得できません');
+	}
+
+	public function getPureUrlDataProvider() {
+		return array(
+			array('hoge', 'hoge'),
+			array('m/', ''),
+			array('/m/', ''),
+			array('/m/hoge', 'hoge'),
+		);
+	}
+
+/**
+ * Viewキャッシュを削除する
+ * TODO basics.php 295行目 $homesにバグ？あり
+ * 			app/tmp/cache/views/のキャッシュファイルを複数回削除している
+ * 
+ * @param string $url
+ * @param string $ext
+ * @dataProvider clearViewCacheDataProvider
+ */
+	public function testClearViewCache($url, $ext) {
+		$viewCachePath = CACHE . 'views' . DS;
+		if ($url == '/' || $url == '/index' || $url == '/index.html' || $url == '/m/' || $url == '/m/index' || $url == '/m/index.html') {
+			$cache = new File($viewCachePath . DS . strtolower(Inflector::slug($url)) . $ext, true);
+			// 削除実行
+			clearViewCache($url, $ext);
+
+		} elseif ($url) {
+			// ダミーのキャッシュファイルを生成
+			$cache = new File($viewCachePath . DS . strtolower(Inflector::slug($url)) . $ext, true);
+			$cacheHoge = new File($viewCachePath . DS . strtolower(Inflector::slug($url)) . '.hoge', true);
+			if (preg_match('/\/index$/', $url)) {
+				$replacedUrl = preg_replace('/\/index$/', '', $url);
+				$replacedCache = new File($viewCachePath . DS . strtolower(Inflector::slug($replacedUrl)) . $ext, true);
+			}
+			// 削除実行
+			clearViewCache($url, $ext);
+
+			$this->assertTrue($cacheHoge->exists(), '指定されていない拡張子のファイルが削除されてしまいます');
+			$cacheHoge->delete();
+			$cacheHoge->close();
+
+			if (preg_match('/\/index$/', $url)) {
+				$this->assertFalse($replacedCache->exists(), '置換された名前のキャッシュファイルを削除できません');
+				$replacedCache->delete();
+				$replacedCache->close();
+			}
+		
+		} else {
+			// ダミーのキャッシュファイルを生成
+			$cache = new File($viewCachePath . DS . 'cache', true);
+			$empty = new File($viewCachePath . DS . 'empty', true);
+
+			// 削除実行
+			clearViewCache($url, $ext);
+
+			$this->assertTrue($empty->exists(), 'emptyファイルが削除されてしまいます');
+			$empty->delete();
+			$empty->close();
+		}
+
+		$this->assertFalse($cache->exists(), 'キャッシュを削除できません');
+		$cache->delete();
+		$cache->close();
+
+	}
+
+	public function clearViewCacheDataProvider() {
+		return array(
+			array(null, null),
+			array('/test/', '.ext'),
+			array('/test/index', '.ext'),
+			array('/index.html', '.php'),
+			array('/m/index.html', '.php'),
+		);
+	}
+
+/**
+ * キャッシュファイルを全て削除する
+ */
 	public function testClearAllCache() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+		// ダミーのキャッシュファイルを生成
+		$coreConf = Cache::config('_cake_core_')['settings'];
+		$modelConf = Cache::config('_cake_model_')['settings'];
+		$envConf = Cache::config('_cake_env_')['settings'];
+
+		$coreCache = new File($coreConf['path'] . $coreConf['prefix'] . 'cache', true);
+		$modelCache = new File($modelConf['path'] . $modelConf['prefix'] . 'cache', true);
+		$envCache = new File($envConf['path'] . $envConf['prefix'] . 'cache', true);
+		$viewCache = new File(CACHE . 'views' . DS . 'cache', true);
+		$dataCache = new File(CACHE . 'datas' . DS . 'cache', true);
+
+		// キャッシュ削除
+		clearAllCache();
+
+		$this->assertFalse($coreCache->exists());
+		$this->assertFalse($modelCache->exists());
+		$this->assertFalse($envCache->exists());
+		$this->assertFalse($viewCache->exists());
+		$this->assertFalse($dataCache->exists());
+
+		$coreCache->close();
+		$modelCache->close();
+		$envCache->close();
+		$viewCache->close();
+		$dataCache->close();
 	}
 
+/**
+ * baserCMSのインストールが完了しているかチェックする
+ */
 	public function testIsInstalled() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+		$installedPath = APP . 'Config' . DS . 'install.php';
+
+		// app/Config/installed.phpが存在しない場合
+		if (rename($installedPath, $installedPath . '_copy')) {
+			$result = isInstalled();
+			$this->assertFalse($result, 'app/Config/installed.phpが存在していない場合にtrueが返ってきます');
+		} else {
+			$this->markTestIncomplete('app/Config/installed.phpのファイル名変更に失敗したのでテストをスキップしました。');
+		}
+
+		// app/Config/installed.phpが存在する場合
+		if (rename($installedPath . '_copy', $installedPath)) {
+			$result = isInstalled();
+			$this->assertTrue($result, 'app/Config/installed.phpが存在している場合にfalseが返ってきます');
+		} else {
+			$this->markTestIncomplete('app/Config/installed.phpのファイル名変更に失敗したのでテストをスキップしました。');
+		}
+
 	}
 
+/**
+ * DBセッティングが存在するかチェックする
+ */
 	public function testGetDbConfig() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+		$dbconfigPath = APP . 'Config' . DS . 'database.php';
+
+		// app/Config/database.phpが存在しない場合
+		if (rename($dbconfigPath, $dbconfigPath . '_copy')) {
+			$result = getDbConfig();
+			$this->assertFalse($result, 'app/Config/database.php が存在していない場合にtrueが返ってきます');
+		} else {
+			$this->markTestIncomplete('app/Config/database.php のファイル名変更に失敗したのでテストをスキップしました。');
+		}
+
+		// app/Config/database.phpが存在する場合
+		if (rename($dbconfigPath . '_copy', $dbconfigPath)) {
+			$result = getDbConfig();
+			$this->assertContains('basercms', $result, 'app/Config/database.php が存在している場合にデータベースの情報が返ってきません');
+
+			$result = getDbConfig('hoge');
+			$this->assertFalse($result, '存在しないデータベースの設定名を入力した場合にfalseが返ってきます');
+
+		} else {
+			$this->markTestIncomplete('app/Config/database.php のファイル名変更に失敗したのでテストをスキップしました。');
+		}
+		
 	}
 
+/**
+ * 必要な一時フォルダが存在するかチェックし、なければ生成する
+ */
 	public function testCheckTmpFolders() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+		checkTmpFolders();
+
+		$paths = array(
+			TMP . 'logs',
+			TMP . 'sessions',
+			TMP . 'schemas',
+			TMP . 'schemas' . DS . 'baser',
+			TMP . 'schemas' . DS . 'plugin',
+			CACHE,
+			CACHE . 'models',
+			CACHE . 'persistent',
+			CACHE . 'views',
+			CACHE . 'datas',
+			CACHE . 'environment',
+		);
+
+		// フォルダが生成されているかチェック
+		$result = true;
+		foreach ($paths as $key => $value) {
+			if(!is_dir($value)) {
+				$result = false;
+			}
+		}
+		$this->assertTrue($result, '一時フォルダが正しく生成されていません');
+		
 	}
 
+/**
+ * フォルダの中をフォルダを残して空にする
+ */
 	public function testEmptyFolder() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+
+		$dummyPath = WWW_ROOT . 'test' . DS;
+		$names = array(
+			'folder' => array('folder1', 'folder2'),
+			'file' => array('file1', 'file2'),
+		);
+
+		// ダミーのフォルダとファイルを作成
+		$Folder = new Folder();
+		$Folder->create($dummyPath, 0755);
+		$Folder->create($dummyPath . $names['folder'][0], 0755);
+		$Folder->create($dummyPath . $names['folder'][1], 0755);
+
+		$File1 = new File($dummyPath . $names['file'][0], true);
+		$File2 = new File($dummyPath . $names['file'][1], true);
+
+		emptyFolder($dummyPath);
+
+		$result = true;
+		// フォルダが存在しているかチェック
+		foreach ($names['folder'] as $key => $name) {
+			if (!is_dir($dummyPath . $name)) {
+				$result = false;
+			}
+			@rmdir($dummyPath . $name);
+		}
+		// ファイルが削除されているかチェック
+		foreach ($names['file'] as $key => $name) {
+			if (file_exists($dummyPath . $name)) {
+				$result = false;
+			}
+			@unlink($dummyPath . $name);
+		}
+		$Folder->delete($dummyPath);
+
+		$this->assertTrue($result, 'フォルダの中のファイルのみを削除することができません');
 	}
 
+
+/**
+ * 現在のビューディレクトリのパスを取得する
+ */
 	public function testGetViewPath() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+		// テーマが設定されている場合
+		Configure::write('BcSite.theme', 'hoge');
+		$result = getViewPath();
+		$expect = WWW_ROOT . 'theme' . DS . 'hoge' . DS;
+		$this->assertEquals($expect, $result, '取得した現在のビューディレクトリのパスが正しくありません');
+
+		// テーマが未設定の場合
+		Configure::write('BcSite.theme', null);
+		$result = getViewPath();
+		$expect = APP . 'View' . DS;
+		$this->assertEquals($expect, $result, '取得した現在のビューディレクトリのパスが正しくありません');
 	}
 
-	public function testFgetcsvReg() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+/**
+ * ファイルポインタから行を取得し、CSVフィールドを処理する
+ * 
+ * @param string $content CSVの内容
+ * @param	int $length length
+ * @param	string $d delimiter
+ * @param string $e enclosure
+ * @param string $expext 期待値
+ * @param string $message テスト失敗時に表示するメッセージ
+ * @dataProvider fgetcsvRegDataProvider
+ */
+	public function testFgetcsvReg($content, $length, $d, $e, $expect, $message) {
+		$csv = new File(CACHE . 'test.csv');
+		$csv->write($content);
+		$csv->close();
+		$csv->open();
+
+		$result = fgetcsvReg($csv->handle, $length, $d, $e);
+		$this->assertEquals($expect, $result, $message);
+
+		$csv->close();
 	}
 
+	public function fgetcsvRegDataProvider() {
+		return array(
+			array('test1,test2,test3', null, ',', '"', array('test1', 'test2', 'test3'), 'ファイルポインタから行を取得し、CSVフィールドを正しく処理できません'),
+			array('test1,test2,test3', 5, ',', '"', array('test'), '読み込む文字列の長さを指定できません'),
+			array('test1?test2?test3', null, '?', '"', array('test1', 'test2', 'test3\\'), 'デリミタを指定できません'),
+			array('test1,<<test2,test3<<', null, ',', '<<', array('test1', 'test2,test3'), 'enclosureを指定できません'),
+		);
+	}
+/**
+ * httpからのフルURLを取得する
+ */
 	public function testFullUrl() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+		$this->assertRegExp('/\//', fullUrl('/'));
+		$this->assertRegExp('/\/.*blog/', fullUrl('/blog'));
+		$this->assertRegExp('/\//', fullUrl(null));
 	}
 
+/**
+ * サイトのトップレベルのURLを取得する
+ */
+	public function testTopLevelUrl() {
+		if (isConsole()) {
+			$this->assertFalse(topLevelUrl());
+		} else {
+			$this->assertRegExp('/^http:\/\/.*\/$/', topLevelUrl());
+			$this->assertRegExp('/^http:\/\/.*[^\/]$/', topLevelUrl(false));
+
+			// httpsの場合
+			$_SERVER['HTTPS'] = 'on';
+			$this->assertRegExp('/^https:\/\//', topLevelUrl());
+		}
+	}
+/**
+ * サイトの設置URLを取得する
+ */
 	public function testSiteUrl() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+		if (isConsole()) {
+			$this->assertEmpty(siteUrl());
+		} else {
+			$topLevelUrl = topLevelUrl(false);
+
+			Configure::write('App.baseUrl', '/test/');
+			$this->assertEquals($topLevelUrl . '/test/', siteUrl());
+
+			Configure::write('App.baseUrl', '/test/index.php');
+			$this->assertEquals($topLevelUrl . '/test/', siteUrl());
+
+			Configure::write('App.baseUrl', '/test/hoge/');
+			$this->assertEquals($topLevelUrl . '/test/hoge/', siteUrl());
+		}
 	}
 
+/**
+ * 配列を再帰的に上書きする
+ */
 	public function testAmr() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+		$a = array('a1','a2', 'a3');
+		$b = array('b1','b2');
+
+		// 1次元配列
+		$this->assertEquals(array('b1','b2', 'a3'), amr($a, $b));
+
+		// 2次元配列	
+		$b = array(array('b1'));
+		$this->assertEquals(array(array('b1'), 'a2', 'a3'), amr($a, $b));
+
+		// 3次元配列
+		$a = array(array('a1'),'a2', 'a3');
+		$b = array(array(array('b1')));
+		$this->assertEquals(array(array(array('b1')), 'a2', 'a3'), amr($a, $b));
 	}
 
+/**
+ * プラグインのコンフィグファイルを読み込む
+ */
+	public function testLoadPluginConfig() {
+		// Blogプラグインの設定を削除
+		Configure::write('BcApp.adminNavi.blog', null);
+
+		// 存在しないファイル名
+		$this->assertFalse(loadPluginConfig('Blog.hoge'), '存在しないファイル名に対してtrueが返ってきます');
+
+		// 正常に読み込む
+		$this->assertTrue(loadPluginConfig('Blog.setting'));
+		$this->assertContains('ブログプラグイン', Configure::read('BcApp.adminNavi.blog'), 'プラグインのコンフィグファイルを読み込めません');
+	}
+
+/**
+ * URLにセッションIDを付加する
+ */
 	public function testAddSessionId() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+		// 初期化
+		session_id('baser');
+		session_name('BASERCMS');
+		Configure::write('BcRequest.agent', 'mobile');
+		$message = 'URLにセッションIDを正しく付加できません';
+
+		$this->assertEquals('/?BASERCMS=baser', addSessionId('/', true), $message);
+		$this->assertEquals('/?id=1&BASERCMS=baser', addSessionId('/?id=1', true), $message);
+		$this->assertEquals('/?id=1&BASERCMS=baser', addSessionId('/?id=1&BASERCMS=1', true), $message);
+		$this->assertEquals('/?id=1&BASERCMS=baser', addSessionId('/?id=1&BASERCMS=1', true), $message);
+		
+		// urlが配列の場合
+		$url = array(
+			0 => '/',
+			'?' => array('id' => 1, 'BASERCMS' => 1)
+		);
+		$expect = array(
+			0 => '/',
+			'?' => array('id' => 1, 'BASERCMS' => 'baser')
+		);
+
+		$this->assertEquals($expect, addSessionId($url, true), $message);
+
 	}
 
+/**
+ * 利用可能なプラグインのリストを取得する
+ */
 	public function testGetEnablePlugins() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+		$result = getEnablePlugins();
+		$pluginNames = array(
+			$result[0]['Plugin']['name'],
+			$result[1]['Plugin']['name'],
+			$result[2]['Plugin']['name']
+		);
+		$expect = array('Blog', 'Feed', 'Mail');
+		$this->assertEquals($expect, $pluginNames, '利用可能なプラグインのリストを正しく取得できません');
 	}
 
+/**
+ * サイト基本設定をConfigureへ読み込む
+ */
 	public function testLoadSiteConfig() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+		Configure::write('BcSite', null);
+		loadSiteConfig();
+		$this->assertArrayHasKey('name', Configure::read('BcSite'));
 	}
 
+/**
+ * バージョンを取得する
+ */
 	public function testGetVersion() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+		// BaserCMSコアのバージョン取得
+		$result = getVersion();
+		$version = file(BASER . 'VERSION.txt');
+		$Bcversion = substr($version[0], 0, -1);
+		$this->assertEquals($Bcversion, $result, 'BaserCMSコアのバージョンを正しく取得できません');
+
+		$result = getVersion('Blog');
+		$this->assertEquals($Bcversion, $result, 'BaserCMSコアのバージョンを正しく取得できません');
+
+		// プラグインのバージョンを取得
+		// ダミーのプラグインを作成
+		$path = BASER_PLUGINS . 'Hoge' . DS;
+		$Folder = new Folder($path, true);
+		$File = new File($path . 'VERSION.txt', true);
+		$File->write('1.2.3');
+		$result = getVersion('Hoge');
+
+		$File->close();
+		$Folder->delete();
+		$this->assertEquals('1.2.3', $result, 'プラグインのバージョンを取得できません');
 	}
 
-	public function testSendUpdateMail() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+/**
+ * 展開出力
+ */
+	public function testP() {
+		ob_start();
+		p(array('test'));
+		$result = ob_get_clean();
+		$expect = 'array.*int.*0.*=&gt; &#039;test&#039;';
+		$this->assertRegExp('/' . $expect . '/s', $result);
 	}
+
+/**
+ * Constructs associative array from pairs of arguments.
+ */
+	public function testAa() {
+		$result = aa('a', 'b', 'c');
+		$expect = array('a' => 'b', 'c' => null);
+		$this->assertEquals($expect, $result);
+	}
+
+/**
+ * 日本語ファイル名対応版basename
+ */
+	public function testMb_basename(){
+		$result = mb_basename('/hoge/あいうえお.php');
+		$this->assertEquals('あいうえお.php', $result);
+
+		$result = mb_basename('/hoge/あいうえお.phptest', 'test');
+		$this->assertEquals('あいうえお.php', $result, 'suffixを取り除けません');
+
+		$result = mb_basename('/hoge/あいうえおtest.php', 'test');
+		$this->assertEquals('あいうえおtest.php', $result);
+	}
+
+/**
+ * プラグインを読み込む
+ * Blogプラグインでテストする前提
+ * TODO 一部未完成 引数$priorityが機能していないバグ？があります
+ * 
+ * 
+ * @param	string	$plugin プラグイン名
+ * @dataProvider loadPluginDataProvider
+ */
+	public function testLoadPlugin($plugin, $priority, $expect) {
+		// Eventテスト準備
+		if ($expect) {
+			$EventFolderPath = CakePlugin::path($plugin) . 'Event' . DS;
+			$EventFilePath = $EventFolderPath . $plugin . 'Controller' . 'EventListener' . '.php';
+
+			$Folder = new Folder();
+			$Folder->create($EventFolderPath);
+
+			$EventFile = new File($EventFilePath, true);
+			$EventFile->write("<?php
+class BlogControllerEventListener extends BcControllerEventListener {
+	public \$events = array('hogeFunction');
+}");
+			$EventFile->close();
+		}
+
+		Configure::delete('BcApp.adminNavi.blog');
+		CakePlugin::unload();
+
+		// プラグインを読み込む
+		$result = loadPlugin($plugin, $priority);
+		$this->assertEquals($expect, $result);
+
+		if ($expect) {
+			$EventFile->close();
+			$Folder->delete($EventFolderPath);
+
+			// プラグインが読み込めているか
+			$this->assertContains($plugin, CakePlugin::loaded(), 'プラグインを読み込めません');
+			$this->assertNotNull(Configure::read('BcApp.adminNavi.blog'), 'プラグインの設定が正しく設定されていません');
+			
+			$this->Event = new CakeEventManager();
+			$EventListeners = $this->Event->listeners('Controller.hogeFunction');
+			
+			// イベントリスナーに登録されているか
+			$this->assertContains('hogeFunction', $EventListeners[0]['callable'], 'プラグインイベントを正しく登録できません');
+
+			// プライオリティを設定できているか 
+			if (!is_null($priority)) {
+				$this->assertEquals($priority, $EventListeners[1]['callable'][0]->events['hogeFunction']['priority']);
+			}
+		}
+		
+	}
+
+	public function loadPluginDataProvider() {
+		return array(
+			array('Blog', null, true),
+			array('Blog', 1, true),
+			array('Hoge', null, false),
+		);
+	}
+
+/**
+ * 後方互換の為の非推奨メッセージを生成する
+ */
+	public function testDeprecatedMessage() {
+		$result = deprecatedMessage('target', 'since', 'remove', 'note');
+		$expect = 'targetは、バージョン since より非推奨となりました。バージョン remove で削除される予定です。note';
+		$this->assertEquals($expect, $result);
+
+		// デバックモードではない場合
+		Configure::write('debug', 0);
+		$result = deprecatedMessage('target', 'since', 'remove', 'note');
+		$this->assertNull($result);
+	}
+
+/**
+ * パーセントエンコーディングされないURLセーフなbase64エンコード
+ */
+	public function testBase64UrlsafeEncodeDecode() {
+		// encode
+		$text = 'ふぁsdlfdfがgふぁsdlpfs'; // base64エンコードすると + と = が含まれる文字列
+		$enc = base64UrlsafeEncode($text);
+		$result = urlencode($enc);
+		// %が含まれてないかチェック
+		$this->assertRegExp('/^(?!.*%)/', $result, 'パーセントエンコーディングされています');
+
+		// decode
+		$dec = base64UrlsafeDecode($enc);
+		$this->assertEquals($dec, $text, '正しくデコードできません');
+	}
+
 
 }

--- a/lib/Baser/Test/Case/BcBasicsTest.php
+++ b/lib/Baser/Test/Case/BcBasicsTest.php
@@ -282,9 +282,12 @@ class BcBasicsTest extends BaserTestCase {
  */
 	public function testClearAllCache() {
 		// ダミーのキャッシュファイルを生成
-		$coreConf = Cache::config('_cake_core_')['settings'];
-		$modelConf = Cache::config('_cake_model_')['settings'];
-		$envConf = Cache::config('_cake_env_')['settings'];
+		$coreConf = Cache::config('_cake_core_');
+		$coreConf = $coreConf['settings'];
+		$modelConf = Cache::config('_cake_model_');
+		$modelConf = $modelConf['settings'];
+		$envConf = Cache::config('_cake_env_');
+		$envConf = $envConf['settings'];
 
 		$coreCache = new File($coreConf['path'] . $coreConf['prefix'] . 'cache', true);
 		$modelCache = new File($modelConf['path'] . $modelConf['prefix'] . 'cache', true);

--- a/lib/Baser/basics.php
+++ b/lib/Baser/basics.php
@@ -36,6 +36,9 @@ function baseUrl() {
 		}
 	} else {
 		$script = $_SERVER['SCRIPT_FILENAME'];
+		if(isConsole()) {
+			$script = str_replace('app' . DS . 'Console' . DS . 'cake.php', '', $script);
+		}
 		$script = str_replace(docRoot(), '', $script);
 		if (BC_DEPLOY_PATTERN == 1) {
 			$baseUrl = preg_replace('/' . preg_quote('app' . DS . 'webroot' . DS . 'index.php', '/') . '/', '', $script);
@@ -68,6 +71,10 @@ function docRoot() {
 
 	if (empty($_SERVER['SCRIPT_NAME'])) {
 		return '';
+	}
+
+	if(isConsole()) {
+		return str_replace('app' . DS . 'Console' . DS . 'cake.php', '', $_SERVER['SCRIPT_NAME']);
 	}
 
 	if (strpos($_SERVER['SCRIPT_NAME'], '.php') === false) {
@@ -293,7 +300,7 @@ function clearViewCache($url = null, $ext = '.php') {
 
 	$url = preg_replace('/^\/mobile\//is', '/m/', $url);
 	if ($url == '/' || $url == '/index' || $url == '/index.html' || $url == '/m/' || $url == '/m/index' || $url == '/m/index.html') {
-		$homes = array('', 'index', 'index_html');
+		$homes = array('index', 'index_html');
 		foreach ($homes as $home) {
 			if (preg_match('/^\/m/is', $url)) {
 				if ($home) {
@@ -428,7 +435,7 @@ function checkTmpFolders() {
 }
 
 /**
- * フォルダの中をフォルダを残して空にする
+ * フォルダの中をフォルダを残して空にする(ファイルのみを削除する)
  *
  * @param	string	$path
  * @return	boolean
@@ -912,7 +919,21 @@ function loadPlugin($plugin, $priority) {
 		if (file_exists($pluginPath . 'Event' . DS . $eventClass . '.php')) {
 			App::uses($eventClass, $plugin . '.Event');
 			$CakeEvent = CakeEventManager::instance();
-			$CakeEvent->attach(new $eventClass(), null, array('priority' => $priority));
+			$EventClass = new $eventClass();
+
+			foreach($EventClass->events as $key => $options) {
+				// プラグイン側で priority の設定がされてない場合に設定
+				if(is_array($options)) {
+					if(empty($options['priority'])) {
+						$options['priority'] = $priority;
+						$EventClass->events[$key] = $options;
+					}
+				} else {
+					unset($EventClass->events[$key]);
+					$EventClass->events[$options] = array('priority' => $priority);
+				}
+			}
+			$CakeEvent->attach($EventClass, null);
 		}
 	}
 	return true;


### PR DESCRIPTION
- testBaseUrl()は一部未完成です。BC_DEPLOY_PATTERNで分岐した場合のテストが記述されていません
- 次のメソッドはCakeやPHPの組み込み定数などに依存しているため、テストの必要性がないと思いテストを記述していません
getDbDriver
isConsole
isWindows
- Travisは失敗していますが、basicsのテストは失敗していないのでプルリクしておきます