### PR TITLE
modify 前の記事、次の記事のリンク表示箇所が、getPostLink を通過するように調整

### DIFF
--- a/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
+++ b/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
@@ -589,11 +589,10 @@ class BlogHelper extends AppHelper {
 		$arrow = $htmlAttributes['arrow'];
 		unset($htmlAttributes['arrow']);
 		if ($prevPost) {
-			$no = $prevPost['BlogPost']['no'];
 			if (!$title) {
 				$title = $arrow . $prevPost['BlogPost']['name'];
 			}
-			$this->BcBaser->link($title, $this->request->params['Content']['url'] . 'archives/' .$no, $htmlAttributes);
+			echo $this->getPostLink($prevPost, $title, $htmlAttributes);
 		}
 	}
 
@@ -627,11 +626,10 @@ class BlogHelper extends AppHelper {
 		$arrow = $htmlAttributes['arrow'];
 		unset($htmlAttributes['arrow']);
 		if ($nextPost) {
-			$no = $nextPost['BlogPost']['no'];
 			if (!$title) {
 				$title = $nextPost['BlogPost']['name'] . $arrow;
 			}
-			$this->BcBaser->link($title, $this->request->params['Content']['url'] . 'archives/' . $no, $htmlAttributes);
+			echo $this->getPostLink($nextPost, $title, $htmlAttributes);
 		}
 	}
 	
@@ -1061,9 +1059,8 @@ class BlogHelper extends AppHelper {
 		// 毎秒抽出条件が違うのでキャッシュしない
 		$nextPost = $BlogPost->find('first', array(
 			'conditions' => $conditions,
-			'fields' => array('no', 'name'),
 			'order' => $order,
-			'recursive' => -1,
+			'recursive' => 0,
 			'cache' => false
 		));
 
@@ -1076,9 +1073,8 @@ class BlogHelper extends AppHelper {
 			// 毎秒抽出条件が違うのでキャッシュしない
 			$nextPost = $BlogPost->find('first', array(
 				'conditions' => $conditions,
-				'fields' => array('no', 'name'),
 				'order' => $order,
-				'recursive' => -1,
+				'recursive' => 0,
 				'cache' => false
 			));
 		}
@@ -1103,9 +1099,8 @@ class BlogHelper extends AppHelper {
 		// 毎秒抽出条件が違うのでキャッシュしない
 		$prevPost = $BlogPost->find('first', array(
 			'conditions' => $conditions,
-			'fields' => array('no', 'name'),
 			'order' => $order,
-			'recursive' => -1,
+			'recursive' => 0,
 			'cache' => false
 		));
 		if (empty($prevPost)) {
@@ -1117,9 +1112,8 @@ class BlogHelper extends AppHelper {
 			// 毎秒抽出条件が違うのでキャッシュしない
 			$prevPost = $BlogPost->find('first', array(
 				'conditions' => $conditions,
-				'fields' => array('no', 'name'),
 				'order' => $order,
-				'recursive' => -1,
+				'recursive' => 0,
 				'cache' => false
 			));
 		}


### PR DESCRIPTION
- ブログ記事のリンク表示の際は、beforeGetPostLink、afterGetPostLink を共通で通過するようにしておくため