### PR TITLE
#17840

### DIFF
--- a/lib/Baser/View/Helper/BcBaserHelper.php
+++ b/lib/Baser/View/Helper/BcBaserHelper.php
@@ -1074,6 +1074,7 @@ class BcBaserHelper extends AppHelper {
 			$options = array();
 		}
 
+		$url = preg_replace('/^' . preg_quote($this->request->base, '/') . '\//', '/', $url);
 		$out = $this->BcHtml->link($title, $url, $options, $confirmMessage);
 
 		/*** afterGetLink ***/


### PR DESCRIPTION
編集管理画面の上部黒帯、「公開ページ」ボタンをクリックでNot Foundの修正

lib/Baser/View/Helper/BcBaserHelper.php
の
$out = $this->BcHtml->link($title, $url, $options, $confirmMessage);#1075
で引数「$url」にサブディレクトリ「/sub/」まで含まれていることが原因のようです。
こちらサブディレクトリ「/sub/」の箇所を「/」に置換する処理を追加すると正常に動作するようですのでその用に修正しております。

宜しくお願い致します。