### PR TITLE
fixes #13679 画像認証利用時のフォームテンプレートのバグを調整

### DIFF
--- a/lib/Baser/Plugin/Mail/View/Elements/mail_form.php
+++ b/lib/Baser/Plugin/Mail/View/Elements/mail_form.php
@@ -56,7 +56,8 @@ $(function(){
 		</div>
 	<?php else: ?>
 		<?php echo $this->Mailform->hidden('MailMessage.auth_captcha') ?>
-	<?php endif ?> 
+		<?php echo $this->Mailform->hidden('MailMessage.captcha_id') ?>
+	<?php endif ?>
 <?php endif ?>
 
 <?php /* 送信ボタン */ ?>


### PR DESCRIPTION
おっかけていったら、MailController.php の function submit での画像チェックのロジック調整の時に発生したバグみたいですね。