### PR TITLE
fix #12056 ブログに公開している記事の総数を取得したい

### DIFF
--- a/lib/Baser/Plugin/Blog/Test/Case/View/Helper/BlogBaserHelperTest.php
+++ b/lib/Baser/Plugin/Blog/Test/Case/View/Helper/BlogBaserHelperTest.php
@@ -127,17 +127,17 @@ class BlogBaserHelperTest extends BaserTestCase {
 		$this->assertFalse(isset($blogs[0]['BlogContent']['post_count']));
 
 		// ソート順を変更
-		$options = array(
+		$options = [
 			'sort' => 'Content.id DESC',
 			'siteId' => 0
-		);
+		];
 		$blogs = $this->BcBaser->getBlogs('', $options);
 		$this->assertEquals(3, $blogs[0]['Content']['id']);
 
 		// 記事数を取得
-		$options = array(
+		$options = [
 			'postCount' => true,
-		);
+		];
 		$blogs = $this->BcBaser->getBlogs('', $options);
 		$this->assertEquals(3, $blogs[0]['BlogContent']['post_count']);
 		$this->assertEquals(0, $blogs[1]['BlogContent']['post_count']);

--- a/lib/Baser/Plugin/Blog/Test/Case/View/Helper/BlogBaserHelperTest.php
+++ b/lib/Baser/Plugin/Blog/Test/Case/View/Helper/BlogBaserHelperTest.php
@@ -123,6 +123,8 @@ class BlogBaserHelperTest extends BaserTestCase {
 		$blogs = $this->BcBaser->getBlogs();
 		$this->assertEquals(3, count($blogs));
 		$this->assertEquals(2, $blogs[0]['Content']['id']);
+		// デフォルトでは記事数を取得しない
+		$this->assertFalse(isset($blogs[0]['BlogContent']['post_count']));
 
 		// ソート順を変更
 		$options = array(
@@ -131,6 +133,14 @@ class BlogBaserHelperTest extends BaserTestCase {
 		);
 		$blogs = $this->BcBaser->getBlogs('', $options);
 		$this->assertEquals(3, $blogs[0]['Content']['id']);
+
+		// 記事数を取得
+		$options = array(
+			'postCount' => true,
+		);
+		$blogs = $this->BcBaser->getBlogs('', $options);
+		$this->assertEquals(3, $blogs[0]['BlogContent']['post_count']);
+		$this->assertEquals(0, $blogs[1]['BlogContent']['post_count']);
 
 		// ブログ指定 1つなので、配列に梱包されてない
 		$blogs = $this->BcBaser->getBlogs('news');

--- a/lib/Baser/Plugin/Blog/View/Helper/BlogBaserHelper.php
+++ b/lib/Baser/Plugin/Blog/View/Helper/BlogBaserHelper.php
@@ -296,7 +296,7 @@ class BlogBaserHelper extends AppHelper {
 		$postCountsData = $BlogPost->find('all', [
 			'fields' => [
 				'BlogPost.blog_content_id',
-				'COUNT(BlogPost.id) as `post_count`',
+				'COUNT(BlogPost.id) as post_count',
 			],
 			'conditions' => $conditions,
 			'group' => ['BlogPost.blog_content_id'],

--- a/lib/Baser/Plugin/Blog/View/Helper/BlogBaserHelper.php
+++ b/lib/Baser/Plugin/Blog/View/Helper/BlogBaserHelper.php
@@ -255,7 +255,7 @@ class BlogBaserHelper extends AppHelper {
 
 		// 公開記事数のカウントを追加
 		if ($options['postCount']) {
-			$datas = $this->_mergePostCountToBlogContentsData($datas);
+			$datas = $this->_mergePostCountToBlogsData($datas);
 		}
 
 		$contents = array();
@@ -279,15 +279,15 @@ class BlogBaserHelper extends AppHelper {
 /**
  * Blogの基本情報に公開記事数を追加する
  *
- * @param array $blogContentsData BlogContentのデータの配列
- * @return array Blogの基本情報
+ * @param array $blogsData Blogの基本情報の配列
+ * @return array
  */
-	private function _mergePostCountToBlogContentsData(array $blogContentsData) {
+	private function _mergePostCountToBlogsData(array $blogsData) {
 
 		/** @var BlogPost $BlogPost */
 		$BlogPost = ClassRegistry::init('Blog.BlogPost');
 
-		$blogContentIds = Hash::extract($blogContentsData, "{n}.BlogContent.id");
+		$blogContentIds = Hash::extract($blogsData, "{n}.BlogContent.id");
 		$conditions = array_merge(
 			['BlogPost.blog_content_id' => $blogContentIds],
 			$BlogPost->getConditionAllowPublish()
@@ -304,28 +304,28 @@ class BlogBaserHelper extends AppHelper {
 		]);
 
 		if(empty($postCountsData)) {
-			foreach ($blogContentsData as $blogContentData) {
-				$blogContentData['BlogContent']['post_count'] = 0;
+			foreach ($blogsData as $blogData) {
+				$blogData['BlogContent']['post_count'] = 0;
 			}
-			return $blogContentsData;
+			return $blogsData;
 		}
 
-		foreach($blogContentsData as $index => $blogContentData) {
+		foreach($blogsData as $index => $blogData) {
 
-			$blogContentId = $blogContentData['BlogContent']['id'];
+			$blogContentId = $blogData['BlogContent']['id'];
 			$countData = array_values(array_filter($postCountsData, function(array $data) use ($blogContentId) {
 				return $data['BlogPost']['blog_content_id'] == $blogContentId;
 			}));
 
 			if(empty($countData)) {
-				$blogContentsData[$index]['BlogContent']['post_count'] = 0;
+				$blogsData[$index]['BlogContent']['post_count'] = 0;
 				continue;
 			}
 
-			$blogContentsData[$index]['BlogContent']['post_count'] = intval($countData[0][0]['post_count']);
+			$blogsData[$index]['BlogContent']['post_count'] = intval($countData[0][0]['post_count']);
 		}
 
-		return $blogContentsData;
+		return $blogsData;
 	}
 
 

--- a/lib/Baser/Plugin/Blog/View/Helper/BlogBaserHelper.php
+++ b/lib/Baser/Plugin/Blog/View/Helper/BlogBaserHelper.php
@@ -289,19 +289,19 @@ class BlogBaserHelper extends AppHelper {
 
 		$blogContentIds = Hash::extract($blogContentsData, "{n}.BlogContent.id");
 		$conditions = array_merge(
-			array('BlogPost.blog_content_id' => $blogContentIds),
+			['BlogPost.blog_content_id' => $blogContentIds],
 			$BlogPost->getConditionAllowPublish()
 		);
 
-		$postCountsData = $BlogPost->find('all', array(
-			'fields' => array(
+		$postCountsData = $BlogPost->find('all', [
+			'fields' => [
 				'BlogPost.blog_content_id',
 				'COUNT(BlogPost.id) as `post_count`',
-			),
+			],
 			'conditions' => $conditions,
-			'group' => array('BlogPost.blog_content_id'),
+			'group' => ['BlogPost.blog_content_id'],
 			'recursive' => -1,
-		));
+		]);
 
 		if(empty($postCountsData)) {
 			foreach ($blogContentsData as $blogContentData) {


### PR DESCRIPTION
BlogBaserHelper::getBlogs()にオプションを追加
http://project.e-catchup.jp/issues/12056

公開記事数のカウントをBlogContent.post_countに追加

```
<?php var_dump($this->BcBaser->getBlogs('', ['postCount' => true])); ?>

array (size=2)
  'BlogContent' => 
    array (size=19)
      'id' => string '1' (length=1)
      'description' => string 'baserCMS inc. [デモ] の最新の情報をお届けします。' (length=65)
      'template' => string 'default' (length=7)
      'list_count' => string '10' (length=2)
      'list_direction' => string 'DESC' (length=4)
      'feed_count' => string '10' (length=2)
      'tag_use' => boolean true
      'comment_use' => string '1' (length=1)
      'comment_approve' => string '0' (length=1)
      'auth_captcha' => boolean true
      'widget_area' => string '2' (length=1)
      'use_content' => boolean true
      'created' => string '2016-08-07 23:10:38' (length=19)
      'modified' => null
      'post_count' => int 1 // ここに追加
      'eye_catch_size_thumb_width' => string '300' (length=3)
      'eye_catch_size_thumb_height' => string '300' (length=3)
      'eye_catch_size_mobile_thumb_width' => string '100' (length=3)
      'eye_catch_size_mobile_thumb_height' => string '100' (length=3)
  'Content' => 
    array (size=34)
```

カウント用のSQL

```sql
SELECT `BlogPost`.`blog_content_id`, COUNT(`BlogPost`.`id`) as `post_count` FROM `basercms`.`mysite_blog_posts` AS `BlogPost` WHERE `BlogPost`.`blog_content_id` IN (1, 2) AND `BlogPost`.`status` = '1' AND ((`BlogPost`.`publish_begin` <= '2017-07-08 19:04:10') OR (`BlogPost`.`publish_begin` IS NULL) OR (`BlogPost`.`publish_begin` = '0000-00-00 00:00:00')) AND ((`BlogPost`.`publish_end` >= '2017-07-08 19:04:10') OR (`BlogPost`.`publish_end` IS NULL) OR (`BlogPost`.`publish_end` = '0000-00-00 00:00:00')) GROUP BY `BlogPost`.`blog_content_id`
```