### PR TITLE
    fixes #14140 ゴミ箱から戻すときは、非同期処理を解除

### DIFF
--- a/lib/Baser/webroot/js/admin/libs/jquery.bcTree.js
+++ b/lib/Baser/webroot/js/admin/libs/jquery.bcTree.js
@@ -715,6 +715,7 @@
 						}
 					},
 					dataType: 'json',
+					async: false,
 					beforeSend: function () {
 						$.bcUtil.hideMessage();
 						$.bcUtil.showLoader();


### PR DESCRIPTION
tokenのコールバック前にリダイレクトしようとしてエラー表示がでてたので、
ajaxの非同期処理をここは禁止して同期処理とした。