### PR TITLE
#18962 管理画面ブログ記事一覧でのSQLエラー

### DIFF
--- a/lib/Baser/Plugin/Blog/Controller/BlogPostsController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogPostsController.php
@@ -142,10 +142,8 @@ class BlogPostsController extends BlogAppController {
 		}
 
 		$conditions = $this->_createAdminIndexConditions($blogContentId, $this->request->data);
-		if ($this->passedArgs['sort'] == 'no') {
+		if ($this->passedArgs['sort'] !== 'BlogCategory.name') {
 			$order = 'BlogPost.' . $this->passedArgs['sort'];
-		} else {
-			$order = $this->passedArgs['sort'];
 		}
 		if ($order && $this->passedArgs['direction']) {
 			$order .= ' ' . $this->passedArgs['direction'];

--- a/lib/Baser/Plugin/Blog/Controller/BlogPostsController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogPostsController.php
@@ -142,7 +142,7 @@ class BlogPostsController extends BlogAppController {
 		}
 
 		$conditions = $this->_createAdminIndexConditions($blogContentId, $this->request->data);
-		if ($this->passedArgs['sort'] !== 'BlogCategory.name') {
+		if (strpos($this->passedArgs['sort'], '.') === false) {
 			$order = 'BlogPost.' . $this->passedArgs['sort'];
 		}
 		if ($order && $this->passedArgs['direction']) {


### PR DESCRIPTION
[fix] カテゴリ以外の並べ替えの際にモデル名を明示してカラム名を指定するよう修正

フォーラムに寄せられた不具合となります。
http://project.e-catchup.jp/issues/18962
お手数ですがこちらご確認いただけたら幸いです。