### PR TITLE
#17846 getRelatedPosts()に　例外タグのオプションと複数のブログをまたぐかまたがないかのオプションを追加

### DIFF
--- a/lib/Baser/Plugin/Blog/Test/Case/View/Helper/BlogHelperTest.php
+++ b/lib/Baser/Plugin/Blog/Test/Case/View/Helper/BlogHelperTest.php
@@ -564,12 +564,12 @@ class BlogHelperTest extends BaserTestCase {
 
 		$post['BlogPost']['id'] = 7;
 		$post['BlogPost']['blog_content_id'] = 2;
-		$result = $this->Blog->getRelatedPosts($post);
+		$result = $this->Blog->getRelatedPosts($post, array('recursive'=>-1, 'limit'=>7, 'excludeTags'=>['新製品']));
 		$this->assertEmpty($result, '関連していない投稿を取得しています');
 
 		$post['BlogPost']['id'] = 2;
 		$post['BlogPost']['blog_content_id'] = 3;
-		$result = $this->Blog->getRelatedPosts($post);
+		$result = $this->Blog->getRelatedPosts($post, array('recursive'=>-1, 'limit'=>7, 'excludeTags'=>['人気記事'], 'isCross'=>false));
 		$this->assertEmpty($result, '関連していない投稿を取得しています');
 	}
 

--- a/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
+++ b/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
@@ -847,8 +847,10 @@ class BlogHelper extends AppHelper {
  * @param array $post ブログ記事
  * @param array $options オプション（初期値 : array()）
  *	- `recursive` : 関連データを取得する場合の階層（初期値 : -1）
- *	- `limit` : 件数（初期値 : 5）
+ *	-  `limit` : 件数（初期値 : 5）
  *	- `order` : 並び順指定（初期値 : BlogPost.posts_date DESC）
+ *	- `excludeTags` : （array）含めないタグ名
+ *	- `isCross` : (bool)現在の記事のブログから読み込む場合:false 全てのブログから読み込む場合:true
  * @return array
  */
 	public function getRelatedPosts($post, $options = array()) {
@@ -859,12 +861,16 @@ class BlogHelper extends AppHelper {
 		$options = array_merge(array(
 			'recursive' => -1,
 			'limit' => 5,
-			'order' => 'BlogPost.posts_date DESC'
+			'order' => 'BlogPost.posts_date DESC',
+			'excludeTags' => [],
+			'isCross' => true,
 			), $options);
 
 		$tagNames = array();
 		foreach ($post['BlogTag'] as $tag) {
-			$tagNames[] = urldecode($tag['name']);
+			if(!in_array($tag['name'], $options['excludeTags'])) {
+				 $tagNames[] = urldecode($tag['name']);
+			}
 		}
 		$BlogTag = ClassRegistry::init('Blog.BlogTag');
 		$tags = $BlogTag->find('all', array(
@@ -880,11 +886,15 @@ class BlogHelper extends AppHelper {
 		
 		$BlogPost = ClassRegistry::init('Blog.BlogPost');
 
-		$conditions = array(
-			array('BlogPost.id' => $ids),
-			array('BlogPost.id <>' => $post['BlogPost']['id']),
-			'BlogPost.blog_content_id' => $post['BlogPost']['blog_content_id']
-		);
+		$conditions = [
+			['BlogPost.id' => $ids],
+			['BlogPost.id <>' => $post['BlogPost']['id']],
+		];
+		
+		if(!$options['isCross']){
+			//isCrossではない場合、現在の記事のblog_content_idを$conditionsに追加
+			$conditions = $conditions + ['BlogPost.blog_content_id' => $post['BlogPost']['blog_content_id']];
+		}
 		$conditions = am($conditions, $BlogPost->getConditionAllowPublish());
 
 		// 毎秒抽出条件が違うのでキャッシュしない
@@ -898,7 +908,7 @@ class BlogHelper extends AppHelper {
 
 		return $relatedPosts;
 	}
-
+	
 /**
  * ブログのアーカイブタイプを取得する
  *

--- a/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
+++ b/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
@@ -863,7 +863,7 @@ class BlogHelper extends AppHelper {
 			'limit' => 5,
 			'order' => 'BlogPost.posts_date DESC',
 			'excludeTags' => [],
-			'isCross' => false,
+			'crossing' => false,
 			), $options);
 
 		$tagNames = array();

--- a/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
+++ b/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
@@ -863,7 +863,7 @@ class BlogHelper extends AppHelper {
 			'limit' => 5,
 			'order' => 'BlogPost.posts_date DESC',
 			'excludeTags' => [],
-			'isCross' => true,
+			'isCross' => false,
 			), $options);
 
 		$tagNames = array();


### PR DESCRIPTION
タグによる関連記事を表示する際に、特定のタグを例外にしたい。→option 'excludeTags' -string
複数のブログを持つサイトの場合、ブログをまたいで関連記事を表示するかどうか切り替えたい。→option 'isCross' -bool