### PR TITLE
PHP7.1でのCUIインストール時に文字列に対する配列アクセスの警告が出るのを修正

### DIFF
--- a/lib/Baser/Model/Behavior/BcUploadBehavior.php
+++ b/lib/Baser/Model/Behavior/BcUploadBehavior.php
@@ -48,9 +48,9 @@ class BcUploadBehavior extends ModelBehavior {
 /**
  * 保存ディレクトリ
  * 
- * @var string
+ * @var string[]
  */
-	public $savePath = '';
+	public $savePath = [];
 
 /**
  * 設定


### PR DESCRIPTION
<img width="1193" alt="2017-06-11 1 06 35" src="https://user-images.githubusercontent.com/2157593/27004678-3f10397a-4e48-11e7-9032-365b8e19b3ec.png">
