### PR TITLE
#18920 受信メール一覧で受信内容を丸めずに表示したい

### DIFF
--- a/lib/Baser/Plugin/Mail/View/Elements/admin/mail_messages/index_row.php
+++ b/lib/Baser/Plugin/Mail/View/Elements/admin/mail_messages/index_row.php
@@ -50,7 +50,7 @@
 				?>
 			<?php endif ?>
 		<?php endforeach ?>
-		<?php echo $this->Text->truncate(implode(',', $inData), 170) ?>
+		<?php echo implode(',', $inData) ?>
 	</td>
 	<td>
 		<?php if($fileExists): ?>


### PR DESCRIPTION
[modify] 受信メール一覧で受信内容を切り詰めずに表示するよう修正

http://project.e-catchup.jp/issues/18920
こちらユーザーからの要望となります。
宜しくお願い致します。