### PR TITLE
fix #12537 デバッグモード２で表示されるテンプレート一覧の表示の調整

### DIFF
--- a/lib/Baser/View/Elements/template_dump.php
+++ b/lib/Baser/View/Elements/template_dump.php
@@ -11,7 +11,7 @@
  */
 
 /**
- * 利用しているテンプレート一覧
+ * 利用しているテンプレート一覧とビュー変数一覧
  *
  * デバッグモード２以上で表示
  */
@@ -19,13 +19,33 @@
  ?>
 
 
-<table class="cake-sql-log" id="cakeSqlLog_%s" summary="Cake SQL Log" cellspacing="0">
+<table class="cake-sql-log" id="baserTempaltes_%s" summary="baserCMS Templates" cellspacing="0">
 	<tr><th>Nr</th><th>Template</th></tr>
 <?php $count = 1 ?>
 <?php foreach($this->_viewFilesLog as $log): ?>
 	<tr>
 		<td><?php echo $count ?>.</td>
 		<td><?php echo $log ?></td>
+	</tr>
+	<?php $count++ ?>
+<?php endforeach ?>
+</table>
+
+
+<table class="cake-sql-log" id="baserViewVars_%s" summary="baserCMS View Variables" cellspacing="0" style="white-space: pre-wrap;">
+	<tr>
+		<th>Nr</th>
+		<th>View Variable</th>
+		<th>Type</th>
+		<th>Value</th>
+	</tr>
+<?php $count = 1 ?>
+<?php foreach($this->viewVars as $name => $value): ?>
+	<tr>
+		<td><?php echo $count ?>.</td>
+		<td><?php echo $name ?></td>
+		<td><?php echo is_object($value) ? get_class($value) : gettype($value) ?></td>
+		<td style="word-break: break-all"><?php echo h(print_r($value, true)) ?></td>
 	</tr>
 	<?php $count++ ?>
 <?php endforeach ?>


### PR DESCRIPTION
ビュー変数の一覧を追加

<img width="962" alt="2017-07-22 16 23 12" src="https://user-images.githubusercontent.com/2157593/28489269-a74f9af8-6efa-11e7-9b04-315c4e1d6953.png">
