### PR TITLE
fix #16318 #UserMenu ul ulのpd-rの影響でツールバーの表示が壊れる

### DIFF
--- a/lib/Baser/webroot/css/admin/toolbar.css
+++ b/lib/Baser/webroot/css/admin/toolbar.css
@@ -90,7 +90,7 @@ span#DebugMode{
 	text-align: left;
 }
 #UserMenu ul ul{
-	padding:0 20px 0 0;
+	padding:0;
 	position: absolute;
 }
 #UserMenu ul li{


### PR DESCRIPTION
表示側のCSSの影響でツールバーの文字が切れる問題をpaddingをゼロにすることで解消