### PR TITLE
fix #16398 フロント認証　異常挙動の修正

### DIFF
--- a/lib/Baser/Controller/UsersController.php
+++ b/lib/Baser/Controller/UsersController.php
@@ -77,7 +77,7 @@ class UsersController extends AppController {
 			/* 認証設定 */
 			// parent::beforeFilterの前に記述する必要あり
 			$this->BcAuth->allow(
-				'admin_login', 'admin_logout', 'admin_login_exec', 'admin_reset_password'
+				'admin_login', 'admin_logout', 'admin_login_exec', 'admin_reset_password', 'back_agent'
 			);
 			if(isset($this->UserGroup)) {
 				$this->set('usePermission', $this->UserGroup->checkOtherAdmins());
@@ -86,7 +86,7 @@ class UsersController extends AppController {
 
 		parent::beforeFilter();
 
-		$this->BcReplacePrefix->allow('login', 'logout', 'login_exec', 'reset_password');
+		$this->BcReplacePrefix->allow('login', 'logout', 'login_exec', 'reset_password', 'back_agent');
 	}
 
 /**
@@ -186,11 +186,11 @@ class UsersController extends AppController {
 		$configs = Configure::read('BcAuthPrefix');
 		if ($this->Session->check('AuthAgent')) {
 			$data = $this->Session->read('AuthAgent');
-			$this->Session->write(BcAuthComponent::$sessionKey, $data);
-			$this->Session->delete('AuthAgent');
-			$this->setMessage('元のユーザーに戻りました。');
 			$authPrefix = explode(',', $data['UserGroup']['auth_prefix']);
 			$authPrefix = $authPrefix[0];
+			$this->Session->write('Auth.' . $configs[$authPrefix]['sessionKey'], $data);
+			$this->Session->delete('AuthAgent');
+			$this->setMessage('元のユーザーに戻りました。');
 		} else {
 			$this->setMessage('不正な操作です。', true);
 			if (!empty($this->request->params['prefix'])) {


### PR DESCRIPTION
フロント認証　異常挙動
フロント認証機能の仕様時に、管理ユーザーから運営ユーザー切替を行い、元のユーザーに戻ろうとすると、/users/login　にリダイレクトされてしまう問題の修正