### PR TITLE
fixes #11995 Test実行時のSchemaファイル走査にプラグインのパスを追加

### DIFF
--- a/lib/Baser/Lib/TestSuite/Fixture/BaserTestFixture.php
+++ b/lib/Baser/Lib/TestSuite/Fixture/BaserTestFixture.php
@@ -64,15 +64,30 @@ class BaserTestFixture extends CakeTestFixture {
  * @return null|string
  */
 	public function findSchemaFile($tableName, $plugin = null) {
+		$configDir = array();
 		if (empty($plugin)) {
-			$configDir = BASER_CONFIGS;
+			$configDir[] = BASER_CONFIGS;
 		} else {
-			$configDir = BASER_PLUGINS . Inflector::camelize($plugin) . DS . 'Config' . DS;
+			$configDir[] = BASER_PLUGINS . Inflector::camelize($plugin) . DS . 'Config' . DS;
+			$pluginPathList = App::path('Plugin');
+			foreach ($pluginPathList as $pluginPath) {
+				$configDir[] = $pluginPath . Inflector::camelize($plugin) . DS . 'Config' . DS;
+			}
 		}
-		$schemaFile = $configDir . 'Schema' . DS . $tableName . '.php';
 
-		if (file_exists($schemaFile)) {
-			return $schemaFile;
+		$schemaFileList = array();
+		foreach ($configDir as $configPath) {
+			$schemaFileList[] = $configPath . 'Schema' . DS . $tableName . '.php';
+		}
+
+		if (!$schemaFileList) {
+			return null;
+		}
+
+		foreach ($schemaFileList as $schemaFile) {
+			if (file_exists($schemaFile)) {
+				return $schemaFile;
+			}
 		}
 		return null;
 	}

--- a/lib/Baser/Lib/TestSuite/Fixture/BaserTestFixture.php
+++ b/lib/Baser/Lib/TestSuite/Fixture/BaserTestFixture.php
@@ -73,20 +73,13 @@ class BaserTestFixture extends CakeTestFixture {
 			}
 		}
 
-		$schemaFileList = array();
 		foreach ($configDir as $configPath) {
-			$schemaFileList[] = $configPath . 'Schema' . DS . $tableName . '.php';
-		}
-
-		if (!$schemaFileList) {
-			return null;
-		}
-
-		foreach ($schemaFileList as $schemaFile) {
+			$schemaFile = $configPath . 'Schema' . DS . $tableName . '.php';
 			if (file_exists($schemaFile)) {
 				return $schemaFile;
 			}
 		}
+
 		return null;
 	}
 

--- a/lib/Baser/Lib/TestSuite/Fixture/BaserTestFixture.php
+++ b/lib/Baser/Lib/TestSuite/Fixture/BaserTestFixture.php
@@ -68,9 +68,7 @@ class BaserTestFixture extends CakeTestFixture {
 		if (empty($plugin)) {
 			$configDir[] = BASER_CONFIGS;
 		} else {
-			$configDir[] = BASER_PLUGINS . Inflector::camelize($plugin) . DS . 'Config' . DS;
-			$pluginPathList = App::path('Plugin');
-			foreach ($pluginPathList as $pluginPath) {
+			foreach (App::path('Plugin') as $pluginPath) {
 				$configDir[] = $pluginPath . Inflector::camelize($plugin) . DS . 'Config' . DS;
 			}
 		}


### PR DESCRIPTION
app/Plugin/ 配下に置いたプラグインのTest実行時に、Schemaファイルの走査ができずに失敗している。
そのため、app/Plugin/ 配下、及びその他のプラグイン用ディレクトリのパスを含め、Schemaファイルを探せるように調整しました。
