### PR TITLE
fix #17191 メールプラグインにてローカルキャッシュさせないHTTPヘッダの追加

### DIFF
--- a/lib/Baser/Plugin/Mail/Controller/MailController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailController.php
@@ -167,6 +167,11 @@ class MailController extends MailAppController {
 		if ($this->dbDatas['mailContent']['MailContent']['widget_area']) {
 			$this->set('widgetArea', $this->dbDatas['mailContent']['MailContent']['widget_area']);
 		}
+		
+		// キャッシュ対策
+		header("Cache-Control: no-cache, no-store, must-revalidate");
+		header("Pragma: no-cache");
+		header("Expires: ". date(DATE_RFC1123, strtotime("-1 day")));
 	}
 
 /**

--- a/lib/Baser/Plugin/Mail/Controller/MailController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailController.php
@@ -169,9 +169,11 @@ class MailController extends MailAppController {
 		}
 		
 		// キャッシュ対策
-		header("Cache-Control: no-cache, no-store, must-revalidate");
-		header("Pragma: no-cache");
-		header("Expires: ". date(DATE_RFC1123, strtotime("-1 day")));
+		if (!isConsole()) {
+			header("Cache-Control: no-cache, no-store, must-revalidate");
+			header("Pragma: no-cache");
+			header("Expires: ". date(DATE_RFC1123, strtotime("-1 day")));
+		}
 	}
 
 /**


### PR DESCRIPTION
メールフォームではローカル（ブラウザ）にキャッシュさせないヘッダ情報を送信するよう変更しました。
よろしくおねがいします！