### PR TITLE
fix #19056 BcListTableHelper の rowClass メソッドで、指定したオプションが反映されない

### DIFF
--- a/lib/Baser/View/Helper/BcListTableHelper.php
+++ b/lib/Baser/View/Helper/BcListTableHelper.php
@@ -102,7 +102,7 @@ class BcListTableHelper extends AppHelper {
 			$classies = ['publish'];
 		}
 		if(!empty($options['class'])) {
-			$options = array_merge($classies, $options['class']);
+			$classies = array_merge($classies, $options['class']);
 		}
 
 		// EVENT BcListTable.rowClass


### PR DESCRIPTION
取込検討、よろしくお願いします。
