### PR TITLE
     fixes #12057 BlogHelper に getCurrentBlogId currentBlogId の実装

### DIFF
--- a/lib/Baser/Plugin/Blog/Test/Case/View/Helper/BlogHelperTest.php
+++ b/lib/Baser/Plugin/Blog/Test/Case/View/Helper/BlogHelperTest.php
@@ -137,6 +137,27 @@ class BlogHelperTest extends BaserTestCase {
 	}
 
 /**
+ * ブログIDを取得する
+ *
+ * @return void
+ */
+	public function testGetBlogId() {
+		$result = $this->Blog->getCurrentBlogId();
+		$expects = '1';
+		$this->assertEquals($expects, $result);
+	}
+
+/**
+ * ブログIDを出力する
+ *
+ * @return void
+ */
+	public function testCurrentBlogId() {
+		$this->expectOutputString('1');
+		$this->Blog->currentBlogId();
+	}
+
+/**
  * ブログアカウント名を取得する
  *
  * @return void

--- a/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
+++ b/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
@@ -73,6 +73,24 @@ class BlogHelper extends AppHelper {
 	}
 
 /**
+ * ブログIDを出力する
+ *
+ * @return void
+ */
+	public function currentBlogId() {
+		echo $this->getCurrentBlogId();
+	}
+
+/**
+ * ブログIDを取得する
+ *
+ * @return integer
+ */
+	public function getCurrentBlogId() {
+		return $this->blogContent['id'];
+	}
+
+/**
  * ブログアカウント名を出力する
  *
  * @return void


### PR DESCRIPTION
test修正してみました。御確認くださいませ。
