### PR TITLE
fixes #12502 getCategoryUrl() でブログカテゴリURLが取得できない場合がある

### DIFF
--- a/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
+++ b/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
@@ -413,7 +413,7 @@ class BlogHelper extends AppHelper {
 		extract($options);
 
 		if (!isset($this->BlogCategory)) {
-			$this->BlogCategory = ClassRegistry::init('BlogCategory', 'Model');
+			$this->BlogCategory = ClassRegistry::init('Blog.BlogCategory');
 		}
 		$categoryPath = $this->BlogCategory->getPath($blogCategoryId);
 		$blogContentId = $categoryPath[0]['BlogCategory']['blog_content_id'];


### PR DESCRIPTION
- プラグイン側からBlogHelperを利用するケースで発生する

よろしくお願いします。
