### PR TITLE
文字列のクオートが混在していて変数名が文字列に含まれてしまっていたためにコンテンツの名前変更が失敗する不具合を修正

### DIFF
--- a/lib/Baser/webroot/js/admin/libs/jquery.bcTree.js
+++ b/lib/Baser/webroot/js/admin/libs/jquery.bcTree.js
@@ -1042,7 +1042,7 @@
 				}
 				$.bcToken.check(function(){
 					$.ajax({
-						url: $.baseUrl + "/' + $.bcTree.config.adminPrefix + '/contents/ajax_rename",
+						url: $.baseUrl + '/' + $.bcTree.config.adminPrefix + '/contents/ajax_rename',
 						type: 'POST',
 						data: {
 							id: node.data.jstree.contentId,


### PR DESCRIPTION
コンテンツ管理内でアイテムの名前変更が失敗します。
AjaxURL生成で、文字列内に挟んであるJS変数が文字列になってしまいURLが正しく生成されていなかったため修正しました。