### PR TITLE
fix #15686 メールフォームの選択リストの保存値をキーとなる数値でなく選択した値そのものを保存するようにする

### DIFF
--- a/lib/Baser/Plugin/Mail/Config/update/4.1.0/updater.php
+++ b/lib/Baser/Plugin/Mail/Config/update/4.1.0/updater.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * MailMessage テーブルデータ更新
+ */
+ClassRegistry::flush();
+CakePlugin::load('Mail');
+$MailContent = ClassRegistry::init('Mail.MailContent');
+$mailContents = $MailContent->find('all', ['recursive' => 1]);
+App::uses('BcTextHelper', 'View/Helper');
+$BcText = new BcTextHelper(new View());
+$result = true;
+if ($mailContents) {
+	foreach ($mailContents as $content) {
+		$mailContentId = $content['MailContent']['id'];
+		$MailMessage = ClassRegistry::init('Mail.MailMessage');
+		$MailMessage->setup($mailContentId);
+		$types = Hash::combine($content['MailField'], '{n}.field_name', '{n}.type');
+		$newSources = Hash::combine($content['MailField'], '{n}.field_name', '{n}.source');
+		$mailMessages = $MailMessage->find('all');
+		foreach ($mailMessages as $message) {
+			foreach ($message['MailMessage'] as $key => $oldValue) {
+				if (isset($types[$key])) {
+					switch ($types[$key]) {
+						case 'radio':
+						case 'select':
+							if (isset($newSources[$key])) {
+								$sources = explode("|", $newSources[$key]);
+								$i = 0;
+								$oldSources = array();
+								foreach ($sources as $source) {
+									$i++;
+									$oldSources[$i] = $source;
+								}
+								if (isset($oldSources[$oldValue]) && $oldSources[$oldValue]) {
+									$message['MailMessage'][$key] = $oldSources[$oldValue];
+								} else {
+									$message['MailMessage'][$key] = $oldValue;
+								}
+							}
+							break;
+						case 'multi_check':
+							if (isset($newSources[$key])) {
+								$sources = explode("|", $newSources[$key]);
+								$i = 0;
+								$oldSources = array();
+								foreach ($sources as $source) {
+									$i++;
+									$oldSources[$i] = $source;
+								}
+								$newValues = array();
+								$oldValues = explode("|", $oldValue);
+								foreach ($oldValues as $value) {
+									if (isset($oldSources[$value]) && $oldSources[$value]) {
+										$newValues[] = $oldSources[$value];
+									} else {
+										$newValues[] = $value;
+									}
+								}
+								$message['MailMessage'][$key] = implode("|", $newValues);
+							}
+							break;
+						case 'pref':
+							$message['MailMessage'][$key] = $BcText->pref($oldValue);
+							break;
+						default:
+							break;
+					}
+				}
+			}
+			$MailMessage->set($message);
+			$result = $MailMessage->save(null, false);
+			if($result) {
+				$this->setUpdateLog('メールプラグイン mail_message_' . $mailContentId . 'テーブルのデータ更新に成功しました。');
+			} else {
+				$this->setUpdateLog('メールプラグイン mail_message_' . $mailContentId . 'テーブルのデータ更新に失敗しました。', true);
+			}
+		}
+	}
+}

--- a/lib/Baser/Plugin/Mail/Controller/MailController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailController.php
@@ -465,17 +465,8 @@ class MailController extends MailAppController {
 			// 件名にフィールドの値を埋め込む
 			// 和暦など配列の場合は無視
 			if (!is_array($value)) {
-				if ($mailField['MailField']['type'] == 'radio' || 
-					  $mailField['MailField']['type'] == 'select') {
-					$source = explode('|', $mailField['MailField']['source']);
-					if(!empty($value)){
-						$mailContent['subject_user'] = str_replace('{$' . $field . '}', $source[$value-1], $mailContent['subject_user']);
-						$mailContent['subject_admin'] = str_replace('{$' . $field . '}', $source[$value-1], $mailContent['subject_admin']);
-					}
-				} else {
-					$mailContent['subject_user'] = str_replace('{$' . $field . '}', $value, $mailContent['subject_user']);
-					$mailContent['subject_admin'] = str_replace('{$' . $field . '}', $value, $mailContent['subject_admin']);
-				}
+				$mailContent['subject_user'] = str_replace('{$' . $field . '}', $value, $mailContent['subject_user']);
+				$mailContent['subject_admin'] = str_replace('{$' . $field . '}', $value, $mailContent['subject_admin']);
 			}
 			if($mailField['MailField']['type'] == 'file' && $value) {
 				$attachments[] = WWW_ROOT . 'files' . DS . $settings['saveDir'] . DS . $value;

--- a/lib/Baser/Plugin/Mail/Test/Case/View/Helper/MaildataHelperTest.php
+++ b/lib/Baser/Plugin/Mail/Test/Case/View/Helper/MaildataHelperTest.php
@@ -70,9 +70,9 @@ class MaildataHelperTest extends BaserTestCase {
             ['select', 'hoge', '',''],
             ['select', 'hoge',  $options, '資料請求'],
             ['select', 'h', $options, ''],
-            ['pref', '35', '','山口県'],
-            ['pref', '0', '',''],
-            ['pref', '', '','都道府県'],
+            ['pref', '東京都', '','東京都'],
+            ['pref', '福岡県', '','福岡県'],
+            ['pref', '', '',''],
             //TODO 配列がemptyでhogeが返ってくるはずだが、配列がありhogeが返ってこない。問題はなし。
             ['check', 'hoge', '', ''],
             ['check', 'hoge', $options, '資料請求'],

--- a/lib/Baser/Plugin/Mail/View/Helper/MaildataHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MaildataHelper.php
@@ -66,7 +66,11 @@ class MaildataHelper extends BcTextHelper {
 				return '';
 
 			case 'pref':
-				$options = $this->prefList();
+				$prefs = $this->prefList();
+				$options = array();
+				foreach($prefs as $pref) {
+					$options[$pref] = $pref;
+				}
 				if (isset($options[$value])) {
 					return $options[$value];
 				}

--- a/lib/Baser/Plugin/Mail/View/Helper/MailfieldHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MailfieldHelper.php
@@ -61,10 +61,8 @@ class MailfieldHelper extends AppHelper {
 
 			if ($data['type'] != "check") {
 				$values = explode("|", $data['source']);
-				$i = 0;
 				foreach ($values as $value) {
-					$i++;
-					$source[$i] = $value;
+					$source[$value] = $value;
 				}
 
 				return $source;

--- a/lib/Baser/Plugin/Mail/View/Helper/MailformHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MailformHelper.php
@@ -57,7 +57,6 @@ class MailformHelper extends BcFreezeHelper {
 				unset($attributes['maxlength']);
 				unset($attributes['empty']);
 				$attributes['legend'] = false;
-				$attributes['div'] = true;
 				if (!empty($attributes['separator'])) {
 					$attributes['separator'] = $attributes['separator'];
 				} else {
@@ -92,15 +91,33 @@ class MailformHelper extends BcFreezeHelper {
 				unset($attributes['maxlength']);
 				unset($attributes['separator']);
 				unset($attributes['empty']);
-				$out = $this->prefTag($fieldName, null, $attributes);
+				$out = $this->prefTag($fieldName, null, $attributes, true);
 				break;
 
 			case 'autozip':
 				unset($attributes['separator']);
 				unset($attributes['rows']);
 				unset($attributes['empty']);
-				$address1 = $this->_name(array(), $options[1]);
-				$address2 = $this->_name(array(), $options[2]);
+				$count = 0;
+				foreach($options as $option) {
+					switch ($count) {
+						case 0:
+							$address1 = $this->_name(array(), $option);
+							break;
+						case 1:
+							$address2 = $this->_name(array(), $option);
+							break;
+						default:
+							break;
+					}
+					$count++;
+				}
+				if (!isset($address1['name'])) {
+					$address1['name'] = '';
+					$address2['name'] = '';
+				} elseif (!isset($address2['name'])) {
+					$address2['name'] = $address1['name'];
+				}
 				$attributes['onKeyUp'] = "AjaxZip3.zip2addr(this,'','{$address1['name']}','{$address2['name']}')";
 				$out = $this->Html->script('admin/vendors/ajaxzip3.js') . $this->text($fieldName, $attributes);
 				break;

--- a/lib/Baser/View/Helper/BcFormHelper.php
+++ b/lib/Baser/View/Helper/BcFormHelper.php
@@ -1237,11 +1237,24 @@ DOC_END;
  * @param string $fieldName Name attribute of the SELECT
  * @param mixed $selected Selected option
  * @param array $attributes Array of HTML options for the opening SELECT element
+ * @param array $convertKey true value = "value" / false value = "key"
  * @return string 都道府県用のSELECTタグ
  */
-	public function prefTag($fieldName, $selected = null, $attributes = array()) {
+	public function prefTag($fieldName, $selected = null, $attributes = array(), $convertKey = false) {
 
-		$options = $this->BcText->prefList();
+		$prefs = $this->BcText->prefList();
+		if ($convertKey) {
+			$options = array();
+			foreach($prefs as $key => $value) {
+				if ($key) {
+					$options[$value] = $value;
+				} else {
+					$options[$key] = $value;
+				}
+			}
+		} else {
+			$options = $prefs;
+		}
 		$attributes['value'] = $selected;
 		$attributes['empty'] = false;
 		return $this->select($fieldName, $options, $attributes);


### PR DESCRIPTION
よろしくお願いします！