### PR TITLE
fix #18370 テーマ用初期データダウンロードのデータにテーマ配下のプラグインのデータが含まれない

### DIFF
--- a/lib/Baser/basics.php
+++ b/lib/Baser/basics.php
@@ -1038,7 +1038,10 @@ function getTableList() {
 	$pluginFiles = [];
 	foreach($plugins as $plugin) {
 		$path = null;
-		if (is_dir(APP . 'Plugin' . DS . $plugin . DS . 'Config' . DS . 'Schema')) {
+		$themePath = BASER_THEMES . Configure::read('BcSite.theme') . DS;
+		if (is_dir($themePath . 'Plugin' . DS . $plugin . DS . 'Config' . DS . 'Schema')) {
+			$path = $themePath . 'Plugin' . DS . $plugin . DS . 'Config' . DS . 'Schema';
+		}elseif (is_dir(APP . 'Plugin' . DS . $plugin . DS . 'Config' . DS . 'Schema')) {
 			$path = APP . 'Plugin' . DS . $plugin . DS . 'Config' . DS . 'Schema';
 		} elseif (is_dir(BASER_PLUGINS . $plugin . DS . 'Config' . DS . 'Schema')) {
 			$path = BASER_PLUGINS . $plugin . DS . 'Config' . DS . 'Schema';


### PR DESCRIPTION
以下の点について修正しています。
ご確認の程、よろしくお願いします。

http://project.e-catchup.jp/issues/18370
