### PR TITLE
Fixes #13310 [ブログ][アイキャッチ画像] 画像比率はそのままで、指定サイズを基準とした画像を作成する

### DIFF
--- a/lib/Baser/Model/Behavior/BcUploadBehavior.php
+++ b/lib/Baser/Model/Behavior/BcUploadBehavior.php
@@ -413,6 +413,7 @@ class BcUploadBehavior extends ModelBehavior {
  * @param Model $Model
  * @param array 画像保存対象フィールドの設定
  * @return boolean
+ * @access public
  */
 	public function copyImage(Model $Model, $field) {
 		// データを取得
@@ -440,7 +441,14 @@ class BcUploadBehavior extends ModelBehavior {
 			$thumb = false;
 		}
 
-		return $this->resizeImage($Model->data[$Model->name][$field['name']]['tmp_name'], $filePath, $field['width'], $field['height'], $thumb);
+		// 画像比率を保ったサムネイル作成指定
+		if (!empty($field['sameratio'])) {
+			$sameRatio = $field['sameratio'];
+		} else {
+			$sameRatio = false;
+		}
+
+		return $this->resizeImage($Model->data[$Model->name][$field['name']]['tmp_name'], $filePath, $field['width'], $field['height'], $thumb, $sameRatio);
 	}
 
 /**
@@ -451,13 +459,15 @@ class BcUploadBehavior extends ModelBehavior {
  * @param string $distination コピー先のパス
  * @param int $width 横幅
  * @param int $height 高さ
- * @param boolean $$thumb サムネイルとしてコピーするか
+ * @param boolean $thumb サムネイルとしてコピーするか
+ * @param boolean $sameRatio 画像比率を保持するか
  * @return boolean
+ * @access public
  */
-	public function resizeImage($source, $distination, $width = 0, $height = 0, $thumb = false) {
+	public function resizeImage($source, $distination, $width = 0, $height = 0, $thumb = false, $sameRatio = false) {
 		if ($width > 0 || $height > 0) {
 			$imageresizer = new Imageresizer();
-			$ret = $imageresizer->resize($source, $distination, $width, $height, $thumb);
+			$ret = $imageresizer->resize($source, $distination, $width, $height, $thumb, $sameRatio);
 		} else {
 			$ret = copy($source, $distination);
 		}

--- a/lib/Baser/Plugin/Blog/Model/BlogContent.php
+++ b/lib/Baser/Plugin/Blog/Model/BlogContent.php
@@ -248,6 +248,7 @@ class BlogContent extends BlogAppModel {
  * フォームの初期値を取得する
  *
  * @return void
+ * @access public
  */
 	public function getDefaultValue() {
 		$data['BlogContent']['comment_use'] = true;
@@ -262,8 +263,10 @@ class BlogContent extends BlogAppModel {
 		$data['BlogContent']['status'] = false;
 		$data['BlogContent']['eye_catch_size_thumb_width'] = 600;
 		$data['BlogContent']['eye_catch_size_thumb_height'] = 600;
+		$data['BlogContent']['eye_catch_size_thumb_sameratio'] = false;
 		$data['BlogContent']['eye_catch_size_mobile_thumb_width'] = 150;
 		$data['BlogContent']['eye_catch_size_mobile_thumb_height'] = 150;
+		$data['BlogContent']['eye_catch_size_mobile_thumb_sameratio'] = false;
 		$data['BlogContent']['use_content'] = true;
 
 		return $data;
@@ -273,19 +276,24 @@ class BlogContent extends BlogAppModel {
  * アイキャッチサイズフィールドの値をDB用に変換する
  * 
  * @param array $data
- * @return array 
+ * @return array
+ * @access public
  */
 	public function deconstructEyeCatchSize($data) {
 		$data['BlogContent']['eye_catch_size'] = BcUtil::serialize(array(
 			'thumb_width' => $data['BlogContent']['eye_catch_size_thumb_width'],
 			'thumb_height' => $data['BlogContent']['eye_catch_size_thumb_height'],
+			'thumb_sameratio' => $data['BlogContent']['eye_catch_size_thumb_sameratio'],
 			'mobile_thumb_width' => $data['BlogContent']['eye_catch_size_mobile_thumb_width'],
 			'mobile_thumb_height' => $data['BlogContent']['eye_catch_size_mobile_thumb_height'],
+			'mobile_thumb_sameratio' => $data['BlogContent']['eye_catch_size_mobile_thumb_sameratio'],
 		));
 		unset($data['BlogContent']['eye_catch_size_thumb_width']);
 		unset($data['BlogContent']['eye_catch_size_thumb_height']);
+		unset($data['BlogContent']['eye_catch_size_thumb_sameratio']);
 		unset($data['BlogContent']['eye_catch_size_mobile_thumb_width']);
 		unset($data['BlogContent']['eye_catch_size_mobile_thumb_height']);
+		unset($data['BlogContent']['eye_catch_size_mobile_thumb_sameratio']);
 
 		return $data;
 	}
@@ -294,14 +302,17 @@ class BlogContent extends BlogAppModel {
  * アイキャッチサイズフィールドの値をフォーム用に変換する
  * 
  * @param array $data
- * @return array 
+ * @return array
+ * @access public
  */
 	public function constructEyeCatchSize($data) {
 		$eyeCatchSize = BcUtil::unserialize($data['BlogContent']['eye_catch_size']);
 		$data['BlogContent']['eye_catch_size_thumb_width'] = $eyeCatchSize['thumb_width'];
 		$data['BlogContent']['eye_catch_size_thumb_height'] = $eyeCatchSize['thumb_height'];
+		$data['BlogContent']['eye_catch_size_thumb_sameratio'] = $eyeCatchSize['thumb_sameratio'];
 		$data['BlogContent']['eye_catch_size_mobile_thumb_width'] = $eyeCatchSize['mobile_thumb_width'];
 		$data['BlogContent']['eye_catch_size_mobile_thumb_height'] = $eyeCatchSize['mobile_thumb_height'];
+		$data['BlogContent']['eye_catch_size_mobile_thumb_sameratio'] = $eyeCatchSize['mobile_thumb_sameratio'];
 		return $data;
 	}
 

--- a/lib/Baser/Plugin/Blog/Model/BlogPost.php
+++ b/lib/Baser/Plugin/Blog/Model/BlogPost.php
@@ -152,7 +152,7 @@ class BlogPost extends BlogAppModel {
  * @param	int $id ブログコンテンツID
  */
 	public function setupUpload($id) {
-		$sizes = array('thumb', 'mobile_thumb');
+		$sizes = array('thumb', 'mobile_thumb', 'sameratio');
 		$data = $this->BlogContent->find('first', array('conditions' => array('BlogContent.id' => $id), 'recursive' => 0));
 		$data = $this->BlogContent->constructEyeCatchSize($data);
 		$blogContent = $data['BlogContent'];

--- a/lib/Baser/Plugin/Blog/View/BlogContents/admin/form.php
+++ b/lib/Baser/Plugin/Blog/View/BlogContents/admin/form.php
@@ -178,14 +178,21 @@ $this->BcBaser->js('Blog.admin/blog_contents/edit', false);
 			<td class="col-input">
 				<span>PCサイズ</span>　
 				<small>[幅]</small><?php echo $this->BcForm->input('BlogContent.eye_catch_size_thumb_width', array('type' => 'text', 'size' => '8')) ?>&nbsp;px　×　
-				<small>[高さ]</small><?php echo $this->BcForm->input('BlogContent.eye_catch_size_thumb_height', array('type' => 'text', 'size' => '8')) ?><br />
+				<small>[高さ]</small><?php echo $this->BcForm->input('BlogContent.eye_catch_size_thumb_height', array('type' => 'text', 'size' => '8')) ?>
+				&nbsp;&nbsp;&nbsp;&nbsp;
+				<?php echo $this->BcForm->input('BlogContent.eye_catch_size_thumb_sameratio', array('type' => 'checkbox', 'label' => '比率を保持した指定サイズにする')) ?>
+				<?php echo $this->Html->image('admin/icn_help.png', array('id' => 'helpEyeCatchSize', 'class' => 'btn help', 'alt' => 'ヘルプ')) ?>
+				<br />
 				<span>携帯サイズ</span>　
 				<small>[幅]</small><?php echo $this->BcForm->input('BlogContent.eye_catch_size_mobile_thumb_width', array('type' => 'text', 'size' => '8')) ?>&nbsp;px　×　
 				<small>[高さ]</small><?php echo $this->BcForm->input('BlogContent.eye_catch_size_mobile_thumb_height', array('type' => 'text', 'size' => '8')) ?>
+				&nbsp;&nbsp;&nbsp;&nbsp;
+				<?php echo $this->BcForm->input('BlogContent.eye_catch_size_mobile_thumb_sameratio', array('type' => 'checkbox', 'label' => '比率を保持した指定サイズにする')) ?>
 <?php echo $this->BcForm->error('BlogContent.eye_catch_size') ?>
-				<div id="helptextTemplate" class="helptext">
+				<div id="helptextEyeCatchSize" class="helptext">
 					<ul>
 						<li>アイキャッチ画像のサイズを指定します。</li>
+						<li>「比率を保持した指定サイズにする」場合、<br />切り取られる画像は中央が基準となります。</li>
 					</ul>
 				</div>
 			</td>


### PR DESCRIPTION
アイキャッチ画像のサイズ指定に、比率を保持した指定サイズが行えるように調整してみました。

![sc_admin_blog_contents_edit](https://cloud.githubusercontent.com/assets/1115768/17467252/3cb0ebd0-5d57-11e6-9e76-a815f904a53f.png)
