### PR TITLE
fix #18293 php5.4の環境でバージョン4.0.6をインストールすると500エラーが発生する事象修正

### DIFF
--- a/lib/Baser/View/Layouts/admin/default.php
+++ b/lib/Baser/View/Layouts/admin/default.php
@@ -147,7 +147,10 @@
 
 				<!-- / #Wrap .clearfix --></div>
 
-<?php if (!empty(BcUtil::loginUser())): ?>
+<?php
+$login = BcUtil::loginUser();
+if (!empty($login)):
+?>
 	<?php $this->BcBaser->footer([], ['cache' => ['key' => '_admin_footer']]) ?>
 <?php else: ?>
 	<?php $this->BcBaser->footer() ?>


### PR DESCRIPTION
こちら管理画面のログインページでログイン状態かどうかを判定する処理が関数にネストされている為php5.4以前の環境で５００エラー発生するようです。
こちら解消しておりますのでご確認くださいませ。

お手数ですが宜しくお願い致します。