### PR TITLE
最新環境のVagrantで環境を立ちあげられない問題を修正した。

### DIFF
--- a/Vagrantfile.default
+++ b/Vagrantfile.default
@@ -88,7 +88,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # vagrant upの前に、vagrant-omnibusプラグインを導入してください。
   #   $ vagrant plugin install vagrant-omnibus
   #
-  config.omnibus.chef_version = :latest
+  config.omnibus.chef_version = "12.10.24"
 
   config.vm.provision :chef_solo do |chef|
     chef.cookbooks_path = "./vagrant_cookbooks"


### PR DESCRIPTION
新しいバージョンのVagrant環境（下記参照）で、新たに環境構築できない問題を修正しました。

新しいバージョンのChefが上手く利用できておらず、「INFO: HTTP Request Returned 404 Not Found: Object not found: chefzero://localhost:8889/nodes/」等のエラーが出ていたところ、安定して使えそうなChefのバージョンを決め打ちするようにして、環境が立ち上がるようにしました。

■問題を確認した環境
MacOS 10.11.5
Vagrant 1.8.1
VirtualBox 5.0.20