### PR TITLE
Fixes #14049 同一URLコンテンツが生成される問題の修正

### DIFF
--- a/lib/Baser/Controller/ContentsController.php
+++ b/lib/Baser/Controller/ContentsController.php
@@ -622,6 +622,10 @@ class ContentsController extends AppController {
 			$this->ajaxError(500, "コンテンツ一覧を表示後、他のログインユーザーがコンテンツの並び順を更新しました。<br>一度リロードしてから並び替えてください。");
 		}
 		
+		if(!$this->Content->isMovable($this->request->data['currentId'], $this->request->data['targetParentId'])) {
+			$this->ajaxError(500, "同一URLのコンテンツが存在するため処理に失敗しました。");
+		}
+		
 		// EVENT Contents.beforeMove
 		$event = $this->dispatchEvent('beforeMove', array(
 			'data' => $this->request->data

--- a/lib/Baser/Model/Content.php
+++ b/lib/Baser/Model/Content.php
@@ -1201,6 +1201,41 @@ class Content extends AppModel {
 		}
 		return true;
 	}
+	
+/**
+ * 移動元のコンテンツと移動先のディレクトリから移動が可能かチェックする
+ * 
+ * @param $currentId int 移動元コンテンツID
+ * @param $targetParentId int 移動先コンテンツID (ContentFolder)
+ * @return bool
+ */
+	public function isMovable($currentId, $targetParentId) {
+		$currentContent = $this->find('first', [
+			'conditions' => ['id' => $currentId],
+			'recursive' => -1
+		]);
+		$parentCuntent = $this->find('first', [
+			'conditions' => ['id' => $targetParentId],
+			'recursive' => -1
+		]);
+		
+		// 指定コンテンツがない
+		if (!$currentContent || !$parentCuntent) {
+			return false;
+		}
+		
+		// 移動先に同一コンテンツが存在する
+		$movedUrl = $parentCuntent['Content']['url'] . $currentContent['Content']['name'];
+		$movedContent = $this->find('first', [
+			'conditions' => ['url' => $movedUrl],
+			'recursive' => -1
+		]);
+		if ($movedContent) {
+			return false;
+		}
+		
+		return true;
+	}
 
 /**
  * タイトル、URL、公開状態が更新されているか確認する

--- a/lib/Baser/webroot/js/admin/libs/jquery.bcTree.js
+++ b/lib/Baser/webroot/js/admin/libs/jquery.bcTree.js
@@ -96,7 +96,7 @@
 					type: "POST",
 					url: url,
 					beforeSend: function() {
-						$.bcUtil.hideMessage();
+//						$.bcUtil.hideMessage();
 						$.bcUtil.showLoader();
 					},
 					data: {data: {
@@ -1139,13 +1139,13 @@
 							$.bcTree.refreshTree();
 							node.data.jstree.contentParentId = $.bcTree.dropTarget.data.jstree.contentId;
 						}
+						$.bcUtil.hideLoader();
 					},
 					error: function (XMLHttpRequest, textStatus, errorThrown) {
 						$.bcUtil.showAjaxError('並び替えに失敗しました。', XMLHttpRequest, errorThrown);
 						$.bcTree.load();
 					},
 					complete: function () {
-						$.bcUtil.hideLoader();
 					}
 				});
 			}, {hideLoader: false});

--- a/lib/Baser/webroot/js/admin/libs/jquery.bcTree.js
+++ b/lib/Baser/webroot/js/admin/libs/jquery.bcTree.js
@@ -1142,6 +1142,7 @@
 					},
 					error: function (XMLHttpRequest, textStatus, errorThrown) {
 						$.bcUtil.showAjaxError('並び替えに失敗しました。', XMLHttpRequest, errorThrown);
+						$.bcTree.load();
 					},
 					complete: function () {
 						$.bcUtil.hideLoader();


### PR DESCRIPTION
/lib/Baser/webroot/js/admin/lib/jquery.bcTree.js [Line: 99]をコメントしています。
エラーメッセージ表示後、移動前の状態の描画に戻すためloadを走らせるとエラーメッセージの表示がすぐに消されてしまうためです。

確認ください。