### PR TITLE
fix #18683 setMessage を複数利用できるようにする

### DIFF
--- a/lib/Baser/Controller/BcAppController.php
+++ b/lib/Baser/Controller/BcAppController.php
@@ -1529,22 +1529,24 @@ class BcAppController extends Controller {
  * @param bool $alert 警告かどうか
  * @param bool $saveDblog Dblogに保存するか
  * @param bool $setFlash flash message に保存するか
+ * @param array $options オプション ※FlashComponent の $_defaultConfig 参照
  * @return void
  */
-	public function setMessage($message, $alert = false, $saveDblog = false, $setFlash = true) {
+	public function setMessage($message, $alert = false, $saveDblog = false, $setFlash = true, $options = array()) {
 		if (!isset($this->Session)) {
 			return;
 		}
-		$class = 'notice-message';
+
+		$options = Hash::merge($this->Flash->_defaultConfig, ['params' => ['class' => 'notice-message']], $options);
+
 		if ($alert) {
-			$class = 'alert-message';
+			$options['params']['class'] = 'alert-message';
 		}
-		if($setFlash) {
-			$this->Flash->set($message, [
-				'element' => 'default',
-				'params' => ['class' => $class]
-			]);
+
+		if ($setFlash) {
+			$this->Flash->set($message, $options);
 		}
+
 		if ($saveDblog) {
 			$AppModel = ClassRegistry::init('AppModel');
 			$AppModel->saveDblog($message);

--- a/lib/Baser/View/Helper/BcBaserHelper.php
+++ b/lib/Baser/View/Helper/BcBaserHelper.php
@@ -720,10 +720,15 @@ class BcBaserHelper extends AppHelper {
  * @return void
  */
 	public function flash($key = 'flash') {
-		if ($this->Session->check('Message.' . $key)) {
-			echo '<div id="MessageBox">';
-			echo $this->Flash->render($key, ['escape' => false]);
-			echo '</div>';
+		$sessionMessageList = $this->Session->read('Message');
+		if ($sessionMessageList) {
+			foreach ($sessionMessageList as $messageKey => $sessionMessage) {
+				if ($this->Session->check('Message.' . $messageKey)) {
+					echo '<div id="MessageBox" class="message-box">';
+					echo $this->Flash->render($messageKey, ['escape' => false]);
+					echo '</div>';
+				}
+			}
 		}
 	}
 

--- a/lib/Baser/webroot/css/admin/contents.css
+++ b/lib/Baser/webroot/css/admin/contents.css
@@ -738,6 +738,26 @@ table.sub-menu{
 	color:#F23561;
 	background: #F7E9EC url(../../img/admin/warning.png) no-repeat 10px 13px;
 }
+
+.message-box .message {
+	padding:10px 10px 10px 36px;
+	margin:20px 0;
+	font-size:16px;
+    border-radius: 10px;
+    -webkit-border-radius: 10px;
+    -moz-border-radius: 10px;
+	font-weight:bold;
+}
+.message-box .message,
+.message-box .notice-message {
+	color:#5C8A01;
+	background: #EBF5E1 url(../../img/admin/icn_info.png) no-repeat 10px 13px;
+}
+.message-box .alert-message {
+	color:#F23561;
+	background: #F7E9EC url(../../img/admin/warning.png) no-repeat 10px 13px;
+}
+
 #Login #flashMessage {
     border-radius: 0px;
     -webkit-border-radius: 0px;


### PR DESCRIPTION
取込検討、どうかよろしくお願いします。
- setMessage を続けて2つ利用したい場合に、2つ目の内容でひとつ目が上書きされてしまうため
- キーを指定することで簡単に複数利用できるように調整
- 後方互換は保ち、過去のコードはそのまま利用できるように css 調整を入れた
