### PR TITLE
fix #18273 管理画面のフッターの表示が不正確

### DIFF
--- a/lib/Baser/View/Layouts/admin/default.php
+++ b/lib/Baser/View/Layouts/admin/default.php
@@ -147,7 +147,7 @@
 
 				<!-- / #Wrap .clearfix --></div>
 
-<?php if (!empty($user)): ?>
+<?php if (!empty(BcUtil::loginUser())): ?>
 	<?php $this->BcBaser->footer([], ['cache' => ['key' => '_admin_footer']]) ?>
 <?php else: ?>
 	<?php $this->BcBaser->footer() ?>

--- a/lib/Baser/View/Layouts/admin/default.php
+++ b/lib/Baser/View/Layouts/admin/default.php
@@ -147,7 +147,11 @@
 
 				<!-- / #Wrap .clearfix --></div>
 
-<?php $this->BcBaser->footer([], ['cache' => ['key' => '_admin_footer']]) ?>
+<?php if (!empty($user)): ?>
+	<?php $this->BcBaser->footer([], ['cache' => ['key' => '_admin_footer']]) ?>
+<?php else: ?>
+	<?php $this->BcBaser->footer() ?>
+<?php endif ?>
 
 			<!-- / #Page --></div>
 


### PR DESCRIPTION
ログイン状態でない場合キャッシュを利用せずフッターを表示するよう修正しました。
宜しくお願い致します。