### PR TITLE
fix #17717 メールフォームの「半角数字」バリデーションが動作しない

### DIFF
--- a/lib/Baser/Plugin/Mail/Model/MailMessage.php
+++ b/lib/Baser/Plugin/Mail/Model/MailMessage.php
@@ -192,6 +192,12 @@ class MailMessage extends MailAppModel {
 							'message' => '形式が不正です。'
 					));
 				// 半角数字
+				} elseif ($mailField['valid'] == '/^(|[0-9]+)$/') {
+					$this->validate[$mailField['field_name']] = array(
+							'rule' => '/^(|[0-9]+)$/',
+							'message' => '半角数字で入力してください。'
+				);
+				// 半角数字（入力必須）
 				} elseif ($mailField['valid'] == '/^([0-9]+)$/') {
 					$this->validate[$mailField['field_name']] = array(
 							'rule' => '/^([0-9]+)$/',


### PR DESCRIPTION
以下のチケットの件になります。
http://project.e-catchup.jp/issues/17717