### PR TITLE
#17839 コンテンツ管理でルートフォルダの編集で「保存」を押すとエラーの修正

### DIFF
--- a/lib/Baser/Model/Content.php
+++ b/lib/Baser/Model/Content.php
@@ -762,7 +762,7 @@ class Content extends AppModel {
 		if(array_key_exists('self_publish_end', $data['Content'])) {
 			$data['Content']['publish_end'] = $data['Content']['self_publish_end'];
 		}
-		if($data['Content']['parent_id']) {
+		if(!empty($data['Content']['parent_id'])) {
 			$parent = $this->find('first', [
 				'fields' => ['name', 'status', 'publish_begin', 'publish_end'], 
 				'conditions' => ['Content.id' => $data['Content']['parent_id']], 


### PR DESCRIPTION
4.0.5のコンテンツ管理でルートフォルダの編集で「保存」を押すとエラー
該当箇所
 [CORE/Baser/Model/Content.php, line 765]
if($data['Content']['parent_id']) {

変更後
if(!empty($data['Content']['parent_id'])) {
