### PR TITLE
fix #15977 キャッシュの指定に不要なoptionを除去

### DIFF
--- a/app/Config/core.php
+++ b/app/Config/core.php
@@ -404,7 +404,6 @@ $prefix = 'myapp_';
 	'engine' => $engine,
 	'prefix' => $prefix . 'cake_core_',
 	'path' => CACHE . 'persistent' . DS,
-	'serialize' => ($engine === 'File'),
 	'duration' => $duration
 ));*/
 // <<<
@@ -419,7 +418,6 @@ $prefix = 'myapp_';
 	'engine' => $engine,
 	'prefix' => $prefix . 'cake_model_',
 	'path' => CACHE . 'models' . DS,
-	'serialize' => ($engine === 'File'),
 	'duration' => $duration
 ));*/
 // <<<

--- a/lib/Baser/Config/bootstrap.php
+++ b/lib/Baser/Config/bootstrap.php
@@ -221,7 +221,6 @@ if (BC_INSTALLED) {
 		'engine' => $cacheEngine,
 		'prefix' => $cachePrefix . 'cake_model_',
 		'path' => CACHE . 'models' . DS,
-		'serialize' => ($cacheEngine === 'File'),
 		'duration' => $cacheDuration
 	));
 	// コア環境
@@ -229,7 +228,6 @@ if (BC_INSTALLED) {
 		'engine' => $cacheEngine,
 		'prefix' => $cachePrefix . 'cake_core_',
 		'path' => CACHE . 'persistent' . DS,
-		'serialize' => ($cacheEngine === 'File'),
 		'duration' => $cacheDuration
 	));
 	// DBデータキャッシュ
@@ -239,7 +237,6 @@ if (BC_INSTALLED) {
 		'probability' => 100,
 		'prefix' => $cachePrefix . 'cake_data_',
 		'lock' => true,
-		'serialize' => ($cacheEngine === 'File'),
 		'duration' => $cacheDuration
 	));
 	// エレメントキャッシュ
@@ -249,7 +246,6 @@ if (BC_INSTALLED) {
 		'probability' => 100,
 //		'prefix' => $cachePrefix . 'cake_data_',
 		'lock' => true,
-		'serialize' => ($cacheEngine === 'File'),
 		'duration' => Configure::read('BcCache.viewDuration')
 	));
 	// 環境情報キャッシュ
@@ -259,7 +255,6 @@ if (BC_INSTALLED) {
 		'path' => CACHE . 'environment',
 		'prefix' => $cachePrefix . 'cake_env_',
 		'lock' => false,
-		'serialize' => ($cacheEngine === 'File'),
 		'duration' => $cacheDuration
 	));
 


### PR DESCRIPTION
cache engineにFileを指定した場合は、defaultでtrueが利用される。(※1)
Memcachedのserializeはtrueを許容しておらず (※2) Exceptionが発生するため全てのEnginでtrue or falseを登録するコードを除去しています。

※1 https://github.com/baserproject/basercms/blob/dev-4/lib/Cake/Cache/Engine/FileEngine.php#L75
※2 https://github.com/baserproject/basercms/blob/dev-4/lib/Cake/Cache/Engine/MemcachedEngine.php#L58
