### PR TITLE
fix #12497 メールフォームのフィールド名の前に半角空白が入ると保存できてしまうが、その後エラーが発生

### DIFF
--- a/lib/Baser/Plugin/Mail/Model/MailField.php
+++ b/lib/Baser/Plugin/Mail/Model/MailField.php
@@ -163,14 +163,14 @@ class MailField extends MailAppModel {
 
 /**
  * メールフィールドの値として正しい文字列か検証する
- * 半角英数-_\s
+ * 半角英数-_
  *
  * @param array $check
  * @return boolean
  */
 	public function halfTextMailField($check) {
 		$subject = $check[key($check)];
-		$pattern = "/^[a-zA-Z0-9-_\s]*$/";
+		$pattern = "/^[a-zA-Z0-9-_]*$/";
 		return !!(preg_match($pattern, $subject) === 1);
 	}
 


### PR DESCRIPTION
入力チェックは行っていましたが、空白を許可していたので、許可しないように変更しました。
よろしくお願いします！