### PR TITLE
fix #18498 ブログ記事プレビュー時、記事に紐付くブログカテゴリ、ブログタグ、ユーザ情報のみしか取得できない点を調整

### DIFF
--- a/lib/Baser/Plugin/Blog/Model/BlogPost.php
+++ b/lib/Baser/Plugin/Blog/Model/BlogPost.php
@@ -720,6 +720,12 @@ class BlogPost extends BlogAppModel {
 				$post['BlogTag'] = $tags;
 			}
 		}
+
+		// BlogPostキーのデータは作り直しているため、元データは削除して他のモデルキーのデータとマージする
+		unset($data['BlogPost']);
+		unset($data['BlogTag']); // プレビュー時に、フロントでの利用データの形式と異なるため削除
+		$post = Hash::merge($data, $post);
+
 		return $post;
 	}
 


### PR DESCRIPTION
ブログ記事のプレビュー時動作を調整してみました。
http://project.e-catchup.jp/issues/18498
よろしくお願いします。
