### PR TITLE
fixes #13828 初期インストール時にPostgreSQLのsequenceの数値のデータにあわせてupdate

### DIFF
--- a/lib/Baser/Controller/Component/BcManagerComponent.php
+++ b/lib/Baser/Controller/Component/BcManagerComponent.php
@@ -544,6 +544,11 @@ class BcManagerComponent extends Component {
 			return false;
 		}
 
+		$Db = $this->_getDataSource();
+		if($Db->config['datasource'] == 'Database/BcPostgres') {
+			$Db->updateSequence();
+		}
+
 		return true;
 	}
 


### PR DESCRIPTION
管理画面のテーマ管理からの初期データ取込ではupdateSequenceされていたので、初期インストールのロジックの所に移植しました。