### PR TITLE
  fixes #13943 固定ページ/ブログの本文の容量を増やしたい

### DIFF
--- a/lib/Baser/Config/Schema/pages.php
+++ b/lib/Baser/Config/Schema/pages.php
@@ -14,7 +14,21 @@ class PagesSchema extends CakeSchema {
 		return true;
 	}
 
-	public function after($event = array()) {
+	public function after($event = [])
+	{
+		$db = ConnectionManager::getDataSource($this->connection);
+		if (get_class($db) !== 'BcMysql') {
+			return true;
+		}
+
+		if (isset($event['create'])) {
+			switch ($event['create']) {
+				case 'pages':
+					$tableName = $db->config['prefix'] . 'pages';
+					$db->query("ALTER TABLE {$tableName} CHANGE contents contents MEDIUMTEXT");
+					break;
+			}
+		}
 	}
 
 	public $pages = array(

--- a/lib/Baser/Model/Datasource/DboSource.php
+++ b/lib/Baser/Model/Datasource/DboSource.php
@@ -3880,7 +3880,11 @@ class DboSource extends DataSource {
 
 		// SQLを生成して実行
 		$sql = $this->createSchema($schema);
-		$return = $this->execute($sql);
+		if($return = $this->execute($sql)){
+			if(method_exists($schema, 'after')){
+				$schema->after(['create'=> strtolower($schema->name),'errors'=>null]);
+			}
+		}
 		// とりあえずキャッシュを全て削除
 		clearCache(null, 'models');
 		return $return;

--- a/lib/Baser/Plugin/Blog/Config/Schema/blog_posts.php
+++ b/lib/Baser/Plugin/Blog/Config/Schema/blog_posts.php
@@ -14,7 +14,21 @@ class BlogPostsSchema extends CakeSchema {
 		return true;
 	}
 
-	public function after($event = array()) {
+	public function after($event = [])
+	{
+		$db = ConnectionManager::getDataSource($this->connection);
+		if( get_class($db) !== 'BcMysql'){
+			return true ;
+		}
+
+		if (isset($event['create'])) {
+			switch ($event['create']) {
+				case 'blogposts':
+					$tableName = $db->config['prefix'] . 'blog_posts';
+					$db->query("ALTER TABLE {$tableName} CHANGE detail detail MEDIUMTEXT");
+					break;
+			}
+		}
 	}
 
 	public $blog_posts = array(


### PR DESCRIPTION
増やすために、MEDIUMTEXTを設定、
cakeschema の定義だと、text しか指定出来ないので、強引かもしれないが
after methodで、MEDIUMTEXT に型変換した。(alter table)

本来、after method は、CakeSchemaのコールバックで呼ばれる予定なのだが
baserCMSのオリジナル拡張(というより1系からの下位互換のため)で、コールバック
がうごいてない。(ここ追ってないので他の原因ならそこで修正した方がいいかと思います)

ちょっと強引だけど、createTableに成功して、スキーマファイルに after methodが
あれば呼び出すようにした。引数は、CakeSchemaのコールバックとあわせてるので
CakePHP3にしたときも大幅な改修はしなくて大丈夫と思われる。

全体的に強引な感じはぬぐえないので、とりあえず確認してもらえればと思います。
