### PR TITLE
データの復元を利用した際に、復元後にキャッシュが利用され、復元後の最新状態となっていないように見えてしまう点を調整

### DIFF
--- a/lib/Baser/Controller/ToolsController.php
+++ b/lib/Baser/Controller/ToolsController.php
@@ -97,6 +97,7 @@ class ToolsController extends AppController {
 				if ($messages) {
 					$this->setMessage(implode('<br />', $messages), $error);
 				}
+				clearAllCache();
 				$this->redirect(array('action' => 'maintenance'));
 				break;
 		}


### PR DESCRIPTION
改修提案のプルリクエストです。
ご検討よろしくお願いします。

- 例えば、承認プラグインを利用している際の固定ページ一覧表示のときや、ブログ記事一覧表示のタイミング