### PR TITLE
#17845 メールのアクションも判定できるisAction()ヘルパーの追加

### DIFF
--- a/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
@@ -2065,5 +2065,47 @@ class BcBaserHelperTest extends BaserTestCase {
 	public function testGetParentFolder() {
 		$this->markTestIncomplete('このメソッドは、BcContentsHelper::getParent() をラッピングしているメソッドの為スキップします。');
 	}
+
+/**
+ * アクションを判定する(メールの場合BackとSubmitも判定する)
+ *
+* @param string $name :メールアクションは'index','Confirm','Back','Submit'(固定ページは'display')
+* @return bool or string
+*/
+	public function testIsAction() {
+		$this->BcBaser->request = $this->_getRequest('/contact/index');
+		$params = $this->BcBaser->isAction('index');
+		$this->assertEquals('index', $params);
+
+		$this->BcBaser->request = $this->_getRequest('/contact/submit');
+		$params = $this->BcBaser->isAction('submit');
+		$this->assertEquals('submit', $params);
+
+		$this->BcBaser->request = $this->_getRequest('/');
+		$params = $this->BcBaser->isAction('page');
+		$this->assertEquals(false, $params);	
+	}
+/**
+ * アクションを取得する(メールの場合BackとSubmitも取得する)
+ *
+ * @return string メール送信完了の時は 'Submit'を返す
+ */
+	public function testGetAction() {
+		$this->BcBaser->request = $this->_getRequest('/contact/index');
+		$params = $this->BcBaser->getAction();
+
+		$this->assertEquals('index', $params);
+
+		$this->BcBaser->request = $this->_getRequest('/contact/submit');
+		$params = $this->BcBaser->getAction();
+
+		$this->assertEquals('submit', $params);
+
+		$this->BcBaser->request = $this->_getRequest('/');
+		$params = $this->BcBaser->getAction();
+
+		$this->assertEquals('display', $params);
+		
+	}
 	
 }

--- a/lib/Baser/View/Helper/BcBaserHelper.php
+++ b/lib/Baser/View/Helper/BcBaserHelper.php
@@ -2704,4 +2704,32 @@ END_FLASH;
 		return $this->BcContents->getParent($id, $direct);
 	}
 
+/**
+* アクションを判定する(メールの場合BackとSubmitも判定する)
+*
+* @param string $name :メールアクションは'index','confirm','back','submit'(固定ページは'display')
+* @return bool or string 
+*/
+    public function isAction( $name ) {  
+		$getAction = $this->getAction();
+		if($name == $getAction) {
+			return $getAction;
+		} else {
+			return false;			
+		}
+	}
+
+/**
+* アクションを取得する(メールの場合BackとSubmitも取得する)
+*
+* @return string メール送信完了の時は 'Submit'を返す
+*/
+    public function getAction() {  
+		if(!empty($this->request->data['MailMessage'])) {
+			return $this->request->data['MailMessage']['mode'];
+		} else {
+			return $this->request->action;
+		} 
+	}
+	
 }


### PR DESCRIPTION
$this->request->actionと$this->request->data['MailMessage']['mode']を取得する
getAction()
と 判定用の
isAction()
ヘルパーの追加