### PR TITLE
fix #16839 メールプラグインにてメールアドレスを複数指定した場合に発生するbugの修正

### DIFF
--- a/lib/Baser/Plugin/Mail/Controller/MailController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailController.php
@@ -490,6 +490,10 @@ class MailController extends MailAppController {
 
 		// 管理者に送信
 		if (!empty($adminMail)) {
+			// カンマ区切りで複数設定されていた場合先頭のアドレスをreplayToに利用
+			if (strpos($userMail, ',') !== false) {
+				list($userMail) = explode(',', $userMail);
+			}
 			$data['other']['mode'] = 'admin';
 			$options = array(
 				'fromName' => $mailContent['sender_name'],


### PR DESCRIPTION
イベント等で書き換えや、メールフォームのemailフィールドを特殊な作り方をしないと発生しないですが、フォーム利用者宛は配信され、管理者宛でエラーが出ます。

取込検討お願いします。