### PR TITLE
fix #17275 長いファイル名のブログアイキャッチ画像が保存できない対応

### DIFF
--- a/lib/Baser/Plugin/Blog/Config/Schema/blog_posts.php
+++ b/lib/Baser/Plugin/Blog/Config/Schema/blog_posts.php
@@ -33,7 +33,7 @@ class BlogPostsSchema extends CakeSchema {
 		'publish_begin' => array('type' => 'datetime', 'null' => true, 'default' => null),
 		'publish_end' => array('type' => 'datetime', 'null' => true, 'default' => null),
 		'exclude_search' => array('type' => 'boolean', 'null' => true, 'default' => null),
-		'eye_catch' => array('type' => 'string', 'null' => true, 'default' => null, 'length' => 30),
+		'eye_catch' => array('type' => 'text', 'null' => true, 'default' => null),
 		'created' => array('type' => 'datetime', 'null' => true, 'default' => null),
 		'modified' => array('type' => 'datetime', 'null' => true, 'default' => null),
 		'indexes' => array('PRIMARY' => array('column' => 'id', 'unique' => 1)),


### PR DESCRIPTION
下記チケット対応分となります。
テーブル作成時のカラムの型をVARCHAR(30)からTEXTへ変更致しました。
http://project.e-catchup.jp/issues/17275

宜しくお願い致します。