### PR TITLE
add trim

### DIFF
--- a/lib/Baser/Controller/UsersController.php
+++ b/lib/Baser/Controller/UsersController.php
@@ -503,7 +503,7 @@ class UsersController extends AppController {
 				$this->Session->setFlash('メールアドレスを入力してください。');
 				return;
 			}
-			$email = $this->request->data[$userModel]['email'];
+			$email = trim($this->request->data[$userModel]['email']);
 			$user = $this->{$userModel}->findByEmail($email);
 			if (!$user) {
 				$this->Session->setFlash('送信されたメールアドレスは登録されていません。');


### PR DESCRIPTION
パスワードリセットで、メールアドレスの後ろにスペースを入れるとエラーになり、メールは送信されない。
しかし、内部的にパスワードはリセットされてる。
場当たり的な修正で恐縮ですが、とりあえず参考までにプルリク送ります。

/admin/users/reset_password
メールアドレスの後ろにスペースを入れると、
Invalid email: 
エラー: An Internal Error Has Occurred.
エラーになるが、
findByEmail($email)
は値を返しているので、パスワードはリセットされる。
メールは送信されない。