### PR TITLE
fixes #15071 ブログ詳細の詳細画面の「前に戻る」「次に進む」のリンク先が正しくない場合がある。

### DIFF
--- a/lib/Baser/Plugin/Blog/Controller/BlogController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogController.php
@@ -685,7 +685,7 @@ class BlogController extends BlogAppController {
 					break;
 			}
 		} else {
-			$order = "BlogPost.{$sort} {$direction}, BlogPost.id";
+			$order = "BlogPost.{$sort} {$direction}, BlogPost.id {$direction}";
 		}
 
 		// 毎秒抽出条件が違うのでキャッシュしない

--- a/lib/Baser/Plugin/Blog/Test/Case/View/Helper/BlogHelperTest.php
+++ b/lib/Baser/Plugin/Blog/Test/Case/View/Helper/BlogHelperTest.php
@@ -372,13 +372,15 @@ class BlogHelperTest extends BaserTestCase {
  * 前の記事へのリンクを出力する
  * 
  * @param int $blogContentId ブログコンテンツID
+ * @param int $id 記事ID
  * @param int $posts_date 日付
  * @dataProvider prevLinkDataProvider
  */
-	public function testPrevLink($blogContentId, $posts_date, $expected) {
+	public function testPrevLink($blogContentId, $id, $posts_date, $expected) {
 		$this->expectOutputString($expected);
 		$post = array('BlogPost' => array(
 			'blog_content_id' => $blogContentId,
+			'id' => $id,
 			'posts_date' => $posts_date
 		));
 		$this->Blog->prevLink($post);
@@ -386,10 +388,10 @@ class BlogHelperTest extends BaserTestCase {
 
 	public function prevLinkDataProvider() {
 		return array(
-			array(1, '9000-08-10 18:58:07', '<a href="/news/archives/1" class="prev-link">≪ ホームページをオープンしました</a>'),
-			array(1, '1000-08-10 18:58:07', ''),
-			array(2, '9000-08-10 18:58:07', '<a href="/news/archives/3" class="prev-link">≪ 新商品を販売を開始しました。</a>'),
-			array(2, '1000-08-10 18:58:07', ''),
+			array(1, 4, '9000-08-10 18:58:07', '<a href="/news/archives/1" class="prev-link">≪ ホームページをオープンしました</a>'),
+			array(1, 3, '1000-08-10 18:58:07', ''),
+			array(2, 2, '9000-08-10 18:58:07', '<a href="/news/archives/3" class="prev-link">≪ 新商品を販売を開始しました。</a>'),
+			array(2, 1, '1000-08-10 18:58:07', ''),
 		);
 	}
 
@@ -397,13 +399,15 @@ class BlogHelperTest extends BaserTestCase {
  * 次の記事へのリンクを出力する
  *
  * @param int $blogContentId ブログコンテンツID
+ * @param int $id 記事ID
  * @param int $posts_date 日付
  * @dataProvider nextLinkDataProvider
  */
-	public function testNextLink($blogContentId, $posts_date, $expected) {
+	public function testNextLink($blogContentId, $id, $posts_date, $expected) {
 		$this->expectOutputString($expected);
 		$post = array('BlogPost' => array(
 			'blog_content_id' => $blogContentId,
+			'id' => $id,
 			'posts_date' => $posts_date
 		));
 		$this->Blog->nextLink($post);
@@ -411,10 +415,10 @@ class BlogHelperTest extends BaserTestCase {
 
 	public function nextLinkDataProvider() {
 		return array(
-			array(1, '9000-08-10 18:58:07', ''),
-			array(1, '1000-08-10 18:58:07', '<a href="/news/archives/1" class="next-link">ホームページをオープンしました ≫</a>'),
-			array(2, '9000-08-10 18:58:07', ''),
-			array(2, '1000-08-10 18:58:07', '<a href="/news/archives/2" class="next-link">新商品を販売を開始しました。 ≫</a>'),
+			array(1, 1, '9000-08-10 18:58:07', ''),
+			array(1, 2, '1000-08-10 18:58:07', '<a href="/news/archives/1" class="next-link">ホームページをオープンしました ≫</a>'),
+			array(2, 3, '9000-08-10 18:58:07', ''),
+			array(2, 4, '1000-08-10 18:58:07', '<a href="/news/archives/2" class="next-link">新商品を販売を開始しました。 ≫</a>'),
 		);
 	}
 

--- a/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
+++ b/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
@@ -551,18 +551,36 @@ class BlogHelper extends AppHelper {
 		$htmlAttributes = am($_htmlAttributes, $htmlAttributes);
 		$arrow = $htmlAttributes['arrow'];
 		unset($htmlAttributes['arrow']);
+		// 投稿日が年月日時分秒が同一のデータの対応の為、投稿日が同じでIDが大きいデータを検索
 		$conditions = array();
-		$conditions['BlogPost.posts_date <'] = $post['BlogPost']['posts_date'];
-		$conditions["BlogPost.blog_content_id"] = $post['BlogPost']['blog_content_id'];
+		$conditions['BlogPost.id <'] = $post['BlogPost']['id'];
+		$conditions['BlogPost.posts_date'] = $post['BlogPost']['posts_date'];
+		$conditions['BlogPost.blog_content_id'] = $post['BlogPost']['blog_content_id'];
 		$conditions = am($conditions, $BlogPost->getConditionAllowPublish());
+		$order = 'BlogPost.posts_date DESC, BlogPost.id DESC';
 		// 毎秒抽出条件が違うのでキャッシュしない
 		$prevPost = $BlogPost->find('first', array(
 			'conditions' => $conditions,
 			'fields' => array('no', 'name'),
-			'order' => 'posts_date DESC',
-			'recursive' => 0,
+			'order' => $order,
+			'recursive' => -1,
 			'cache' => false
 		));
+		if (empty($prevPost)) {
+			// 投稿日が古いデータを取得
+			$conditions = array();
+			$conditions['BlogPost.posts_date <'] = $post['BlogPost']['posts_date'];
+			$conditions['BlogPost.blog_content_id'] = $post['BlogPost']['blog_content_id'];
+			$conditions = am($conditions, $BlogPost->getConditionAllowPublish());
+			// 毎秒抽出条件が違うのでキャッシュしない
+			$prevPost = $BlogPost->find('first', array(
+				'conditions' => $conditions,
+				'fields' => array('no', 'name'),
+				'order' => $order,
+				'recursive' => -1,
+				'cache' => false
+			));
+		}
 		if ($prevPost) {
 			$no = $prevPost['BlogPost']['no'];
 			if (!$title) {
@@ -587,18 +605,37 @@ class BlogHelper extends AppHelper {
 		$htmlAttributes = am($_htmlAttributes, $htmlAttributes);
 		$arrow = $htmlAttributes['arrow'];
 		unset($htmlAttributes['arrow']);
+		// 投稿日が年月日時分秒が同一のデータの対応の為、投稿日が同じでIDが小さいデータを検索
 		$conditions = array();
-		$conditions['BlogPost.posts_date >'] = $post['BlogPost']['posts_date'];
-		$conditions["BlogPost.blog_content_id"] = $post['BlogPost']['blog_content_id'];
+		$conditions['BlogPost.id >'] = $post['BlogPost']['id'];
+		$conditions['BlogPost.posts_date'] = $post['BlogPost']['posts_date'];
+		$conditions['BlogPost.blog_content_id'] = $post['BlogPost']['blog_content_id'];
 		$conditions = am($conditions, $BlogPost->getConditionAllowPublish());
+		$order = 'BlogPost.posts_date, BlogPost.id';
 		// 毎秒抽出条件が違うのでキャッシュしない
 		$nextPost = $BlogPost->find('first', array(
 			'conditions' => $conditions,
 			'fields' => array('no', 'name'),
-			'order' => 'posts_date',
-			'recursive' => 0,
+			'order' => $order,
+			'recursive' => -1,
 			'cache' => false
 		));
+
+		if (empty($nextPost)) {
+			// 投稿日が新しいデータを取得
+			$conditions = array();
+			$conditions['BlogPost.posts_date >'] = $post['BlogPost']['posts_date'];
+			$conditions['BlogPost.blog_content_id'] = $post['BlogPost']['blog_content_id'];
+			$conditions = am($conditions, $BlogPost->getConditionAllowPublish());
+			// 毎秒抽出条件が違うのでキャッシュしない
+			$nextPost = $BlogPost->find('first', array(
+				'conditions' => $conditions,
+				'fields' => array('no', 'name'),
+				'order' => $order,
+				'recursive' => -1,
+				'cache' => false
+			));
+		}
 		if ($nextPost) {
 			$no = $nextPost['BlogPost']['no'];
 			if (!$title) {


### PR DESCRIPTION
4系も3系と同じ症状でしたので対応しました。
よろしくお願いします！（再）
