### PR TITLE
Test/yada10

### DIFF
--- a/lib/Baser/Config/setting.php
+++ b/lib/Baser/Config/setting.php
@@ -115,9 +115,7 @@ $config['BcAuthPrefix'] = array(
 		// モデル
 		'userModel' => 'User',
 		// セッションキー
-		// TODO Adminとした方がわかりやすいが、アップデート時にセッションキーが変わってしまうと
-		// 予期せぬ事態が発生しかねない為、メジャーバージョンアップのタイミングで変更する
-		'sessionKey' => 'User'
+		'sessionKey' => 'Admin'
 	)
 	// フロント（例）
 /* 'front' => array(

--- a/lib/Baser/Model/Datasource/Database/BcSqlite.php
+++ b/lib/Baser/Model/Datasource/Database/BcSqlite.php
@@ -997,8 +997,8 @@ class BcSqlite extends Sqlite {
 				// sqlite_sequence テーブルの場合、typeがないのでエラーとなるので調整
 				'length' => ($column[0]['type']) ? $this->length($column[0]['type']) : ''
 			);
-			if (in_array($fields[$column['name']]['type'], array('timestamp', 'datetime')) && strtoupper($fields[$column['name']]['default']) === 'CURRENT_TIMESTAMP') {
-				$fields[$column['name']]['default'] = null;
+			if (in_array($fields[$column[0]['name']]['type'], array('timestamp', 'datetime')) && strtoupper($fields[$column[0]['name']]['default']) === 'CURRENT_TIMESTAMP') {
+				$fields[$column[0]['name']]['default'] = null;
 			}
 			// SQLiteではdefaultのNULLが文字列として扱われてしまう様子
 			if ($fields[$column[0]['name']]['default'] == 'NULL') {

--- a/lib/Baser/Test/Case/Controller/Component/BcAuthConfigureComponentTest.php
+++ b/lib/Baser/Test/Case/Controller/Component/BcAuthConfigureComponentTest.php
@@ -54,7 +54,7 @@ class BcAuthConfigureComponentTest extends BaserTestCase {
 		
 		Router::reload();
 		Router::connect('/:controller/:action/*');
-	
+
 	}
 	
 	public function tearDown() {
@@ -73,7 +73,6 @@ class BcAuthConfigureComponentTest extends BaserTestCase {
  * @return boolean
  */
 	public function testSettingCheckInitialize() {
-
 		// 異常系
 		$result = $this->Controller->BcAuthConfigure->setting(array(1));
 		$this->assertFalse($result, '初期化がされていない場合にtrueが返ってきます');
@@ -111,9 +110,6 @@ class BcAuthConfigureComponentTest extends BaserTestCase {
 
 		$this->Controller->params['prefix'] = $requestedPrefix;
 
-		$redirect = '/admin';
-		$this->Controller->BcAuth->Session->write('Auth.redirect', $redirect);
-
 		// 認証設定を設定
 		$this->Controller->BcAuthConfigure->setting($config);
 
@@ -138,6 +134,7 @@ class BcAuthConfigureComponentTest extends BaserTestCase {
 				),
 			),
 			'sessionKey' => null,
+			'redirect' => null
 		);
 
 		// loginAction
@@ -158,9 +155,6 @@ class BcAuthConfigureComponentTest extends BaserTestCase {
 		} else if (!empty($auth_prefix)) {
 			$expected['authenticate']['Form']['scope'] = array('UserGroup.auth_prefix LIKE' => '%' . $auth_prefix .'%');
 		}
-
-		// Session Auth.redirect
-		$expected['redirect'] = null;
 
 		// 判定
 		$this->assertEquals($expected, $result, '認証設定が正しくありません');

--- a/lib/Baser/Test/Case/Controller/Component/BcAuthConfigureComponentTest.php
+++ b/lib/Baser/Test/Case/Controller/Component/BcAuthConfigureComponentTest.php
@@ -35,7 +35,7 @@ class BcAuthConfigureComponentTest extends BaserTestCase {
 	public $components = array('BcAuthConfigure');
 	
 	public function setUp() {
-	
+		@session_start();
 		parent::setUp();
 		
 		// コンポーネントと偽のコントローラをセットアップする
@@ -58,7 +58,7 @@ class BcAuthConfigureComponentTest extends BaserTestCase {
 	}
 	
 	public function tearDown() {
-	
+		@session_destroy();
 		parent::tearDown();
 		unset($this->Controller);
 		unset($this->BcAuthConfigure);

--- a/lib/Baser/Test/Case/Controller/Component/BcCaptchaComponentTest.php
+++ b/lib/Baser/Test/Case/Controller/Component/BcCaptchaComponentTest.php
@@ -49,6 +49,7 @@ class BcCaptchaComponentTest extends BaserTestCase {
 	public $components = array('BcCaptcha');
 
 	public function setUp() {
+		@session_start();
 		parent::setUp();
 
 		// コンポーネントと偽のテストコントローラをセットアップする
@@ -69,6 +70,7 @@ class BcCaptchaComponentTest extends BaserTestCase {
 	}
 
 	public function tearDown() {
+		@session_destroy();
 		parent::tearDown();
 		unset($this->Controller);
 		unset($this->BcCaptcha);

--- a/lib/Baser/Test/Case/Model/Behavior/BcUploadBehaviorTest.php
+++ b/lib/Baser/Test/Case/Model/Behavior/BcUploadBehaviorTest.php
@@ -29,6 +29,7 @@ class BcUploadBehaviorTest extends BaserTestCase {
  * @return void
  */
 	public function setUp() {
+		@session_start();
 		parent::setUp();
 		$this->EditorTemplate = ClassRegistry::init('EditorTemplate');
 		$this->BcUploadBehavior = ClassRegistry::init('BcUploadBehavior');
@@ -40,6 +41,7 @@ class BcUploadBehaviorTest extends BaserTestCase {
  * @return void
  */
 	public function tearDown() {
+		@session_destroy();
 		unset($this->EditorTemplate);
 		unset($this->BcUploadBehavior);
 		parent::tearDown();


### PR DESCRIPTION
- sqliteのインストールに失敗していたので修正 (syntax error)
- setting.phpにあったTODOを解消
- session_id()に適当な文字列を与え、強制的にコンソール上でセッションを開始することができないよう、CakeSession::startedに変更があったので、テストを修正
- BcAuthConfigureComponentの仕様変更に伴い修正