### PR TITLE
BcPageHelper/testContent追加

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,7 @@
 	},
 	"require-dev": {
 		"phpunit/phpunit": "3.7.*",
-		"cakephp/debug_kit" : "2.2.*",
-		"mikey179/vfsStream": "v1.6.4"
+		"cakephp/debug_kit" : "2.2.*"
 	},
 	"bin": [
 		"lib/Cake/Console/cake"

--- a/lib/Baser/Plugin/Feed/Test/Case/Model/FeedTest.php
+++ b/lib/Baser/Plugin/Feed/Test/Case/Model/FeedTest.php
@@ -12,6 +12,11 @@
 
 App::uses('Feed', 'Feed.Model');
 
+/**
+ * Class FeedTest
+ *
+ * @property Feed $Feed
+ */
 class FeedTest extends BaserTestCase {
 
 	public $fixtures = array(

--- a/lib/Baser/Test/Case/Model/BcAppTest.php
+++ b/lib/Baser/Test/Case/Model/BcAppTest.php
@@ -198,10 +198,27 @@ class BcAppTest extends BaserTestCase {
 	}
 
 /**
- * データベースを初期化
+ * データベース初期化
+ *
+ * @param $pluginName
+ * @param $options
+ * @param $expected
+ *
+ * @dataProvider initDbDataProvider
+ *
+ * MEMO: pluginNameが実在する場合が未実装
  */
-	public function testInitDb() {
+	public function testInitDb($pluginName, $options, $expected) {
 		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+		$result = $this->BcApp->initDb($pluginName, $options);
+		$this->assertEquals($expected, $result);
+	}
+
+	public function initDbDataProvider() {
+		return array(
+			array('', [], true),
+			array('hoge', ['dbDataPattern' => true], 1)
+		);
 	}
 
 /**
@@ -210,9 +227,10 @@ class BcAppTest extends BaserTestCase {
 	public function testLoadSchema() {
 		$this->markTestIncomplete('このテストは、まだ実装されていません。');
 		$path = BASER_CONFIGS . 'Schema';
-		$this->BcApp->loadSchema('test', $path);
+		$result = $this->BcApp->loadSchema('test', $path);
+		$expected = true;
 		var_dump($result);
-		// $this->assertEquals($expect, $result);
+		 $this->assertEquals($expected, $result);
 	}
 
 /**
@@ -220,6 +238,7 @@ class BcAppTest extends BaserTestCase {
  */
 	public function testLoadCsv() {
 		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+		$result = $this->BcApp->loadCsv('test','test');
 	}
 
 /**

--- a/lib/Baser/Test/Case/View/Helper/BcWidgetAreaHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcWidgetAreaHelperTest.php
@@ -49,22 +49,33 @@ class BcWidgetAreaHelperTest extends BaserTestCase {
  * @param string $expected 期待値
  * @dataProvider showDataProvider
  *
- * MEMO: show()内のelement()の際、$noで指定したwidgetsが存在しないためエラー(1の場合 Elements/Widgets/text.ctp)
- * テスト中にファイルを準備する必要あり
+ * MEMO: $pathがわからないため保留
  */
-	public function testShow($no, $expected) {
+	public function testShow($fileName, $no, $expected) {
 		$this->markTestIncomplete('このテストは、まだ実装されていません。');
-		ob_start();
-		$this->BcWidgetArea->show($no);
-		$result = ob_get_clean();
+		$path = APP . 'Elements/widgets/' . $fileName . '.ctp';
+		$fh = fopen($path, 'w');
+		fwrite($fh, '東京' . PHP_EOL . '埼玉' . PHP_EOL . '大阪' . PHP_EOL);
+		fclose($fh);
 
+		ob_start();
+		//エラーでファイルが残留するため,tryで確実に削除を実行
+		try {
+			$this->BcWidgetArea->show($no);
+		}catch (Exception $e) {
+			echo 'error: ',  $e->getMessage(), "\n";
+		}
+		$result = ob_get_clean();
+		unlink($path);
+
+		pr($result);
 		$this->assertEquals($expected, $result);
 	}
 
 	public function showDataProvider() {
 		return array(
-			array(1, ''),
-			array(2, '')
+			array('test', 1, ''),
+			array('test', 2, '')
 		);
 	}
 


### PR DESCRIPTION
vfsStreamをcomposerから削除
BcPageHelperTest/testContentをvfsStreamからphpの標準システムに変更しました。

他開発中のもので、スキップしています。

先程travisが通らなかったので二度目