### PR TITLE
特定の環境においてダッシュボードの読み込みに失敗する不都合を修正

### DIFF
--- a/lib/Baser/webroot/js/admin/dblogs/ajax_index.js
+++ b/lib/Baser/webroot/js/admin/dblogs/ajax_index.js
@@ -29,6 +29,7 @@ $ (function (){
 				$.bcUtil.showAlertMessage('処理に失敗しました。');
 			}
 		}, {
+			type: 'GET',
 			loaderType: 'inner',
 			loaderSelector: '#DblogList'
 		});

--- a/lib/Baser/webroot/js/admin/libs/jquery.bcDashboard.js
+++ b/lib/Baser/webroot/js/admin/libs/jquery.bcDashboard.js
@@ -18,6 +18,7 @@
 					$(selector).slideDown(500);
 				}
 			},{
+				'type': 'GET',
 				'loaderType': 'inner',
 				'loaderSelector': selector
 			});


### PR DESCRIPTION
特定の環境において、ajaxの「POSTメソッド」+「送信データが空」のリクエストでphpファイルを読み込む際にDeprecatedエラーが発生するため、ダッシュボードのページロード処理の修正を行っています。

ご対応をよろしくお願いします。