### PR TITLE
fix #16738 BcUploadBehaviorにexifが読めない画像ファイルを読ませるとwarningが発生する問題の修正

### DIFF
--- a/lib/Baser/Model/Behavior/BcUploadBehavior.php
+++ b/lib/Baser/Model/Behavior/BcUploadBehavior.php
@@ -436,8 +436,8 @@ class BcUploadBehavior extends ModelBehavior {
 		if(!function_exists('exif_read_data')) {
 			return false;
 		}
-		$exif = exif_read_data($file);
-		if(empty($exif['Orientation'])) {
+		$exif = @exif_read_data($file);
+		if(empty($exif) || empty($exif['Orientation'])) {
 			return true;
 		}
 		switch($exif['Orientation']) {


### PR DESCRIPTION
よろしくおねがいします。