### PR TITLE
管理画面で現在のテーマから編集画面に飛ぶリンクを削除

### DIFF
--- a/lib/Baser/View/Elements/admin/themes/index_list.php
+++ b/lib/Baser/View/Elements/admin/themes/index_list.php
@@ -36,7 +36,6 @@ $(function(){
 			</div>
 			<p class="row-tools">
 				<?php $this->BcBaser->link($this->BcBaser->getImg('admin/icn_tool_manage.png', array('alt' => 'テンプレート編集', 'class' => 'btn')), array('controller' => 'theme_files', 'action' => 'index', $currentTheme['name']), array('title' => 'テンプレート編集')) ?>
-				<?php $this->BcBaser->link($this->BcBaser->getImg('admin/icn_tool_edit.png', array('alt' => 'テーマ情報設定', 'class' => 'btn')), array('action' => 'edit', $currentTheme['name']), array('title' => 'テーマ情報設定')) ?>
 				<?php $this->BcBaser->link($this->BcBaser->getImg('admin/icn_tool_copy.png', array('alt' => 'テーマコピー', 'class' => 'btn')), array('action' => 'ajax_copy', $currentTheme['name']), array('title' => 'テーマコピー', 'class' => 'btn-copy')) ?>
 			</p>
 		</div>


### PR DESCRIPTION
管理画面のテーマ選択画面では、選択できるテーマには編集や削除できるボタンがついているが、「現在のテーマ」の下側にも編集ボタンが残っていた。編集ボタンを押すと、編集画面に飛ばされるが、「編集」や「削除」といったボタンが存在しないため、編集を完了することのできない仕様になっていた。なので、編集画面へのリンクがある編集ボタンを削除。