### PR TITLE
    fixes #14474 初期データ登録でPostgreSQLの場合primary keyの重複が発生するので調整

### DIFF
--- a/lib/Baser/Controller/InstallationsController.php
+++ b/lib/Baser/Controller/InstallationsController.php
@@ -343,6 +343,11 @@ class InstallationsController extends AppController {
 				}
 			}
 
+			$Db = ConnectionManager::getDataSource('default');
+			if($Db->config['datasource'] == 'Database/BcPostgres') {
+				$Db->updateSequence();
+			}
+
 			clearAllCache();
 			if (function_exists('opcache_reset')) {
 				opcache_reset();


### PR DESCRIPTION
#13828 の修正では、コアプラグイン及びプラグインに対して、有効でなかったので
step5の最後で、最終的にprimary key をupdateする処理を追加。

#13828は、処理の場所が、BcManagerComponent.php であり、別から呼ばれる可能性
が否定できないので処理はそのままにしています。
