### PR TITLE
fix #16894 ブログのアイキャッチ初期値override機能の提案

### DIFF
--- a/lib/Baser/Plugin/Blog/Config/setting.php
+++ b/lib/Baser/Plugin/Blog/Config/setting.php
@@ -71,3 +71,11 @@ $config['BcContents']['items']['Blog'] = [
 		]
 	]
 ];
+
+$config['Blog'] = [
+	// ブログアイキャッチサイズの初期値
+	'eye_catch_size_thumb_width' => 600,
+	'eye_catch_size_thumb_height' => 600,
+	'eye_catch_size_mobile_thumb_width' => 150,
+	'eye_catch_size_mobile_thumb_height' => 150,
+];

--- a/lib/Baser/Plugin/Blog/Model/BlogContent.php
+++ b/lib/Baser/Plugin/Blog/Model/BlogContent.php
@@ -282,10 +282,10 @@ class BlogContent extends BlogAppModel {
 		$data['BlogContent']['auth_captcha'] = 1;
 		$data['BlogContent']['tag_use'] = false;
 		$data['BlogContent']['status'] = false;
-		$data['BlogContent']['eye_catch_size_thumb_width'] = 600;
-		$data['BlogContent']['eye_catch_size_thumb_height'] = 600;
-		$data['BlogContent']['eye_catch_size_mobile_thumb_width'] = 150;
-		$data['BlogContent']['eye_catch_size_mobile_thumb_height'] = 150;
+		$data['BlogContent']['eye_catch_size_thumb_width'] = Configure::read("Blog.eye_catch_size_thumb_width");
+		$data['BlogContent']['eye_catch_size_thumb_height'] = Configure::read("Blog.eye_catch_size_thumb_height");
+		$data['BlogContent']['eye_catch_size_mobile_thumb_width'] = Configure::read("Blog.eye_catch_size_mobile_thumb_width");
+		$data['BlogContent']['eye_catch_size_mobile_thumb_height'] = Configure::read("Blog.eye_catch_size_mobile_thumb_height");
 		$data['BlogContent']['use_content'] = true;
 
 		return $data;


### PR DESCRIPTION
/app/Config/setting.php にて下記を追加して上書き可能
$config['Blog'] = [
// ブログアイキャッチサイズの初期値
'eye_catch_size_thumb_width' => 2000,
'eye_catch_size_thumb_height' => 2000,
'eye_catch_size_mobile_thumb_width' => 600,
'eye_catch_size_mobile_thumb_height' => 600,
];

ご検討ください！