### PR TITLE
固定ページのcode欄に記述が有る場合は文言を表示して判別しやすくする

### DIFF
--- a/lib/Baser/View/Pages/admin/form.php
+++ b/lib/Baser/View/Pages/admin/form.php
@@ -497,6 +497,7 @@ function pageTypeChengeHandler() {
 </div>
 
 <h2 class="btn-slide-form"><a href="javascript:void(0)" id="formOption">オプション</a></h2>
+<?php if ($this->BcForm->value('Page.code')): ?><p class="align-right"><small>※ コード欄に記述有</small></p><?php endif ?>
 
 <div id ="formOptionBody" class="slide-body section">
 	<table cellpadding="0" cellspacing="0" class="form-table">


### PR DESCRIPTION
提案です。
固定ページのcode欄への記述は、オプションを開かないと有無がわからないため、内容がある場合は文言を表示してユーザーに知らせるようにしてみました。
ご検討よろしくお願いします。