### PR TITLE
fix #16838 baserが変換するURLにtel:protocolを追加

### DIFF
--- a/lib/Baser/View/Helper/BcAppHelper.php
+++ b/lib/Baser/View/Helper/BcAppHelper.php
@@ -185,7 +185,7 @@ class BcAppHelper extends Helper {
 			$url = array_merge($url, array('admin' => true));
 		}
 
-		if (!is_array($url) && preg_match('/^(javascript|https?|ftp):/', $url)) {
+		if (!is_array($url) && preg_match('/^(javascript|https?|ftp|tel):/', $url)) {
 			return $url;
 		} elseif (!is_array($url) && preg_match('/\/(img|css|js|files)/', $url)) {
 			return $this->webroot($url);

--- a/lib/Baser/View/Helper/BcBaserHelper.php
+++ b/lib/Baser/View/Helper/BcBaserHelper.php
@@ -1043,11 +1043,10 @@ class BcBaserHelper extends AppHelper {
 			}
 		}
 
-		// 現在SSLのURLの場合、フルパスで取得（javascript:とhttpから始まるものは除外）
+		// 現在SSLのURLの場合、プロトコル指定(フルパス)で取得以外
 		// //(スラッシュスラッシュ)から始まるSSL、非SSL共有URLも除外する
 		if (($this->isSSL() || $ssl) 
-			&& !(strpos($_url, 'javascript') === 0)
-			&& !(strpos($_url, 'http') === 0)
+			&& !(preg_match('/^(javascript|https?|ftp|tel):/', $_url))
 			&& !(strpos($_url, '//') === 0)) {
 
 			$_url = preg_replace("/^\//", "", $_url);


### PR DESCRIPTION
BcBaserHelper::getLink() / BcAppHelper::url() の判別方法を同一にし、事項が増えたのでpregにしました。
ご確認おねがいします。