### PR TITLE
fix #12064 メールフォーム セレクトボックスのオプション欄にてempty|falseが有効にならない

### DIFF
--- a/lib/Baser/Plugin/Mail/View/Helper/MailformHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MailformHelper.php
@@ -69,7 +69,12 @@ class MailformHelper extends BcFreezeHelper {
 				unset($attributes['maxlength']);
 				unset($attributes['separator']);
 				if (isset($attributes['empty'])) {
-					$showEmpty = $attributes['empty'];
+					if (strtolower($attributes['empty']) == 'false' || 
+						strtolower($attributes['empty']) == 'null') {
+						$showEmpty = false;
+					} else {
+						$showEmpty = $attributes['empty'];
+					}
 				} else {
 					$showEmpty = true;
 				}


### PR DESCRIPTION
よろしくお願いします！