### PR TITLE
fix #17728 システム管理からメール送信テストを行った後にシステム設定を保存するとCSRFエラーが発生

### DIFF
--- a/lib/Baser/webroot/js/admin/libs/jquery.bcToken.js
+++ b/lib/Baser/webroot/js/admin/libs/jquery.bcToken.js
@@ -88,6 +88,7 @@
 				$.bcUtil.ajax($.baseUrl + this.url, function(result) {
 					$.bcToken.key = result;
 					$.bcToken.requesting = false;
+					$('input[name="data[_Token][key]"]').val($.bcToken.key);
 				}, $.extend(true, {}, config)).done(function() {
 					if(callback) {
 						callback();

--- a/lib/Baser/webroot/js/admin/site_configs/form.js
+++ b/lib/Baser/webroot/js/admin/site_configs/form.js
@@ -68,7 +68,6 @@ $(function(){
 			return false;
 		}
 		$.bcToken.check(function(){
-			$("#SiteConfigFormForm").append($.bcToken.getHiddenToken());
 			$.ajax({
 				type: 'POST',
 				url: $.baseUrl + '/' + $.bcUtil.adminPrefix + '/site_configs/check_sendmail',


### PR DESCRIPTION
* ページ内のすべてのCSRFトークンの値を更新するように修正
* app/webrootにコピーされたものを修正しないと直らない。どうするか