### PR TITLE
#17885 ブログウィジェット 月別・年別アーカイブのリンクURLに現在のURLが入ってしまう問題の解消

### DIFF
--- a/lib/Baser/Config/theme/bc_sample/Elements/widgets/blog_monthly_archives.php
+++ b/lib/Baser/Config/theme/bc_sample/Elements/widgets/blog_monthly_archives.php
@@ -29,8 +29,8 @@ if ($view_count) {
 $data = $this->requestAction($actionUrl, ['entityId' => $id]);
 $postedDates = $data['postedDates'];
 $blogContent = $data['blogContent'];
-$ContentType = 'BlogContent';
-$blogUrl = $this->BcBaser->getContentByEntityId($id,$ContentType,'url');
+$contentType = 'BlogContent';
+$blogUrl = $this->BcBaser->getContentByEntityId($id, $contentType, 'url');
 if($this->request->params['Content']['url'] == $blogUrl){
 	$blogUrl = '';
 }

--- a/lib/Baser/Config/theme/bc_sample/Elements/widgets/blog_monthly_archives.php
+++ b/lib/Baser/Config/theme/bc_sample/Elements/widgets/blog_monthly_archives.php
@@ -30,7 +30,7 @@ $data = $this->requestAction($actionUrl, ['entityId' => $id]);
 $postedDates = $data['postedDates'];
 $blogContent = $data['blogContent'];
 $ContentType = 'BlogContent';
-$blogUrl = $this->BcBaser->getContentByID($id,$ContentType,'url');
+$blogUrl = $this->BcBaser->getContentByEntityId($id,$ContentType,'url');
 if($this->request->params['Content']['url'] == $blogUrl){
 	$blogUrl = '';
 }

--- a/lib/Baser/Config/theme/bc_sample/Elements/widgets/blog_monthly_archives.php
+++ b/lib/Baser/Config/theme/bc_sample/Elements/widgets/blog_monthly_archives.php
@@ -29,11 +29,6 @@ if ($view_count) {
 $data = $this->requestAction($actionUrl, ['entityId' => $id]);
 $postedDates = $data['postedDates'];
 $blogContent = $data['blogContent'];
-$contentType = 'BlogContent';
-$blogUrl = $this->BcBaser->getContentByEntityId($id, $contentType, 'url');
-if($this->request->params['Content']['url'] == $blogUrl){
-	$blogUrl = '';
-}
 $baseCurrentUrl = $this->params['Content']['name'] . '/archives/date/';
 ?>
 
@@ -58,7 +53,7 @@ $baseCurrentUrl = $this->params['Content']['name'] . '/archives/date/';
 					<?php $title = $postedDate['year'] . '年' . $postedDate['month'] . '月' ?>
 				<?php endif ?>
 				<li<?php echo $class ?>>
-					<?php $this->BcBaser->link($title, $blogUrl. $this->request->params['Content']['url'] . '/archives/date/' . $postedDate['year'] . '/' . $postedDate['month']) ?>
+					<?php $this->BcBaser->link($title, $this->BcBaser->getContentByEntityId($id, 'BlogContent', 'url') . '/archives/date/' . $postedDate['year'] . '/' . $postedDate['month']) ?>
 				</li>
 			<?php endforeach; ?>
 		</ul>

--- a/lib/Baser/Config/theme/bc_sample/Elements/widgets/blog_monthly_archives.php
+++ b/lib/Baser/Config/theme/bc_sample/Elements/widgets/blog_monthly_archives.php
@@ -29,6 +29,11 @@ if ($view_count) {
 $data = $this->requestAction($actionUrl, ['entityId' => $id]);
 $postedDates = $data['postedDates'];
 $blogContent = $data['blogContent'];
+$ContentType = 'BlogContent';
+$blogUrl = $this->BcBaser->getContentByID($id,$ContentType,'url');
+if($this->request->params['Content']['url'] == $blogUrl){
+	$blogUrl = '';
+}
 $baseCurrentUrl = $this->params['Content']['name'] . '/archives/date/';
 ?>
 
@@ -53,7 +58,7 @@ $baseCurrentUrl = $this->params['Content']['name'] . '/archives/date/';
 					<?php $title = $postedDate['year'] . '年' . $postedDate['month'] . '月' ?>
 				<?php endif ?>
 				<li<?php echo $class ?>>
-					<?php $this->BcBaser->link($title, $this->request->params['Content']['url'] . '/archives/date/' . $postedDate['year'] . '/' . $postedDate['month']) ?>
+					<?php $this->BcBaser->link($title, $blogUrl. $this->request->params['Content']['url'] . '/archives/date/' . $postedDate['year'] . '/' . $postedDate['month']) ?>
 				</li>
 			<?php endforeach; ?>
 		</ul>

--- a/lib/Baser/Config/theme/bc_sample/Elements/widgets/blog_yearly_archives.php
+++ b/lib/Baser/Config/theme/bc_sample/Elements/widgets/blog_yearly_archives.php
@@ -37,11 +37,6 @@ if ($view_count) {
 $data = $this->requestAction($actionUrl, ['entityId' => $id]);
 $postedDates = $data['postedDates'];
 $blogcontent = $data['blogContent'];
-$contentType = 'BlogContent';
-$blogUrl = $this->BcBaser->getContentByEntityId($id, $contentType, 'url');
-if($this->request->params['Content']['url'] == $blogUrl){
-	$blogUrl = '';
-}
 $baseCurrentUrl = $this->request->params['Content']['name'] . '/archives/date/';
 ?>
 
@@ -66,7 +61,7 @@ $baseCurrentUrl = $this->request->params['Content']['name'] . '/archives/date/';
 					<?php $title = $postedDate['year'] . '年' ?>
 				<?php endif ?>
 				<li<?php echo $class ?>>
-					<?php $this->BcBaser->link($title, $blogUrl. $this->request->params['Content']['url'] . '/archives/date/' . $postedDate['year']) ?>
+					<?php $this->BcBaser->link($title, $this->BcBaser->getContentByEntityId($id, 'BlogContent', 'url') . '/archives/date/' . $postedDate['year'] . '/' . $postedDate['month']) ?>
 				</li>
 			<?php endforeach; ?>
 		</ul>

--- a/lib/Baser/Config/theme/bc_sample/Elements/widgets/blog_yearly_archives.php
+++ b/lib/Baser/Config/theme/bc_sample/Elements/widgets/blog_yearly_archives.php
@@ -38,7 +38,7 @@ $data = $this->requestAction($actionUrl, ['entityId' => $id]);
 $postedDates = $data['postedDates'];
 $blogContent = $data['blogContent'];
 $ContentType = 'BlogContent';
-$blogUrl = $this->BcBaser->getContentByID($id, $ContentType, 'url');
+$blogUrl = $this->BcBaser->getContentByEntityId($id, $ContentType, 'url');
 if($this->request->params['Content']['url'] == $blogUrl){
 	$blogUrl = '';
 }

--- a/lib/Baser/Config/theme/bc_sample/Elements/widgets/blog_yearly_archives.php
+++ b/lib/Baser/Config/theme/bc_sample/Elements/widgets/blog_yearly_archives.php
@@ -61,7 +61,7 @@ $baseCurrentUrl = $this->request->params['Content']['name'] . '/archives/date/';
 					<?php $title = $postedDate['year'] . '年' ?>
 				<?php endif ?>
 				<li<?php echo $class ?>>
-					<?php $this->BcBaser->link($title, $this->BcBaser->getContentByEntityId($id, 'BlogContent', 'url') . '/archives/date/' . $postedDate['year'] . '/' . $postedDate['month']) ?>
+					<?php $this->BcBaser->link($title, $this->BcBaser->getContentByEntityId($id, 'BlogContent', 'url') . '/archives/date/' . $postedDate['year']) ?>
 				</li>
 			<?php endforeach; ?>
 		</ul>

--- a/lib/Baser/Config/theme/bc_sample/Elements/widgets/blog_yearly_archives.php
+++ b/lib/Baser/Config/theme/bc_sample/Elements/widgets/blog_yearly_archives.php
@@ -30,10 +30,18 @@ if ($limit) {
 }
 if ($view_count) {
 	$actionUrl .= '/1';
+} else {
+	$actionUrl .= '/0';	
 }
+
 $data = $this->requestAction($actionUrl, ['entityId' => $id]);
 $postedDates = $data['postedDates'];
 $blogContent = $data['blogContent'];
+$ContentType = 'BlogContent';
+$blogUrl = $this->BcBaser->getContentByID($id, $ContentType, 'url');
+if($this->request->params['Content']['url'] == $blogUrl){
+	$blogUrl = '';
+}
 $baseCurrentUrl = $this->request->params['Content']['name'] . '/archives/date/';
 ?>
 
@@ -58,7 +66,7 @@ $baseCurrentUrl = $this->request->params['Content']['name'] . '/archives/date/';
 					<?php $title = $postedDate['year'] . '年' ?>
 				<?php endif ?>
 				<li<?php echo $class ?>>
-					<?php $this->BcBaser->link($title, $this->request->params['Content']['url'] . '/archives/date/' . $postedDate['year']) ?>
+					<?php $this->BcBaser->link($title, $blogUrl. $this->request->params['Content']['url'] . '/archives/date/' . $postedDate['year']) ?>
 				</li>
 			<?php endforeach; ?>
 		</ul>

--- a/lib/Baser/Config/theme/bc_sample/Elements/widgets/blog_yearly_archives.php
+++ b/lib/Baser/Config/theme/bc_sample/Elements/widgets/blog_yearly_archives.php
@@ -36,9 +36,9 @@ if ($view_count) {
 
 $data = $this->requestAction($actionUrl, ['entityId' => $id]);
 $postedDates = $data['postedDates'];
-$blogContent = $data['blogContent'];
-$ContentType = 'BlogContent';
-$blogUrl = $this->BcBaser->getContentByEntityId($id, $ContentType, 'url');
+$blogcontent = $data['blogContent'];
+$contentType = 'BlogContent';
+$blogUrl = $this->BcBaser->getContentByEntityId($id, $contentType, 'url');
 if($this->request->params['Content']['url'] == $blogUrl){
 	$blogUrl = '';
 }

--- a/lib/Baser/Plugin/Blog/View/Elements/admin/widgets/blog_yearly_archives.php
+++ b/lib/Baser/Plugin/Blog/View/Elements/admin/widgets/blog_yearly_archives.php
@@ -22,6 +22,8 @@ $description = 'ブログの年別アーカイブー一覧を表示します。'
 <?php echo $this->BcForm->input($key . '.limit', array('type' => 'text', 'size' => 6, 'default' => null)) ?>&nbsp;件<br />
 <?php echo $this->BcForm->label($key . '.view_count', '記事数表示') ?>&nbsp;
 <?php echo $this->BcForm->input($key . '.view_count', array('type' => 'radio', 'options' => $this->BcText->booleanDoList(''), 'legend' => false, 'default' => 0)) ?><br />
+<?php echo $this->BcForm->label($key . '.start_month', '年度別の場合の開始月') ?>&nbsp;
+<?php echo $this->BcForm->input($key . '.start_month', array('type' => 'int', 'size' => 2, 'default' => 1)) ?>&nbsp;月<br />
 <?php echo $this->BcForm->label($key . '.blog_content_id', 'ブログ') ?>&nbsp;
 <?php echo $this->BcForm->input($key . '.blog_content_id', array('type' => 'select', 'options' => $this->BcForm->getControlSource('Blog.BlogContent.id'))) ?><br />
 <small>ブログページを表示している場合は、上記の設定に関係なく、対象ブログの年別アーカイブ一覧を表示します。</small>

--- a/lib/Baser/Plugin/Blog/View/Elements/widgets/blog_monthly_archives.php
+++ b/lib/Baser/Plugin/Blog/View/Elements/widgets/blog_monthly_archives.php
@@ -31,8 +31,8 @@ if ($view_count) {
 $data = $this->requestAction($actionUrl, ['entityId' => $id]);
 $postedDates = $data['postedDates'];
 $blogContent = $data['blogContent'];
-$ContentType = 'BlogContent';
-$blogUrl = $this->BcBaser->getContentByEntityId($id, $ContentType, 'url');
+$contentType = 'BlogContent';
+$blogUrl = $this->BcBaser->getContentByEntityId($id, $contentType, 'url');
 if($this->request->params['Content']['url'] == $blogUrl){
 	$blogUrl = '';
 }

--- a/lib/Baser/Plugin/Blog/View/Elements/widgets/blog_monthly_archives.php
+++ b/lib/Baser/Plugin/Blog/View/Elements/widgets/blog_monthly_archives.php
@@ -31,11 +31,6 @@ if ($view_count) {
 $data = $this->requestAction($actionUrl, ['entityId' => $id]);
 $postedDates = $data['postedDates'];
 $blogContent = $data['blogContent'];
-$contentType = 'BlogContent';
-$blogUrl = $this->BcBaser->getContentByEntityId($id, $contentType, 'url');
-if($this->request->params['Content']['url'] == $blogUrl){
-	$blogUrl = '';
-}
 $baseCurrentUrl = $this->params['Content']['name'] . '/archives/date/';
 ?>
 
@@ -60,7 +55,7 @@ $baseCurrentUrl = $this->params['Content']['name'] . '/archives/date/';
 					<?php $title = $postedDate['year'] . '年' . $postedDate['month'] . '月' ?>
 				<?php endif ?>
 				<li<?php echo $class ?>>
-					<?php $this->BcBaser->link($title, $blogUrl. $this->request->params['Content']['url'] . '/archives/date/' . $postedDate['year'] . '/' . $postedDate['month']) ?>
+					<?php $this->BcBaser->link($title, $this->BcBaser->getContentByEntityId($id, 'BlogContent', 'url') . '/archives/date/' . $postedDate['year'] . '/' . $postedDate['month']) ?>
 				</li>
 			<?php endforeach; ?>
 		</ul>

--- a/lib/Baser/Plugin/Blog/View/Elements/widgets/blog_monthly_archives.php
+++ b/lib/Baser/Plugin/Blog/View/Elements/widgets/blog_monthly_archives.php
@@ -31,6 +31,11 @@ if ($view_count) {
 $data = $this->requestAction($actionUrl, ['entityId' => $id]);
 $postedDates = $data['postedDates'];
 $blogContent = $data['blogContent'];
+$ContentType = 'BlogContent';
+$blogUrl = $this->BcBaser->getContentByID($id, $ContentType, 'url');
+if($this->request->params['Content']['url'] == $blogUrl){
+	$blogUrl = '';
+}
 $baseCurrentUrl = $this->params['Content']['name'] . '/archives/date/';
 ?>
 
@@ -55,7 +60,7 @@ $baseCurrentUrl = $this->params['Content']['name'] . '/archives/date/';
 					<?php $title = $postedDate['year'] . '年' . $postedDate['month'] . '月' ?>
 				<?php endif ?>
 				<li<?php echo $class ?>>
-					<?php $this->BcBaser->link($title, $this->request->params['Content']['url'] . '/archives/date/' . $postedDate['year'] . '/' . $postedDate['month']) ?>
+					<?php $this->BcBaser->link($title, $blogUrl. $this->request->params['Content']['url'] . '/archives/date/' . $postedDate['year'] . '/' . $postedDate['month']) ?>
 				</li>
 			<?php endforeach; ?>
 		</ul>

--- a/lib/Baser/Plugin/Blog/View/Elements/widgets/blog_monthly_archives.php
+++ b/lib/Baser/Plugin/Blog/View/Elements/widgets/blog_monthly_archives.php
@@ -32,7 +32,7 @@ $data = $this->requestAction($actionUrl, ['entityId' => $id]);
 $postedDates = $data['postedDates'];
 $blogContent = $data['blogContent'];
 $ContentType = 'BlogContent';
-$blogUrl = $this->BcBaser->getContentByID($id, $ContentType, 'url');
+$blogUrl = $this->BcBaser->getContentByEntityId($id, $ContentType, 'url');
 if($this->request->params['Content']['url'] == $blogUrl){
 	$blogUrl = '';
 }

--- a/lib/Baser/Plugin/Blog/View/Elements/widgets/blog_yearly_archives.php
+++ b/lib/Baser/Plugin/Blog/View/Elements/widgets/blog_yearly_archives.php
@@ -40,11 +40,6 @@ if ($view_count) {
 $data = $this->requestAction($actionUrl, ['entityId' => $id]);
 $postedDates = $data['postedDates'];
 $blogContent = $data['blogContent'];
-$contentType = 'BlogContent';
-$blogUrl = $this->BcBaser->getContentByEntityId($id, $contentType, 'url');
-if($this->request->params['Content']['url'] == $blogUrl){
-	$blogUrl = '';
-}
 $baseCurrentUrl = $this->request->params['Content']['name'] . '/archives/date/';
 ?>
 
@@ -69,7 +64,7 @@ $baseCurrentUrl = $this->request->params['Content']['name'] . '/archives/date/';
 					<?php $title = $postedDate['year'] . '年' ?>
 				<?php endif ?>
 				<li<?php echo $class ?>>
-					<?php $this->BcBaser->link($title, $blogUrl. $this->request->params['Content']['url'] . '/archives/date/' . $postedDate['year']) ?>
+					<?php $this->BcBaser->link($title, $this->BcBaser->getContentByEntityId($id, 'BlogContent', 'url') . '/archives/date/' . $postedDate['year'] . '/' . $postedDate['month']) ?>
 				</li>
 			<?php endforeach; ?>
 		</ul>

--- a/lib/Baser/Plugin/Blog/View/Elements/widgets/blog_yearly_archives.php
+++ b/lib/Baser/Plugin/Blog/View/Elements/widgets/blog_yearly_archives.php
@@ -40,8 +40,8 @@ if ($view_count) {
 $data = $this->requestAction($actionUrl, ['entityId' => $id]);
 $postedDates = $data['postedDates'];
 $blogContent = $data['blogContent'];
-$ContentType = 'BlogContent';
-$blogUrl = $this->BcBaser->getContentByEntityId($id,$ContentType,'url');
+$contentType = 'BlogContent';
+$blogUrl = $this->BcBaser->getContentByEntityId($id, $contentType, 'url');
 if($this->request->params['Content']['url'] == $blogUrl){
 	$blogUrl = '';
 }

--- a/lib/Baser/Plugin/Blog/View/Elements/widgets/blog_yearly_archives.php
+++ b/lib/Baser/Plugin/Blog/View/Elements/widgets/blog_yearly_archives.php
@@ -24,6 +24,7 @@ if (isset($blogContent)) {
 } else {
 	$id = $blog_content_id;
 }
+
 $actionUrl = '/blog/blog/get_posted_years/' . $id;
 if ($limit) {
 	$actionUrl .= '/' . $limit;
@@ -32,10 +33,18 @@ if ($limit) {
 }
 if ($view_count) {
 	$actionUrl .= '/1';
+} else {
+	$actionUrl .= '/0';	
 }
+
 $data = $this->requestAction($actionUrl, ['entityId' => $id]);
 $postedDates = $data['postedDates'];
 $blogContent = $data['blogContent'];
+$ContentType = 'BlogContent';
+$blogUrl = $this->BcBaser->getContentByID($id,$ContentType,'url');
+if($this->request->params['Content']['url'] == $blogUrl){
+	$blogUrl = '';
+}
 $baseCurrentUrl = $this->request->params['Content']['name'] . '/archives/date/';
 ?>
 
@@ -60,7 +69,7 @@ $baseCurrentUrl = $this->request->params['Content']['name'] . '/archives/date/';
 					<?php $title = $postedDate['year'] . '年' ?>
 				<?php endif ?>
 				<li<?php echo $class ?>>
-					<?php $this->BcBaser->link($title, $this->request->params['Content']['url'] . '/archives/date/' . $postedDate['year']) ?>
+					<?php $this->BcBaser->link($title, $blogUrl. $this->request->params['Content']['url'] . '/archives/date/' . $postedDate['year']) ?>
 				</li>
 			<?php endforeach; ?>
 		</ul>

--- a/lib/Baser/Plugin/Blog/View/Elements/widgets/blog_yearly_archives.php
+++ b/lib/Baser/Plugin/Blog/View/Elements/widgets/blog_yearly_archives.php
@@ -41,7 +41,7 @@ $data = $this->requestAction($actionUrl, ['entityId' => $id]);
 $postedDates = $data['postedDates'];
 $blogContent = $data['blogContent'];
 $ContentType = 'BlogContent';
-$blogUrl = $this->BcBaser->getContentByID($id,$ContentType,'url');
+$blogUrl = $this->BcBaser->getContentByEntityId($id,$ContentType,'url');
 if($this->request->params['Content']['url'] == $blogUrl){
 	$blogUrl = '';
 }

--- a/lib/Baser/Test/Case/View/Helper/BcContentsHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcContentsHelperTest.php
@@ -449,5 +449,35 @@ class BcContentsHelperTest extends BaserTestCase {
 			[99, false],
 		];
 	}
-
+/**
+ * エンティティIDからコンテンツの情報を取得
+ * getContentByID
+ * 
+ * @param string $ContentType コンテンツタイプ
+ * ('Page','MailContent','BlogContent','ContentFolder')
+ * @param int $id エンティティID
+ * @param string|bool $expect 期待値
+ * @dataProvider getContentByIDDataProvider
+ */	
+	public function testGetContentByID($expect, $id, $ContentType, $contValue) {
+//		var_dump($this->BcContents->getContentByID('13', 'Page'));
+		$result = $this->BcContents->getContentByID($id, $ContentType, $contValue);
+		$this->assertEquals($expect, $result);                       
+	}
+	
+	public function getContentByIDDataProvider() {
+		return [
+			// 存在するID（0~2）を指定した場合
+			['/news', '1', 'BlogContent', 'url'],
+			['/contact', '1', 'MailContent', 'url'],
+			['/index', '1', 'Page', 'url'],
+			['/service/', '4', 'ContentFolder', 'url'],
+			['/service/sub_service/sub_service_1', '14', 'Page', 'url'],
+			['サービス２', '12', 'Page', 'title'],
+			// 存在しないIDを指定した場合
+			[false, '5', 'BlogContent', 'name'],
+			//指定がおかしい場合
+			[false, '5', 'Blog', 'url'],
+		];
+	}
 }

--- a/lib/Baser/Test/Case/View/Helper/BcContentsHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcContentsHelperTest.php
@@ -451,21 +451,23 @@ class BcContentsHelperTest extends BaserTestCase {
 	}
 /**
  * エンティティIDからコンテンツの情報を取得
- * getContentByID
+ * getContentByEntityId
  * 
  * @param string $ContentType コンテンツタイプ
  * ('Page','MailContent','BlogContent','ContentFolder')
  * @param int $id エンティティID
+ * @param string $field 取得したい値
+ *  'name','url','title'など　初期値：Null 
+ *  省略した場合配列を取得
  * @param string|bool $expect 期待値
- * @dataProvider getContentByIDDataProvider
+ * @dataProvider getContentByEntityIdDataProvider
  */	
-	public function testGetContentByID($expect, $id, $ContentType, $contValue) {
-//		var_dump($this->BcContents->getContentByID('13', 'Page'));
-		$result = $this->BcContents->getContentByID($id, $ContentType, $contValue);
+	public function testgetContentByEntityId($expect, $id, $ContentType, $field) {
+		$result = $this->BcContents->getContentByEntityId($id, $ContentType, $field);
 		$this->assertEquals($expect, $result);                       
 	}
 	
-	public function getContentByIDDataProvider() {
+	public function getContentByEntityIdDataProvider() {
 		return [
 			// 存在するID（0~2）を指定した場合
 			['/news', '1', 'BlogContent', 'url'],

--- a/lib/Baser/Test/Case/View/Helper/BcContentsHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcContentsHelperTest.php
@@ -453,7 +453,7 @@ class BcContentsHelperTest extends BaserTestCase {
  * エンティティIDからコンテンツの情報を取得
  * getContentByEntityId
  * 
- * @param string $ContentType コンテンツタイプ
+ * @param string $contentType コンテンツタイプ
  * ('Page','MailContent','BlogContent','ContentFolder')
  * @param int $id エンティティID
  * @param string $field 取得したい値
@@ -462,8 +462,8 @@ class BcContentsHelperTest extends BaserTestCase {
  * @param string|bool $expect 期待値
  * @dataProvider getContentByEntityIdDataProvider
  */	
-	public function testgetContentByEntityId($expect, $id, $ContentType, $field) {
-		$result = $this->BcContents->getContentByEntityId($id, $ContentType, $field);
+	public function testgetContentByEntityId($expect, $id, $contentType, $field) {
+		$result = $this->BcContents->getContentByEntityId($id, $contentType, $field);
 		$this->assertEquals($expect, $result);                       
 	}
 	

--- a/lib/Baser/View/Helper/BcBaserHelper.php
+++ b/lib/Baser/View/Helper/BcBaserHelper.php
@@ -2701,10 +2701,11 @@ END_FLASH;
 	public function getParentFolder($id, $direct = true) {
 		return $this->BcContents->getParent($id, $direct);
 	}
+
 /**
  * エンティティIDからコンテンツの情報を取得
  *
- * @param string $ContentType コンテンツタイプ
+ * @param string $contentType コンテンツタイプ
  * ('Page','MailContent','BlogContent','ContentFolder')
  * @param int $id エンティティID
  * @param string $field 取得したい値
@@ -2712,9 +2713,9 @@ END_FLASH;
  *  省略した場合配列を取得
  * @return array or bool
  */
-	public function getContentByEntityId($id, $ContentType, $field = null){
-		$getContentByEntityId = $this->BcContents->getContentByEntityId($id,$ContentType, $field);
-		return $getContentByEntityId;	
+	public function getContentByEntityId($id, $contentType, $field = null){
+		$getContentByEntityId = $this->BcContents->getContentByEntityId($id,$contentType, $field);
+		return $getContentByEntityId;
 	}
-	
+
 }

--- a/lib/Baser/View/Helper/BcBaserHelper.php
+++ b/lib/Baser/View/Helper/BcBaserHelper.php
@@ -2714,8 +2714,7 @@ END_FLASH;
  * @return array or bool
  */
 	public function getContentByEntityId($id, $contentType, $field = null){
-		$getContentByEntityId = $this->BcContents->getContentByEntityId($id,$contentType, $field);
-		return $getContentByEntityId;
+		return $this->BcContents->getContentByEntityId($id,$contentType, $field);
 	}
 
 }

--- a/lib/Baser/View/Helper/BcBaserHelper.php
+++ b/lib/Baser/View/Helper/BcBaserHelper.php
@@ -2701,5 +2701,20 @@ END_FLASH;
 	public function getParentFolder($id, $direct = true) {
 		return $this->BcContents->getParent($id, $direct);
 	}
-
+/**
+ * エンティティIDからコンテンツの情報を取得
+ *
+ * @param string $ContentType コンテンツタイプ
+ * ('Page','MailContent','BlogContent','ContentFolder')
+ * @param int $id エンティティID
+ * @param string $contValue 取得したい値
+ *  'name','url','title'など　初期値：Null 
+ *  省略した場合配列を取得
+ * @return array or bool
+ */
+	public function getContentByID($id, $ContentType, $contValue = null){
+		$getContentByID = $this->BcContents->getContentByID($id,$ContentType, $contValue);
+		return $getContentByID;	
+	}
+	
 }

--- a/lib/Baser/View/Helper/BcBaserHelper.php
+++ b/lib/Baser/View/Helper/BcBaserHelper.php
@@ -2707,14 +2707,14 @@ END_FLASH;
  * @param string $ContentType コンテンツタイプ
  * ('Page','MailContent','BlogContent','ContentFolder')
  * @param int $id エンティティID
- * @param string $contValue 取得したい値
+ * @param string $field 取得したい値
  *  'name','url','title'など　初期値：Null 
  *  省略した場合配列を取得
  * @return array or bool
  */
-	public function getContentByID($id, $ContentType, $contValue = null){
-		$getContentByID = $this->BcContents->getContentByID($id,$ContentType, $contValue);
-		return $getContentByID;	
+	public function getContentByEntityId($id, $ContentType, $field = null){
+		$getContentByEntityId = $this->BcContents->getContentByEntityId($id,$ContentType, $field);
+		return $getContentByEntityId;	
 	}
 	
 }

--- a/lib/Baser/View/Helper/BcContentsHelper.php
+++ b/lib/Baser/View/Helper/BcContentsHelper.php
@@ -501,17 +501,17 @@ class BcContentsHelper extends AppHelper {
  * @param string $ContentType コンテンツタイプ
  * ('Page','MailContent','BlogContent','ContentFolder')
  * @param int $id エンティティID
- * @param string $contValue 取得したい値
+ * @param string $field 取得したい値
  *  'name','url','title'など　初期値：Null 
  *  省略した場合配列を取得
  * @return array or string or bool
  */
-	public function getContentByID($id, $ContentType, $contValue = null){
+	public function getContentByEntityId($id, $ContentType, $field = null){
 		$conditions = array_merge($this->_Content->getConditionAllowPublish(), ['type' => $ContentType, 'entity_id' => $id]);
 		$content = $this->_Content->find('first', ['conditions' => $conditions, 'cache' => false]);
 		if(!empty($content)){
-			if($contValue){
-				return $content ['Content'][$contValue];
+			if($field){
+				return $content ['Content'][$field];
 			} else {
 				return $content ['Content'];
 			}

--- a/lib/Baser/View/Helper/BcContentsHelper.php
+++ b/lib/Baser/View/Helper/BcContentsHelper.php
@@ -513,7 +513,7 @@ class BcContentsHelper extends AppHelper {
 			if($field){
 				return $content ['Content'][$field];
 			} else {
-				return $content ['Content'];
+				return $content;
 			}
 		} else {
 			return false;

--- a/lib/Baser/View/Helper/BcContentsHelper.php
+++ b/lib/Baser/View/Helper/BcContentsHelper.php
@@ -495,4 +495,28 @@ class BcContentsHelper extends AppHelper {
 		return true;
 	}
 	
+/**
+ * エンティティIDからコンテンツの情報を取得
+ *
+ * @param string $ContentType コンテンツタイプ
+ * ('Page','MailContent','BlogContent','ContentFolder')
+ * @param int $id エンティティID
+ * @param string $contValue 取得したい値
+ *  'name','url','title'など　初期値：Null 
+ *  省略した場合配列を取得
+ * @return array or string or bool
+ */
+	public function getContentByID($id, $ContentType, $contValue = null){
+		$conditions = array_merge($this->_Content->getConditionAllowPublish(), ['type' => $ContentType, 'entity_id' => $id]);
+		$content = $this->_Content->find('first', ['conditions' => $conditions, 'cache' => false]);
+		if(!empty($content)){
+			if($contValue){
+				return $content ['Content'][$contValue];
+			} else {
+				return $content ['Content'];
+			}
+		} else {
+					return false;		
+		}
+	}	
 }

--- a/lib/Baser/View/Helper/BcContentsHelper.php
+++ b/lib/Baser/View/Helper/BcContentsHelper.php
@@ -494,11 +494,11 @@ class BcContentsHelper extends AppHelper {
 		}
 		return true;
 	}
-	
+
 /**
  * エンティティIDからコンテンツの情報を取得
  *
- * @param string $ContentType コンテンツタイプ
+ * @param string $contentType コンテンツタイプ
  * ('Page','MailContent','BlogContent','ContentFolder')
  * @param int $id エンティティID
  * @param string $field 取得したい値
@@ -506,8 +506,8 @@ class BcContentsHelper extends AppHelper {
  *  省略した場合配列を取得
  * @return array or string or bool
  */
-	public function getContentByEntityId($id, $ContentType, $field = null){
-		$conditions = array_merge($this->_Content->getConditionAllowPublish(), ['type' => $ContentType, 'entity_id' => $id]);
+	public function getContentByEntityId($id, $contentType, $field = null){
+		$conditions = array_merge($this->_Content->getConditionAllowPublish(), ['type' => $contentType, 'entity_id' => $id]);
 		$content = $this->_Content->find('first', ['conditions' => $conditions, 'cache' => false]);
 		if(!empty($content)){
 			if($field){
@@ -516,7 +516,8 @@ class BcContentsHelper extends AppHelper {
 				return $content ['Content'];
 			}
 		} else {
-					return false;		
+			return false;
 		}
-	}	
+	}
+
 }


### PR DESCRIPTION
ブログウィジェット 月別・年別アーカイブ改修
**1、ブログウィジェット 月別・年別アーカイブのリンクURLに現在のURLが入ってしまう問題の解消**
トップページなどで月別・年別アーカイブを使用すると、「ブログのURL/archive/」とならなければならないものが「index/archive/」となってしまう問題の解消
・IDとコンテンツタイプから　コンテンツのURL等を取得できるメソッド「getContentByID($id, $ContentType, $contValue)」を作成し、
　blog_monthly_archives.phpとblog_yearly_archives.phpにて使用する

