### PR TITLE
Fixes #13310 [ブログ][アイキャッチ画像] 画像比率はそのままで、指定サイズを基準とした画像を作成する

### DIFF
--- a/lib/Baser/Model/Behavior/BcUploadBehavior.php
+++ b/lib/Baser/Model/Behavior/BcUploadBehavior.php
@@ -442,7 +442,14 @@ class BcUploadBehavior extends ModelBehavior {
 			$thumb = false;
 		}
 
-		return $this->resizeImage($Model->data[$Model->name][$field['name']]['tmp_name'], $filePath, $field['width'], $field['height'], $thumb);
+		// 画像比率を保ったサムネイル作成指定
+		if (!empty($field['sameratio'])) {
+			$sameRatio = $field['sameratio'];
+		} else {
+			$sameRatio = false;
+		}
+
+		return $this->resizeImage($Model->data[$Model->name][$field['name']]['tmp_name'], $filePath, $field['width'], $field['height'], $thumb, $sameRatio);
 	}
 
 /**
@@ -453,14 +460,15 @@ class BcUploadBehavior extends ModelBehavior {
  * @param string $distination コピー先のパス
  * @param int $width 横幅
  * @param int $height 高さ
- * @param boolean $$thumb サムネイルとしてコピーするか
+ * @param boolean $thumb サムネイルとしてコピーするか
+ * @param boolean $sameRatio 画像比率を保持するか
  * @return boolean
  * @access public
  */
-	public function resizeImage($source, $distination, $width = 0, $height = 0, $thumb = false) {
+	public function resizeImage($source, $distination, $width = 0, $height = 0, $thumb = false, $sameRatio = false) {
 		if ($width > 0 || $height > 0) {
 			$imageresizer = new Imageresizer();
-			$ret = $imageresizer->resize($source, $distination, $width, $height, $thumb);
+			$ret = $imageresizer->resize($source, $distination, $width, $height, $thumb, $sameRatio);
 		} else {
 			$ret = copy($source, $distination);
 		}

--- a/lib/Baser/Model/Behavior/BcUploadBehavior.php
+++ b/lib/Baser/Model/Behavior/BcUploadBehavior.php
@@ -461,7 +461,7 @@ class BcUploadBehavior extends ModelBehavior {
  * @param int $width 横幅
  * @param int $height 高さ
  * @param boolean $thumb サムネイルとしてコピーするか
- * @param boolean $sameRatio 画像比率を保持するか
+ * @param boolean $sameRatio サムネイルを指定サイズにトリミングするか
  * @return boolean
  * @access public
  */

--- a/lib/Baser/Plugin/Blog/Model/BlogContent.php
+++ b/lib/Baser/Plugin/Blog/Model/BlogContent.php
@@ -277,8 +277,10 @@ class BlogContent extends BlogAppModel {
 		$data['BlogContent']['status'] = false;
 		$data['BlogContent']['eye_catch_size_thumb_width'] = 600;
 		$data['BlogContent']['eye_catch_size_thumb_height'] = 600;
+		$data['BlogContent']['eye_catch_size_thumb_sameratio'] = false;
 		$data['BlogContent']['eye_catch_size_mobile_thumb_width'] = 150;
 		$data['BlogContent']['eye_catch_size_mobile_thumb_height'] = 150;
+		$data['BlogContent']['eye_catch_size_mobile_thumb_sameratio'] = false;
 		$data['BlogContent']['use_content'] = true;
 
 		return $data;
@@ -294,13 +296,17 @@ class BlogContent extends BlogAppModel {
 		$data['BlogContent']['eye_catch_size'] = BcUtil::serialize(array(
 			'thumb_width' => $data['BlogContent']['eye_catch_size_thumb_width'],
 			'thumb_height' => $data['BlogContent']['eye_catch_size_thumb_height'],
+			'thumb_sameratio' => $data['BlogContent']['eye_catch_size_thumb_sameratio'],
 			'mobile_thumb_width' => $data['BlogContent']['eye_catch_size_mobile_thumb_width'],
 			'mobile_thumb_height' => $data['BlogContent']['eye_catch_size_mobile_thumb_height'],
+			'mobile_thumb_sameratio' => $data['BlogContent']['eye_catch_size_mobile_thumb_sameratio'],
 		));
 		unset($data['BlogContent']['eye_catch_size_thumb_width']);
 		unset($data['BlogContent']['eye_catch_size_thumb_height']);
+		unset($data['BlogContent']['eye_catch_size_thumb_sameratio']);
 		unset($data['BlogContent']['eye_catch_size_mobile_thumb_width']);
 		unset($data['BlogContent']['eye_catch_size_mobile_thumb_height']);
+		unset($data['BlogContent']['eye_catch_size_mobile_thumb_sameratio']);
 
 		return $data;
 	}
@@ -315,8 +321,10 @@ class BlogContent extends BlogAppModel {
 		$eyeCatchSize = BcUtil::unserialize($data['BlogContent']['eye_catch_size']);
 		$data['BlogContent']['eye_catch_size_thumb_width'] = $eyeCatchSize['thumb_width'];
 		$data['BlogContent']['eye_catch_size_thumb_height'] = $eyeCatchSize['thumb_height'];
+		$data['BlogContent']['eye_catch_size_thumb_sameratio'] = $eyeCatchSize['thumb_sameratio'];
 		$data['BlogContent']['eye_catch_size_mobile_thumb_width'] = $eyeCatchSize['mobile_thumb_width'];
 		$data['BlogContent']['eye_catch_size_mobile_thumb_height'] = $eyeCatchSize['mobile_thumb_height'];
+		$data['BlogContent']['eye_catch_size_mobile_thumb_sameratio'] = $eyeCatchSize['mobile_thumb_sameratio'];
 		return $data;
 	}
 

--- a/lib/Baser/Plugin/Blog/Model/BlogPost.php
+++ b/lib/Baser/Plugin/Blog/Model/BlogPost.php
@@ -164,7 +164,7 @@ class BlogPost extends BlogAppModel {
  * @param	int $id ブログコンテンツID
  */
 	public function setupUpload($id) {
-		$sizes = array('thumb', 'mobile_thumb');
+		$sizes = array('thumb', 'mobile_thumb', 'sameratio');
 		$data = $this->BlogContent->find('first', array('conditions' => array('BlogContent.id' => $id)));
 		$data = $this->BlogContent->constructEyeCatchSize($data);
 		$data = $data['BlogContent'];
@@ -178,6 +178,7 @@ class BlogPost extends BlogAppModel {
 			$imagecopy[$size] = array('suffix' => '__' . $size);
 			$imagecopy[$size]['width'] = $data['eye_catch_size_' . $size . '_width'];
 			$imagecopy[$size]['height'] = $data['eye_catch_size_' . $size . '_height'];
+			$imagecopy[$size]['sameratio'] = $data['eye_catch_size_' . $size . '_sameratio'];
 		}
 
 		$settings = $this->Behaviors->BcUpload->settings['BlogPost'];

--- a/lib/Baser/Plugin/Blog/Test/Case/Model/BlogContentTest.php
+++ b/lib/Baser/Plugin/Blog/Test/Case/Model/BlogContentTest.php
@@ -164,6 +164,8 @@ class BlogContentTest extends BaserTestCase {
 			'thumb_height' => 1,
 			'mobile_thumb_width' => 1,
 			'mobile_thumb_height' => 1,
+			'thumb_sameratio' => false,
+			'mobile_thumb_sameratio' => false,
 		);
 
 		$this->BlogContent->create(array(

--- a/lib/Baser/Plugin/Blog/Test/Case/Model/BlogPostTest.php
+++ b/lib/Baser/Plugin/Blog/Test/Case/Model/BlogPostTest.php
@@ -180,12 +180,14 @@ class BlogPostTest extends BaserTestCase {
 			'thumb' => array(
 				'suffix' => '__thumb',
 				'width' => '300',
-				'height' => '300'
+				'height' => '300',
+				'sameratio' => false,
 			),
 			'mobile_thumb' => array(
 				'suffix' => '__mobile_thumb',
 				'width' => '100',
-				'height' => '100'
+				'height' => '100',
+				'sameratio' => false,
 			)
 		);
 

--- a/lib/Baser/Plugin/Blog/View/BlogContents/admin/form.php
+++ b/lib/Baser/Plugin/Blog/View/BlogContents/admin/form.php
@@ -263,14 +263,21 @@ $(function(){
 			<td class="col-input">
 				<span>PCサイズ</span>　
 				<small>[幅]</small><?php echo $this->BcForm->input('BlogContent.eye_catch_size_thumb_width', array('type' => 'text', 'size' => '8')) ?>&nbsp;px　×　
-				<small>[高さ]</small><?php echo $this->BcForm->input('BlogContent.eye_catch_size_thumb_height', array('type' => 'text', 'size' => '8')) ?><br />
+				<small>[高さ]</small><?php echo $this->BcForm->input('BlogContent.eye_catch_size_thumb_height', array('type' => 'text', 'size' => '8')) ?>
+				&nbsp;&nbsp;&nbsp;&nbsp;
+				<?php echo $this->BcForm->input('BlogContent.eye_catch_size_thumb_sameratio', array('type' => 'checkbox', 'label' => '比率を保持した指定サイズにする')) ?>
+				<?php echo $this->Html->image('admin/icn_help.png', array('id' => 'helpEyeCatchSize', 'class' => 'btn help', 'alt' => 'ヘルプ')) ?>
+				<br />
 				<span>携帯サイズ</span>　
 				<small>[幅]</small><?php echo $this->BcForm->input('BlogContent.eye_catch_size_mobile_thumb_width', array('type' => 'text', 'size' => '8')) ?>&nbsp;px　×　
 				<small>[高さ]</small><?php echo $this->BcForm->input('BlogContent.eye_catch_size_mobile_thumb_height', array('type' => 'text', 'size' => '8')) ?>
+				&nbsp;&nbsp;&nbsp;&nbsp;
+				<?php echo $this->BcForm->input('BlogContent.eye_catch_size_mobile_thumb_sameratio', array('type' => 'checkbox', 'label' => '比率を保持した指定サイズにする')) ?>
 <?php echo $this->BcForm->error('BlogContent.eye_catch_size') ?>
-				<div id="helptextTemplate" class="helptext">
+				<div id="helptextEyeCatchSize" class="helptext">
 					<ul>
 						<li>アイキャッチ画像のサイズを指定します。</li>
+						<li>「比率を保持した指定サイズにする」場合、<br />切り取られる画像は中央が基準となります。</li>
 					</ul>
 				</div>
 			</td>

--- a/lib/Baser/Plugin/Blog/View/BlogContents/admin/form.php
+++ b/lib/Baser/Plugin/Blog/View/BlogContents/admin/form.php
@@ -265,19 +265,19 @@ $(function(){
 				<small>[幅]</small><?php echo $this->BcForm->input('BlogContent.eye_catch_size_thumb_width', array('type' => 'text', 'size' => '8')) ?>&nbsp;px　×　
 				<small>[高さ]</small><?php echo $this->BcForm->input('BlogContent.eye_catch_size_thumb_height', array('type' => 'text', 'size' => '8')) ?>
 				&nbsp;&nbsp;&nbsp;&nbsp;
-				<?php echo $this->BcForm->input('BlogContent.eye_catch_size_thumb_sameratio', array('type' => 'checkbox', 'label' => '比率を保持した指定サイズにする')) ?>
+				<?php echo $this->BcForm->input('BlogContent.eye_catch_size_thumb_sameratio', array('type' => 'checkbox', 'label' => 'サムネイルを指定サイズにトリミングする')) ?>
 				<?php echo $this->Html->image('admin/icn_help.png', array('id' => 'helpEyeCatchSize', 'class' => 'btn help', 'alt' => 'ヘルプ')) ?>
 				<br />
 				<span>携帯サイズ</span>　
 				<small>[幅]</small><?php echo $this->BcForm->input('BlogContent.eye_catch_size_mobile_thumb_width', array('type' => 'text', 'size' => '8')) ?>&nbsp;px　×　
 				<small>[高さ]</small><?php echo $this->BcForm->input('BlogContent.eye_catch_size_mobile_thumb_height', array('type' => 'text', 'size' => '8')) ?>
 				&nbsp;&nbsp;&nbsp;&nbsp;
-				<?php echo $this->BcForm->input('BlogContent.eye_catch_size_mobile_thumb_sameratio', array('type' => 'checkbox', 'label' => '比率を保持した指定サイズにする')) ?>
+				<?php echo $this->BcForm->input('BlogContent.eye_catch_size_mobile_thumb_sameratio', array('type' => 'checkbox', 'label' => 'サムネイルを指定サイズにトリミングする')) ?>
 <?php echo $this->BcForm->error('BlogContent.eye_catch_size') ?>
 				<div id="helptextEyeCatchSize" class="helptext">
 					<ul>
 						<li>アイキャッチ画像のサイズを指定します。</li>
-						<li>「比率を保持した指定サイズにする」場合、<br />切り取られる画像は中央が基準となります。</li>
+						<li>「サムネイルを指定サイズにトリミングする」場合、<br />切り取られる画像は中央が基準となります。<br />※通常は相対的な縮小によりサムネイルを作ります。</li>
 					</ul>
 				</div>
 			</td>

--- a/lib/Baser/Test/Case/Model/Behavior/BcUploadBehaviorTest.php
+++ b/lib/Baser/Test/Case/Model/Behavior/BcUploadBehaviorTest.php
@@ -551,12 +551,13 @@ class BcUploadBehaviorTest extends BaserTestCase {
  * 
  * @param int $width 横幅
  * @param int $height 高さ
- * @param boolean $$thumb サムネイルとしてコピーするか
+ * @param boolean $thumb サムネイルとしてコピーするか
+ * @param boolean $sameRatio サムネイルを指定サイズにトリミングする
  * @param array $expected 期待値
  * @param string $message テストが失敗した時に表示されるメッセージ
  * @dataProvider resizeImageDataProvider
  */
-	public function testResizeImage($width, $height, $thumb, $expected, $message = null) {
+	public function testResizeImage($width, $height, $thumb, $sameRatio, $expected, $message = null) {
 
 		$imgPath = ROOT . '/lib/Baser/webroot/img/';
 		$source = $imgPath . 'baser.power.gif';
@@ -566,7 +567,7 @@ class BcUploadBehaviorTest extends BaserTestCase {
 
 
 		// コピー実行
-		$this->BcUploadBehavior->resizeImage($source, $distination, $width, $height, $thumb);
+		$this->BcUploadBehavior->resizeImage($source, $distination, $width, $height, $thumb, $sameRatio);
 			
 		if (!$width && !$height) {
 			$this->assertFileExists($distination, $message);

--- a/lib/Baser/Vendor/Imageresizer.php
+++ b/lib/Baser/Vendor/Imageresizer.php
@@ -15,7 +15,7 @@ class Imageresizer {
  * @param 	int 	幅
  * @param 	int		高さ
  * @param boolean $trimming サムネイルとしてコピーするか
- * @param boolean $sameRatio 画像比率を保持するか
+ * @param boolean $sameRatio サムネイルを指定サイズにトリミングするか
  * @return 	boolean
  */
 	function resize($imgPath, $savePath = null, $newWidth=null, $newHeight=null, $trimming = false, $sameRatio = false) {
@@ -166,7 +166,7 @@ class Imageresizer {
  * @param 	int 	新しい幅
  * @param 	int		新しい高さ
  * @param	boolean	サムネイルとしてコピーするか
- * @param	boolean	画像比率を保持するか
+ * @param	boolean	サムネイルを指定サイズにトリミングするか
  * @return 	Image	新しいイメージオブジェクト
  */
 	function _copyAndResize($srcImage, $newImage, $srcWidth, $srcHeight, $newWidth, $newHeight, $trimming = false, $sameRatio = false) {


### PR DESCRIPTION
アイキャッチ画像のサイズ指定に、比率を保持した指定サイズが行えるように調整してみました。

![sc_admin_blog_contents_edit](https://cloud.githubusercontent.com/assets/1115768/17464126/de8b5f26-5d11-11e6-8d09-9a14fad4f229.png)
