### PR TITLE
#17708 ブログ詳細のプレビューのURLが「ブログ名//archives/」になってしまう問題の修正

### DIFF
--- a/lib/Baser/Plugin/Blog/View/BlogPosts/admin/form.php
+++ b/lib/Baser/Plugin/Blog/View/BlogPosts/admin/form.php
@@ -17,7 +17,7 @@ if($this->request->params['Site']['use_subdomain']) {
 	$targetSite = BcSite::findByUrl($this->request->params['Content']['url']);
 	$previewUrl = $targetSite->getPureUrl($this->request->params['Content']['url'] . 'archives/' . $this->BcForm->value('BlogPost.no')) . '?host=' . $targetSite->host;
 } else {
-	$previewUrl = $this->request->params['Content']['url'] . '/archives/' . $this->BcForm->value('BlogPost.no');
+	$previewUrl = $this->request->params['Content']['url'] . 'archives/' . $this->BcForm->value('BlogPost.no');
 }
 $this->BcBaser->css('admin/ckeditor/editor', array('inline' => true));
 $statuses = array(0 => '非公開', 1 => '公開');


### PR DESCRIPTION
lib/Baser/Plugin/Blog/View/BlogPosts/admin/form.phpの/archive/をarchive/に修正