### PR TITLE
fix #11096 イベントリスナの挙動を修正

### DIFF
--- a/lib/Baser/Event/BcEventListener.php
+++ b/lib/Baser/Event/BcEventListener.php
@@ -65,9 +65,9 @@ class BcEventListener extends Object implements CakeEventListener {
 	public function implementedEvents() {
 		
 		$events = array();
-		$options = array();
 		if ($this->events) {
 			foreach ($this->events as $key => $registerEvent) {
+				$options = array();
 				if(is_array($registerEvent)) {
 					$options = $registerEvent;
 					$registerEvent = $key;


### PR DESCRIPTION
ビューイベントリスナで

	/**
	 * 登録イベント
	 *
	 * @var array
	 */
	public $events = array(
		'beforeRender',
		'beforeLayout',
	);

としていたらbeforeRenderが２回呼ばれていました。
BcEventListener::implementedEvents()の$optionsが
繰り返し処理の中で引き継がれてしまっているのが原因。
foreachのループごとに初期化することで対応