### PR TITLE
セレクトボックスのinput要素とテキストの間にスペースが自動生成されるのをオプションで変更できるようにした。

### DIFF
--- a/lib/Baser/Plugin/Mail/View/Helper/MailformHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MailformHelper.php
@@ -117,6 +117,13 @@ class MailformHelper extends BcFreezeHelper {
 				$attributes['multiple'] = 'checkbox';
 				$attributes['value'] = null;
 				$attributes['empty'] = false;
+				if (!isset($attributes['textSpace'])) {
+					$attributes['textSpace'] = '&nbsp;';
+				}
+				function add_space ($option, $textSpace) {
+					return $textSpace . $option;
+				}
+				$options = array_map('add_space', $options, array($attributes['textSpace']));
 				$out = $this->select($fieldName, $options, $attributes);
 				break;
 			case 'file':

--- a/lib/Baser/View/Helper/BcAppHelper.php
+++ b/lib/Baser/View/Helper/BcAppHelper.php
@@ -30,7 +30,7 @@ class BcAppHelper extends Helper {
 		parent::__construct($View, $settings);
 
 		if (get_class($this) == 'BcHtmlHelper' || get_class($this) == 'HtmlHelper') {
-			$this->_tags['checkboxmultiple'] = '<input type="checkbox" name="%s[]"%s />&nbsp;';
+			$this->_tags['checkboxmultiple'] = '<input type="checkbox" name="%s[]"%s />';
 			$this->_tags['hiddenmultiple'] = '<input type="hidden" name="%s[]" %s />';
 		}
 	}


### PR DESCRIPTION
標準では `&nbsp;` が自動で挿入され、ヘルパーから取り除くのは不可能なため、オプションで空文字列に変更できるようにした。
後方互換のためにデフォルトでは `&nbsp;` が挿入される。