### PR TITLE
 fixes #12019 isBlog isMail 及びそのテストを追加

### DIFF
--- a/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
@@ -469,6 +469,115 @@ class BcBaserHelperTest extends BaserTestCase {
 	}
 
 /**
+ * 現在のページがブログプラグインかどうかを判定する
+ *
+ * @param bool $expected 期待値
+ * @param string $url リクエストURL
+ * @param string $agent ユーザーエージェント
+ *
+ * @return void
+ * @dataProvider isBlogDataProvider
+ */
+	public function testIsBlog($expected, $url, $agent = null) {
+		$this->_unsetAgent();
+		if ($agent !== null) {
+			$this->_setAgent($agent);
+		}
+		$this->BcBaser->request = $this->_getRequest($url);
+		$this->assertEquals($expected, $this->BcBaser->isBlog());
+	}
+
+	public function isBlogDataProvider() {
+		return array(
+			//PC
+			array(false, '/'),
+			array(false, '/index'),
+			array(false, '/contact/index'),
+			array(true, '/news/index'),
+
+			// モバイルページ
+			array(false, '/m/', 'mobile'),
+			array(false, '/m/index', 'mobile'),
+			array(false, '/m/contact/index', 'mobile'),
+			array(true, '/m/news/index', 'mobile'),
+
+			// スマートフォンページ
+			array(false, '/s/', 'smartphone'),
+			array(false, '/s/index', 'smartphone'),
+			array(false, '/s/contact/index', 'smartphone'),
+			array(true, '/s/news/index', 'smartphone')
+		);
+	}
+
+	/**
+	 * 現在のページがメールプラグインかどうかを判定する
+	 *
+	 * @param bool $expected 期待値
+	 * @param string $url リクエストURL
+	 * @param string $agent ユーザーエージェント
+	 *
+	 * @return void
+	 * @dataProvider isMailDataProvider
+	 */
+	public function testIsMail($expected, $url, $agent = null) {
+		$this->_unsetAgent();
+		if ($agent !== null) {
+			$this->_setAgent($agent);
+		}
+		$this->BcBaser->request = $this->_getRequest($url);
+		$this->assertEquals($expected, $this->BcBaser->isMail());
+	}
+
+	public function isMailDataProvider() {
+		return array(
+			//PC
+			array(false, '/'),
+			array(false, '/index'),
+			array(false, '/news/index'),
+			array(true, '/contact/index'),
+
+			// モバイルページ
+			array(false, '/m/', 'mobile'),
+			array(false, '/m/index', 'mobile'),
+			array(false, '/m/news/index', 'mobile'),
+			array(true, '/m/contact/index', 'mobile'),
+
+			// スマートフォンページ
+			array(false, '/s/', 'smartphone'),
+			array(false, '/s/index', 'smartphone'),
+			array(false, '/s/news/index', 'smartphone'),
+			array(true, '/s/contact/index', 'smartphone')
+		);
+	}
+
+	/**
+	 * 現在のページが指定のプラグインかどうかを判定する
+	 *
+	 * @return void
+	 */
+	public function testIsPluginContent() {
+
+		$this->BcBaser->request = $this->_getRequest('/');
+		$this->assertEquals(false, $this->BcBaser->isPluginContent('Blog'));
+
+		$this->BcBaser->request = $this->_getRequest('/news/index');
+		$this->assertEquals(true, $this->BcBaser->isPluginContent('Blog'));
+
+		$this->BcBaser->request = $this->_getRequest('/index');
+		$this->assertEquals(false, $this->BcBaser->isPluginContent('Mail'));
+
+		$this->BcBaser->request = $this->_getRequest('/contact/index');
+		$this->assertEquals(true, $this->BcBaser->isPluginContent('Mail'));
+
+		$this->BcBaser->request->params['plugin'] = 'hollow_world';
+		$this->assertEquals(true, $this->BcBaser->isPluginContent('HollowWorld'));
+		$this->assertEquals(true, $this->BcBaser->isPluginContent('hollowWorld'));
+		$this->assertEquals(true, $this->BcBaser->isPluginContent('hollow_world'));
+		$this->assertEquals(false, $this->BcBaser->isPluginContent('hollowworld'));
+	}
+
+
+/**
  * baserCMSが設置されているパスを出力する
  *
  * @param string $expected 期待値

--- a/lib/Baser/View/Helper/BcBaserHelper.php
+++ b/lib/Baser/View/Helper/BcBaserHelper.php
@@ -1713,6 +1713,40 @@ END_FLASH;
 	}
 
 /**
+ * 指定のプラグインかを判別する
+ * 現状、Blog,Mail のみ動作確認
+ *
+ * @param string name プラグイン名
+ * @return bool
+ */
+	public function isPluginContent($name) {
+		if (empty($this->request->params['plugin'])) {
+			return false;
+		}
+		return (
+			$this->request->params['plugin'] === Inflector::underscore($name)
+		);
+	}
+
+/**
+ * 現在のページがブログプラグインかどうかを判定する
+ *
+ * @return bool
+ */
+	public function isBlog() {
+		return $this->isPluginContent('Blog');
+	}
+
+/**
+ * 現在のページがメールプラグインかどうかを判定する
+ *
+ * @return bool
+ */
+	public function isMail() {
+		return $this->isPluginContent('Mail');
+	}
+
+/**
  * 現在のページの純粋なURLを取得する
  * 
  * スマートURL、サブフォルダかどうかに依存しない、スラッシュから始まるURLを取得


### PR DESCRIPTION
やはりわかりづらいので、pull request わけました。

https://github.com/baserproject/basercms/pull/405/files/f653338e473dee1fc172102e8f8ad797c0d7ccff#r62588514
の方は、eyeCatchの方もとりこめたら、削除します。

で、
isPluginContents は、isPluginContent へ変更

>プラグイン名の指定は、アッパーキャメルケースを前提として、isPluginContent() 内にて、Inflector を利用し、アンダースコア区切りに強制的に変換して判定する仕様でどうでしょう？

で調整しています。
まぁ、公式には、アッパーキャメルケースですが、
hollow_world プラグインの場合
HollowWorld
hollowWorld
hollow_world
のどれもで、true になるので、厳密にした方がよければ調整いたします。
