### PR TITLE
fix #16750 サブサイト管理の内容がコンテンツ管理に反映されない

### DIFF
--- a/lib/Baser/Model/ContentFolder.php
+++ b/lib/Baser/Model/ContentFolder.php
@@ -48,7 +48,7 @@ class ContentFolder extends AppModel {
 		} else {
 			$this->create($data);
 		}
-		if($this->save(null, ['callbacks' => false])) {
+		if($this->save(null, ['callbacks' => true])) {
 			return true;
 		} else {
 			return false;

--- a/lib/Baser/webroot/js/admin/libs/jquery.bcUtil.js
+++ b/lib/Baser/webroot/js/admin/libs/jquery.bcUtil.js
@@ -31,7 +31,6 @@
 	 * @param config
 	 */
 		init: function (config) {
-		p(config);
 			if(config.baseUrl !== undefined) {
 				$.bcUtil.baseUrl = config.baseUrl;
 			}


### PR DESCRIPTION
ContentFolderモデルのsaveSiteRootにて実行されているsaveでcallback => falseになっているが、
BcContentsBehaviorの処理が実行されないので、callback => true に変更しています。
よろしくお願いします！