### PR TITLE
fix #14947 管理画面のブログ記事一覧で、アイキャッチを使用するとカラムがずれて表示される

### DIFF
--- a/lib/Baser/Plugin/Blog/View/Elements/admin/blog_posts/index_row.php
+++ b/lib/Baser/Plugin/Blog/View/Elements/admin/blog_posts/index_row.php
@@ -35,9 +35,13 @@ $class = ' class="' . implode(' ', $classies) . '"';
 	</td>
 	<td><?php echo $data['BlogPost']['no']; ?></td>
 	<td><?php echo $this->BcTime->format('Y-m-d', $data['BlogPost']['posts_date']); ?></td>
-	<?php if (Hash::get($data, 'BlogPost.eye_catch')): ?>
-	<td class="eye_catch"><?php echo $this->BcUpload->uploadImage('BlogPost.eye_catch',  $data['BlogPost']['eye_catch'], array('imgsize' => 'mobile_thumb')) ?></td>
-	<?php endif ?>
+	<?php if ($existEyeCatch): ?>
+            <?php if (Hash::get($data, 'BlogPost.eye_catch')): ?>
+                <td class="eye_catch"><?php echo $this->BcUpload->uploadImage('BlogPost.eye_catch',  $data['BlogPost']['eye_catch'], array('imgsize' => 'mobile_thumb')) ?></td>
+            <?php else: ?>
+                <td class="eye_catch"></td>
+            <?php endif ?>
+        <?php endif ?>
 	<td>
 		<?php if (!empty($data['BlogCategory']['title'])): ?>
 			<?php echo $data['BlogCategory']['title']; ?>


### PR DESCRIPTION
#14947 管理画面のブログ記事一覧で、アイキャッチを使用するとカラムがずれて表示される