### PR TITLE
Fixes #13162 固定ページの並び順がおかしくなる

### DIFF
--- a/lib/Baser/Model/SiteConfig.php
+++ b/lib/Baser/Model/SiteConfig.php
@@ -138,4 +138,44 @@ class SiteConfig extends AppModel {
 		return true;
 	}
 
+/**
+ * コンテンツ一覧を表示してから、コンテンツの並び順が変更されていないかどうか
+ * 
+ * @param $listDisplayed
+ * @return bool
+ */
+	public function isChangedContentsSortLastModified($listDisplayed) {
+		$siteConfigs = $this->findExpanded();
+		$changed = false;
+		if(!empty($siteConfigs['contents_sort_last_modified'])) {
+			$lastModified = $siteConfigs['contents_sort_last_modified'];
+			list($lastModified, $sessionId) = explode('|', $lastModified);
+			if(session_id() != $sessionId) {
+				// 60秒はブラウザのロード時間を加味したバッファ
+				if($lastModified >= ($listDisplayed - 60)) {
+					$changed = true;
+				}
+			}
+		}
+		return $changed;
+	}
+
+/**
+ * コンテンツ並び順変更時間を更新する
+ */
+	public function updateContentsSortLastModified() {
+		$siteConfigs = $this->findExpanded();
+		$siteConfigs['contents_sort_last_modified'] = date('U') . '|' . session_id();
+		$this->saveKeyValue($siteConfigs);
+	}
+
+/**
+ * コンテンツ並び替え順変更時間をリセットする 
+ */
+	public function resetContentsSortLastModified() {
+		$siteConfigs = $this->findExpanded();
+		$siteConfigs['contents_sort_last_modified'] = '';
+		$this->saveKeyValue($siteConfigs);
+	}
+
 }

--- a/lib/Baser/View/Pages/admin/index.php
+++ b/lib/Baser/View/Pages/admin/index.php
@@ -32,6 +32,7 @@ $(function(){
 <div id="AjaxSorttableUrl" style="display:none"><?php $this->BcBaser->url(array('controller' => 'pages', 'action' => 'ajax_update_sort')) ?></div>
 <div id="AlertMessage" class="message" style="display:none"></div>
 <div id="MessageBox" style="display:none"><div id="flashMessage" class="notice-message"></div></div>
+<?php echo $this->BcForm->hidden('listDisplayed', array('value' => date('U'))); ?>
 
 <?php $this->BcBaser->element('pages/index_view_setting') ?>
 


### PR DESCRIPTION
dev-4のコンテンツ一覧のロック機能をdev-3の固定ページ一覧に実装しました。
dev-4との違いは
・ユーザーIDでチェックしているところをセッションIDに変更
　（同一ユーザーの別ブラウザ対応）
・viewにセットする日付けをUNIX Timeに変更
　（比較時にUNIX Timeに変換して比較いたのでそのままのほうが見た目も良いのでは？）
という感じです。
よろしくお願いします！
