### PR TITLE
modify イベント Blog.Blog.beforeGetPostLink 内で、対象となるブログ記事データを参照できるようにするため

### DIFF
--- a/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
+++ b/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
@@ -200,9 +200,10 @@ class BlogHelper extends AppHelper {
 
 		// EVENT beforeGetPostLink
 		$event = $this->dispatchEvent('beforeGetPostLink', [
+			'post' => $post,
 			'title' => $title,
+			'options' => $options,
 			'url' => $url,
-			'options' => $options
 		], ['class' => 'Blog', 'plugin' => 'Blog']);
 		if ($event !== false) {
 			$options = ($event->result === null || $event->result === true) ? $event->data['options'] : $event->result;
@@ -212,8 +213,10 @@ class BlogHelper extends AppHelper {
 
 		// EVENT afterGetPostLink
 		$event = $this->dispatchEvent('afterGetPostLink', [
+			'post' => $post,
+			'title' => $title,
+			'out' => $out,
 			'url' => $url,
-			'out' => $out
 		], ['class' => 'Blog', 'plugin' => 'Blog']);
 		if ($event !== false) {
 			$out = ($event->result === null || $event->result === true) ? $event->data['out'] : $event->result;


### PR DESCRIPTION
- イベントに引っ掛けている箇所で、記事データ自体は参照できないため、参照できるようにするため
- 引き渡し順は、メソッドの並び順に合わせるため

ご検討よろしくお願いします。
