### PR TITLE
fixes #12038 BcBaser->getTItleの第2引数を調整、tag除去等のオプションを追加

### DIFF
--- a/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
@@ -297,6 +297,25 @@ class BcBaserHelperTest extends BaserTestCase {
 		// カテゴリが対象ページと同じ場合に省略する
 		$this->BcBaser->setTitle('会社データ');
 		$this->assertEquals("会社データ｜会社案内｜{$topTitle}", $this->BcBaser->getTitle('｜', true));
+
+		// strip_tagの機能確認 tag付
+		$this->BcBaser->setTitle('会社<br>沿革<center>真ん中</center>');
+		$this->assertEquals("会社<br>沿革<center>真ん中</center>｜会社データ｜会社案内｜{$topTitle}", $this->BcBaser->getTitle('｜', true));
+
+		// strip_tagの機能確認 tagを削除
+		$options = array(
+			'categoryTitleOn' => true,
+			'tag' => false
+		);
+		$this->assertEquals("会社沿革真ん中｜会社データ｜会社案内｜{$topTitle}", $this->BcBaser->getTitle('｜', $options));
+
+		// 一部タグだけ削除
+		$options = array(
+			'categoryTitleOn' => true,
+			'tag' => false,
+			'allowableTags' => '<center>'
+		);
+		$this->assertEquals("会社沿革<center>真ん中</center>｜会社データ｜会社案内｜{$topTitle}", $this->BcBaser->getTitle('｜', $options));
 	}
 
 /**

--- a/lib/Baser/View/Helper/BcBaserHelper.php
+++ b/lib/Baser/View/Helper/BcBaserHelper.php
@@ -249,7 +249,7 @@ class BcBaserHelper extends AppHelper {
  * @param array $options
  *  `categoryTitleOn` カテゴリタイトルを表示するかどうか boolean で指定 (初期値 : null)
  *  `tag` (boolean) false でタグを削除するかどうか (初期値 : true)
- *  `allowableTags` tagが falseの場合、削除しないタグを指定できる (初期値 : '')
+ *  `allowableTags` tagが falseの場合、削除しないタグを指定できる。詳しくは、php strip_tags のドキュメントを参考してください。 (初期値 : '')
  * @return string メタタグ用のタイトルを返す
  */
 	public function getTitle($separator = '｜', $options = array()) {
@@ -264,14 +264,9 @@ class BcBaserHelper extends AppHelper {
 			'tag' => true,
 			'allowableTags' => ''
 		), $options);
-		extract($options);
-
-		unset($options['categoryTitleOn']);
-		unset($options['tag']);
-		unset($options['allowableTags']);
 
 		$title = array();
-		$crumbs = $this->getCrumbs($categoryTitleOn);
+		$crumbs = $this->getCrumbs($options['categoryTitleOn']);
 		if ($crumbs) {
 			$crumbs = array_reverse($crumbs);
 			foreach ($crumbs as $key => $crumb) {
@@ -280,8 +275,8 @@ class BcBaserHelper extends AppHelper {
 						continue;
 					}
 				}
-				if(!$tag){
-					$title[] = strip_tags($crumb['name'], $allowableTags);
+				if(!$options['tag']){
+					$title[] = strip_tags($crumb['name'], $options['allowableTags']);
 				} else {
 					$title[] = $crumb['name'];
 				}
@@ -290,8 +285,8 @@ class BcBaserHelper extends AppHelper {
 
 		// サイトタイトルを追加
 		if (!empty($this->siteConfig['name'])) {
-			if(!$tag){
-				$title[] = strip_tags($this->siteConfig['name'], $allowableTags);
+			if(!$options['tag']){
+				$title[] = strip_tags($this->siteConfig['name'], $options['allowableTags']);
 			} else {
 				$title[] = $this->siteConfig['name'];
 			}


### PR DESCRIPTION
第2引数は options として調整しました。後方互換は維持しています。
allowableTags は、strip_tags関数のマニュアルと同じ名称がいいと思いこちらにしています。