### PR TITLE
fix #18290 「管理画面のフッターの表示が不正確」の修正がphp5.5以上の記載方法のため、動作確認ができない

### DIFF
--- a/lib/Baser/View/Layouts/admin/default.php
+++ b/lib/Baser/View/Layouts/admin/default.php
@@ -147,7 +147,8 @@
 
 				<!-- / #Wrap .clearfix --></div>
 
-<?php if (!empty(BcUtil::loginUser())): ?>
+<?php $bcUtilLoginUser = BcUtil::loginUser(); ?>
+<?php if (!empty($bcUtilLoginUser)): ?>
 	<?php $this->BcBaser->footer([], ['cache' => ['key' => '_admin_footer']]) ?>
 <?php else: ?>
 	<?php $this->BcBaser->footer() ?>


### PR DESCRIPTION
empty関数で中身が空かどうかチェックする場合、PHP5.5より前のバージョンでは、次のように関数の戻り値が空かどうかチェックするとエラーになる。

修正方法（）empty()の引数「BcUtil::loginUser()」を変数に入れる