### PR TITLE
fix #14132 [BLOG] 同一名称カテゴリ作成の回避

### DIFF
--- a/lib/Baser/Plugin/Blog/Model/BlogCategory.php
+++ b/lib/Baser/Plugin/Blog/Model/BlogCategory.php
@@ -68,7 +68,7 @@ class BlogCategory extends BlogAppModel {
 			['rule' => 'halfText',
 				'message' => 'ブログカテゴリ名は半角のみで入力してください。'],
 			['rule' => ['duplicateBlogCategory'],
-				'message' => '入力されたブログカテゴリは既に登録されています。'],
+				'message' => '入力されたブログカテゴリ名は既に登録されています。'],
 			['rule' => ['maxLength', 255],
 				'message' => 'ブログカテゴリ名は255文字以内で入力してください。']
 		],
@@ -77,7 +77,7 @@ class BlogCategory extends BlogAppModel {
 				'message' => "ブログカテゴリタイトルを入力してください。",
 				'required' => true],
 			['rule' => ['maxLength', 255],
-				'message' => 'ブログカテゴリ名は255文字以内で入力してください。']
+				'message' => 'ブログカテゴリタイトルは255文字以内で入力してください。']
 		]
 	];
 

--- a/lib/Baser/Plugin/Blog/Test/Case/Model/BlogCategoryTest.php
+++ b/lib/Baser/Plugin/Blog/Test/Case/Model/BlogCategoryTest.php
@@ -88,7 +88,7 @@ class BlogCategoryTest extends BaserTestCase {
 		$this->assertEquals('ブログカテゴリ名は255文字以内で入力してください。', current($this->BlogCategory->validationErrors['name']));
 
 		$this->assertArrayHasKey('title', $this->BlogCategory->validationErrors);
-		$this->assertEquals('ブログカテゴリ名は255文字以内で入力してください。', current($this->BlogCategory->validationErrors['title']));
+		$this->assertEquals('ブログカテゴリタイトルは255文字以内で入力してください。', current($this->BlogCategory->validationErrors['title']));
 	}
 
 	public function test桁数チェック正常系() {
@@ -135,7 +135,7 @@ class BlogCategoryTest extends BaserTestCase {
 		$this->assertFalse($this->BlogCategory->validates());
 
 		$this->assertArrayHasKey('name', $this->BlogCategory->validationErrors);
-		$this->assertEquals('入力されたブログカテゴリは既に登録されています。', current($this->BlogCategory->validationErrors['name']));
+		$this->assertEquals('入力されたブログカテゴリ名は既に登録されています。', current($this->BlogCategory->validationErrors['name']));
 	}
 
 /**

--- a/lib/Baser/Plugin/Blog/View/BlogPosts/admin/form.php
+++ b/lib/Baser/Plugin/Blog/View/BlogPosts/admin/form.php
@@ -220,7 +220,7 @@ $this->BcBaser->js('Blog.admin/blog_posts/form', false, array('id' => 'AdminBlog
 					<ul>
 						<li>URLに利用されます</li>
 						<li>半角のみで入力してください</li>
-						<li>空の場合はブログカテゴリタイトルから値が自動で設定されます</li>
+						<li>空の場合はカテゴリタイトルから値が自動で設定されます</li>
 					</ul>
 				</div>
 			</td>

--- a/lib/Baser/Plugin/Blog/webroot/js/admin/blog_posts/form.js
+++ b/lib/Baser/Plugin/Blog/webroot/js/admin/blog_posts/form.js
@@ -118,7 +118,12 @@ $(function(){
 	$("#BtnAddBlogCategory").click(function(){
 		$("#AddBlogCategoryForm").dialog({
 			height: 250,
-			width: 600
+			width: 600,
+			open: function() {
+				// ヘルプがダイアログ内で切れてしまうのを防ぐ
+				$(this).css('overflow', 'visible');
+				$(this.parentNode).css('overflow', 'visible');
+			}
 		});
 		return false;
 	});
@@ -131,11 +136,11 @@ $(function(){
 
 	$("#BtnBlogCategorySave").click(function() {
 
-		var category = $('#AddBlogCategoryForm [name="data[BlogCategory][name]"]').val();
+		var name = $('#AddBlogCategoryForm [name="data[BlogCategory][name]"]').val();
 		var title = $('#AddBlogCategoryForm [name="data[BlogCategory][title]"]').val();
 
-		if(!category) {
-			category = title;
+		if(!name) {
+			name = title;
 		}
 
 		$.bcToken.check(function(){
@@ -143,7 +148,7 @@ $(function(){
 				type: "POST",
 				url: $("#AddBlogCategoryUrl").html(),
 				data: {
-					'data[BlogCategory][name]': category,
+					'data[BlogCategory][name]': name,
 					'data[BlogCategory][title]': title,
 					'data[_Token][key]': $.bcToken.key
 				},
@@ -157,7 +162,7 @@ $(function(){
 						$("#BlogPostBlogCategoryId").append($('<option />').val(result).html(title));
 						$("#BlogPostBlogCategoryId").val(result);
 					} else {
-						alert('ブログカテゴリの追加に失敗しました。既に登録されていないか確認してください。');
+						alert('ブログカテゴリの追加に失敗しました。入力したブログカテゴリ名が既に登録されていないか確認してください。');
 					}
 					$("#AddBlogCategoryForm").dialog('close');
 				},


### PR DESCRIPTION
* ブログカテゴリ名のヘルプのバルーンがダイアログ内で見切れていた（overflow:hidden)ので修正
* ブログカテゴリ名が重複禁止であることがわかりやすいように
* バリデーションの表記揺れ・間違いを修正

<img width="846" alt="2017-07-22 13 47 07" src="https://user-images.githubusercontent.com/2157593/28488404-4d0685b8-6ee4-11e7-8e7b-28f38907ff37.png">
