### PR TITLE
 fixes #13827 contents.title にvalidationを追加,ajaxからの登録で適切なエラーが出るように調整

### DIFF
--- a/lib/Baser/Controller/PagesController.php
+++ b/lib/Baser/Controller/PagesController.php
@@ -102,7 +102,15 @@ class PagesController extends AppController {
 			$this->setMessage($message, false, true, false);
 			return json_encode($data['Content']);
 		} else {
-			$this->ajaxError(500, $this->Page->validationErrors);
+			// 本当は、どこのmodelで、validationErrorがおきたのか取得して、ajaxErrorにつなげたい。
+			// ここでは、titleだけに限定しておかないと、nameの errorも拾ってきて、エラーが重複するため。
+			if ( $this->Content->validationErrors['title'] ) {
+				$this->ajaxError(500, $this->Content->validationErrors);
+			} else if( $this->Page->validationErrors ) {
+				$this->ajaxError(500, $this->Page->validationErrors);
+			} else {
+				$this->ajaxError(500);
+			}
 		}
 		return false;
 	}

--- a/lib/Baser/Model/BcAppModel.php
+++ b/lib/Baser/Model/BcAppModel.php
@@ -689,6 +689,26 @@ class BcAppModel extends Model {
 		}
 	}
 
+	/**
+	 * 削除文字チェック
+	 *
+	 * BcUtile::urlencode で、削除される文字のみで構成されているかチェック(結果ブランクになるためnotBlankになる確認)
+	 *
+	 * @param array $check チェック対象文字列
+	 * @return boolean
+	 */
+	public function bcUtileUrlencodeBlank($check) {
+		if (!$check[key($check)]) {
+			return true;
+		}
+
+		if (preg_match("/^[\\'\|`\^\"\(\)\{\}\[\];\/\?:@&=\+\$,%<>#! 　]+$/", $check[key($check)])) {
+			return false;
+		} else {
+			return true;
+		}
+	}
+
 /**
  * データの重複チェックを行う
  * @param array $check

--- a/lib/Baser/Model/Content.php
+++ b/lib/Baser/Model/Content.php
@@ -69,18 +69,22 @@ class Content extends AppModel {
  */
 	public $validate = [
 		'name' => [
+			['rule' => ['bcUtileUrlencodeBlank'],
+				'message' => 'URLはスペース、全角スペース及び、指定の記号(\\\'|`^"(){}[];/?:@&=+$,%<>#!)だけの名前は付けられません。'],
 			['rule' => ['notBlank'],
 				'message' => 'スラッグを入力してください。'],
 			['rule' => ['maxLength', 2083],
-				'message' => 'タイトルは255文字以内で入力してください。'],
+				'message' => 'タイトルは230文字以内で入力してください。'],
 			['rule' => ['duplicateRelatedSiteContent'],
 				'message' => '連携しているサブサイトでスラッグが重複するコンテンツが存在します。重複するコンテンツのスラッグ名を先に変更してください。']
 		],
 		'title' => [
+			['rule' => ['bcUtileUrlencodeBlank'],
+				'message' => 'タイトルはスペース、全角スペース及び、指定の記号(\\\'|`^"(){}[];/?:@&=+$,%<>#!)だけの名前は付けられません。'],
 			['rule' => ['notBlank'],
 				'message' => 'タイトルを入力してください。'],
-			['rule' => ['maxLength', 255],
-				'message' => 'タイトルは255文字以内で入力してください。'],
+			['rule' => ['maxLength', 230],
+				'message' => 'タイトルは230文字以内で入力してください。'],
 		],
 	];
 


### PR DESCRIPTION
とりえあず、ajax経由の方は修正できたので、送ります。
BcAppModel あたりに、validationErrors をため込んでいくロジック追加が
理想的かと思いますので(eventで呼び込みが増えても、エラーハンドリング周りのソースの改修がすくなくてすむ)、もしくは try,catchでやり直す。

いずれそちらに替えたいと思ってます。
必要なら、別途チケット未来向けにつくっておいてくれても大丈夫です。