### PR TITLE
ホスト・ゲスト間の共有ディレクトリをマウントした後にhttpdを起動するように追記

### DIFF
--- a/Vagrantfile.default
+++ b/Vagrantfile.default
@@ -185,6 +185,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     chef.add_recipe "basercms"
   end
 
+	# ホスト・ゲスト間の共有ディレクトリをマウントした後にhttpdを起動
+	config.vm.provision "shell", run: "always", inline: <<-SHELL
+		sudo /etc/init.d/httpd start
+	SHELL
+	
   # Vagrant環境の使い方は「/vagrant_cookbooks/readme.txt」をご覧ください
 
 end


### PR DESCRIPTION
プロビジョニング後、2回目以降の`vagrant up`で httpd が起動に失敗します（Windows環境にて発生）。
共有ディレクトリマウント前に httpd 起動を試みて失敗しているようなので、マウント後に再度 httpd を起動するよう追記しました。

レビューおねがいいたします。