### PR TITLE
    fixes #13837 create error の場合、delete_nodeで追加表示を削除

### DIFF
--- a/lib/Baser/webroot/js/admin/libs/jquery.bcTree.js
+++ b/lib/Baser/webroot/js/admin/libs/jquery.bcTree.js
@@ -781,7 +781,7 @@
 	 * Create Content
 	 *
 	 * @param parent
-	 * @param _data
+	 * @param data
 	 */
 		createContent: function (parent, data) {
 			var _data = {
@@ -851,6 +851,7 @@
 					},
 					error: function (XMLHttpRequest, textStatus, errorThrown) {
 						$.bcUtil.showAjaxError('追加に失敗しました。', XMLHttpRequest, errorThrown);
+						$.bcTree.jsTree.delete_node(node);
 					},
 					complete: function () {
 						$.bcUtil.hideLoader();


### PR DESCRIPTION
ajax error の場合は、jsTree 自体のnodeを削除する処理追加しました。