### PR TITLE
fix #18274 メールフォームの受信一覧にてCSVダウンロードボタンが２つ表示される

### DIFF
--- a/lib/Baser/Plugin/Mail/Controller/MailMessagesController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailMessagesController.php
@@ -107,6 +107,12 @@ class MailMessagesController extends MailAppController {
 		));
 		$this->set(compact('mailFields'));
 		$this->set(compact('messages'));
+
+		if ($this->RequestHandler->isAjax() || !empty($this->request->query['ajax'])) {
+			$this->render('ajax_index');
+			return;
+		}
+
 		$this->pageTitle = '受信メール一覧';
 		$this->help = 'mail_messages_index';
 	}


### PR DESCRIPTION
よろしくお願いします！