### PR TITLE
#18185 認証プレフィックス機能でパスワードハッシャーの設定が効いていない

### DIFF
--- a/lib/Baser/Controller/Component/BcAuthConfigureComponent.php
+++ b/lib/Baser/Controller/Component/BcAuthConfigureComponent.php
@@ -121,6 +121,10 @@ class BcAuthConfigureComponent extends Component {
 		} elseif ($config['userScope']) {
 			$BcAuth->authenticate['Form']['scope'] = $config['userScope'];
 		}
+		// 認証プレフィックスによるパスワードハッシャー設定
+		if (isset($config['passwordHasher'])) {
+			$BcAuth->authenticate['Form']['passwordHasher'] = $config['passwordHasher'];
+		}
 
 		// セッション識別
 		// TODO 2013/05/27 ryuring


### PR DESCRIPTION
[fix] Authコンポーネントの設定箇所で認証プレフィックスにおけるパスワードハッシャーの設定を読み込むよう修正

http://project.e-catchup.jp/issues/18185

宜しくお願い致します。