### PR TITLE
Helperに未実装テスト追加

### DIFF
--- a/lib/Baser/Test/Case/BcAllAuthTest.php
+++ b/lib/Baser/Test/Case/BcAllAuthTest.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * baserCMS :  Based Website Development Project <http://basercms.net>
+ * Copyright (c) baserCMS Users Community <http://basercms.net/community/>
+ *
+ * @copyright		Copyright (c) baserCMS Users Community
+ * @link			http://basercms.net baserCMS Project
+ * @package			Baser.Test.Case
+ * @since			baserCMS v 4.0.0
+ * @license			http://basercms.net/license/index.html
+ */
+
+/**
+ * run all baser configure tests
+ * 
+ * @package Baser.Test.Case
+ */
+class BcAllAuthTest extends CakeTestSuite {
+
+/**
+ * Suite define the tests for this suite
+ *
+ * @return CakeTestSuite
+ */
+	public static function suite() {
+		$suite = new CakeTestSuite('All Auth tests');
+		$suite->addTestDirectory(BASER_TEST_CASES . DS . 'Controller' . DS . 'Component' . DS . 'Auth' . DS);
+		return $suite;
+	}
+
+}

--- a/lib/Baser/Test/Case/BcAllTest.php
+++ b/lib/Baser/Test/Case/BcAllTest.php
@@ -29,6 +29,7 @@ class BcAllTest extends CakeTestSuite {
 
 		$suite->addTestFile($path . 'BcBasicsTest.php');
 //		$suite->addTestFile($path . 'BcAllConsoleTest.php');
+		$suite->addTestFile($path . 'BcAllAuthTest.php');
 		$suite->addTestFile($path . 'BcAllBehaviorsTest.php');
 //		$suite->addTestFile($path . 'BcAllCacheTest.php');
 		$suite->addTestFile($path . 'BcAllComponentsTest.php');
@@ -49,7 +50,7 @@ class BcAllTest extends CakeTestSuite {
 		$suite->addTestFile($path . 'BcAllNetworkTest.php');
 		$suite->addTestFile($path . 'BcAllPluginTest.php');
 //		$suite->addTestFile($path . 'BcAllUtilityTest.php');
-//		$suite->addTestFile($path . 'BcAllViewTest.php');
+		$suite->addTestFile($path . 'BcAllViewTest.php');
 //		$suite->addTestFile($path . 'BcAllI18nTest.php');
 		return $suite;
 	}

--- a/lib/Baser/Test/Case/BcAllViewTest.php
+++ b/lib/Baser/Test/Case/BcAllViewTest.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * baserCMS :  Based Website Development Project <http://basercms.net>
+ * Copyright (c) baserCMS Users Community <http://basercms.net/community/>
+ *
+ * @copyright		Copyright (c) baserCMS Users Community
+ * @link			http://basercms.net baserCMS Project
+ * @package			Baser.Test.Case
+ * @since			baserCMS v 4.0.0
+ * @license			http://basercms.net/license/index.html
+ */
+
+/**
+ * run all baser configure tests
+ * 
+ * @package Baser.Test.Case
+ */
+class BcAllViewTest extends CakeTestSuite {
+
+/**
+ * Suite define the tests for this suite
+ *
+ * @return CakeTestSuite
+ */
+	public static function suite() {
+		$suite = new CakeTestSuite('All View tests');
+		$suite->addTestDirectory(BASER_TEST_CASES . DS . 'View' . DS);
+		return $suite;
+	}
+
+}

--- a/lib/Baser/Test/Case/Controller/Component/Auth/BcNoPasswordHaserTest.php
+++ b/lib/Baser/Test/Case/Controller/Component/Auth/BcNoPasswordHaserTest.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * baserCMS :  Based Website Development Project <http://basercms.net>
+ * Copyright (c) baserCMS Users Community <http://basercms.net/community/>
+ *
+ * @copyright		Copyright (c) baserCMS Users Community
+ * @link			http://basercms.net baserCMS Project
+ * @package			Baser.Test.Case.Controller.Component
+ * @since			baserCMS v 3.0.0-beta
+ * @license			http://basercms.net/license/index.html
+ */
+App::uses('BcNoPasswordHasher', 'Controller/Auth/Component');
+App::uses('Controller', 'Controller');
+class BcNoPasswordHaserTest extends BaserTestCase {
+
+	public function setUp() {
+		parent::setUp();
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+	}
+
+	public function testHash() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function testCheck() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+}

--- a/lib/Baser/Test/Case/Controller/Component/BcAuthComponentTest.php
+++ b/lib/Baser/Test/Case/Controller/Component/BcAuthComponentTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * baserCMS :  Based Website Development Project <http://basercms.net>
+ * Copyright (c) baserCMS Users Community <http://basercms.net/community/>
+ *
+ * @copyright		Copyright (c) baserCMS Users Community
+ * @link			http://basercms.net baserCMS Project
+ * @package			Baser.Test.Case.Controller.Component
+ * @since			baserCMS v 3.0.0-beta
+ * @license			http://basercms.net/license/index.html
+ */
+App::uses('BcAuthComponent', 'Controller/Component');
+App::uses('Controller', 'Controller');
+class BcAuthComponentTest extends BaserTestCase {
+
+	public function setUp() {
+		parent::setUp();
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+	}
+
+	public function testDeleteSerial() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function testGetSerial() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function testSaveSerial() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function testSetSessionKey() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+	public function testLogin() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function testLogout() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+	public function testRelogin() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+}

--- a/lib/Baser/Test/Case/Controller/Component/BcContentsComponent.php
+++ b/lib/Baser/Test/Case/Controller/Component/BcContentsComponent.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * baserCMS :  Based Website Development Project <http://basercms.net>
+ * Copyright (c) baserCMS Users Community <http://basercms.net/community/>
+ *
+ * @copyright		Copyright (c) baserCMS Users Community
+ * @link			http://basercms.net baserCMS Project
+ * @package			Baser.Test.Case.Controller.Component
+ * @since			baserCMS v 3.0.0-beta
+ * @license			http://basercms.net/license/index.html
+ */
+App::uses('BcContentsComponent', 'Controller/Component');
+App::uses('Controller', 'Controller');
+
+/**
+ * BcContentComponentのテスト
+ */
+class BcContentsComponentTest extends BaserTestCase {
+	public function setUp() {
+		parent::setUp();
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+	}
+
+	public function testInitialize() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function testSetupAdmin() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function testSetupFront() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function testGetCrumbs() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function testGetContent() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function testBeforeRender() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function testSettingForm() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function testGetParentLayoutTemplate() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function testGetType() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+}

--- a/lib/Baser/Test/Case/Controller/Component/BcEmailConponentTest.php
+++ b/lib/Baser/Test/Case/Controller/Component/BcEmailConponentTest.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * baserCMS :  Based Website Development Project <http://basercms.net>
+ * Copyright (c) baserCMS Users Community <http://basercms.net/community/>
+ *
+ * @copyright		Copyright (c) baserCMS Users Community
+ * @link			http://basercms.net baserCMS Project
+ * @package			Baser.Test.Case.Controller.Component
+ * @since			baserCMS v 3.0.0-beta
+ * @license			http://basercms.net/license/index.html
+ */
+App::uses('BcEmailComponent', 'Controller/Component');
+App::uses('Controller', 'Controller');
+
+/**
+ * BcContentComponentのテスト
+ */
+class BcEmailComponentTest extends BaserTestCase {
+	public function setUp() {
+		parent::setUp();
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+	}
+
+	public function testSend() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function testMdFold() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+}

--- a/lib/Baser/Test/Case/Controller/Component/BcGmapsComponentTest.php
+++ b/lib/Baser/Test/Case/Controller/Component/BcGmapsComponentTest.php
@@ -73,6 +73,9 @@ class BcGmapsComponentTest extends BaserTestCase {
 		$this->assertEquals($expected, $result, 'APIのURLが正しくありません');
 	}
 
+	public function test_connect() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
 /**
  * getInfoLocation
  *
@@ -95,6 +98,15 @@ class BcGmapsComponentTest extends BaserTestCase {
 		$result = $this->BcGmaps->getInfoLocation('');
 		$this->assertFalse($result, 'getInfoLocationに空のアドレスにtrueが返ってきます');
 
+	}
+
+
+	public function testGetLatitude() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function testGetLongitude(){
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
 	}
 
 }

--- a/lib/Baser/Test/Case/Controller/Component/BcManagerComponentTest.php
+++ b/lib/Baser/Test/Case/Controller/Component/BcManagerComponentTest.php
@@ -76,6 +76,17 @@ class BcManagerComponentTest extends BaserTestCase {
 		unset($this->BcManager);
 	}
 
+	public function test_getDataSource() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function test_updateContents() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function test_updatePluginStatus() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
 
 /**
  * baserCMSのインストール
@@ -415,7 +426,11 @@ class BcManagerComponentTest extends BaserTestCase {
 		$this->markTestIncomplete('このテストは、まだ実装されていません。');
 
 	}
-	
+
+
+	public function testInitPlugin() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
 /**
  * システムデータを初期化する
  * 
@@ -658,6 +673,21 @@ class BcManagerComponentTest extends BaserTestCase {
  * @param array $dbConfig 
  */
 	public function testReset() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+
+	}
+
+	public function testResetPage() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+
+	}
+
+	public function testResetThema() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+
+	}
+
+	public function testEmptyFolder() {
 		$this->markTestIncomplete('このテストは、まだ実装されていません。');
 
 	}
@@ -922,6 +952,16 @@ class BcManagerComponentTest extends BaserTestCase {
 
 		$this->assertTrue($result, 'config.phpを読み込めません');
 	
+	}
+
+	public function testStartup() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+
+	}
+
+	public function testUninstallPlugin() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+
 	}
 
 }

--- a/lib/Baser/Test/Case/Controller/Component/BcReplacePrefixComponentTest.php
+++ b/lib/Baser/Test/Case/Controller/Component/BcReplacePrefixComponentTest.php
@@ -178,4 +178,8 @@ class BcReplacePrefixComponentTest extends BaserTestCase {
 
 	}
 
+	public function testInitialize() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
 }

--- a/lib/Baser/Test/Case/View/BcAppViewTest.php
+++ b/lib/Baser/Test/Case/View/BcAppViewTest.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * baserCMS :  Based Website Development Project <http://basercms.net>
+ * Copyright (c) baserCMS Users Community <http://basercms.net/community/>
+ *
+ * @copyright		Copyright (c) baserCMS Users Community
+ * @link			http://basercms.net baserCMS Project
+ * @package			Baser.Test.Case.Controller.Component
+ * @since			baserCMS v 3.0.0-beta
+ * @license			http://basercms.net/license/index.html
+ */
+App::uses('BcAppView', 'View');
+class BcAppViewTest extends BaserTestCase {
+
+	public function setUp() {
+		parent::setUp();
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+	}
+
+	public function testDispatchEvent() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function testEvaluate() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+}

--- a/lib/Baser/Test/Case/View/Helper/BcAppHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcAppHelperTest.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * baserCMS :  Based Website Development Project <http://basercms.net>
+ * Copyright (c) baserCMS Users Community <http://basercms.net/community/>
+ *
+ * @copyright		Copyright (c) baserCMS Users Community
+ * @link			http://basercms.net baserCMS Project
+ * @package			Baser.View.Helper
+ * @since			baserCMS v 0.1.0
+ * @license			http://basercms.net/license/index.html
+ */
+
+App::uses('BcAppView', 'View');
+
+/**
+ * ArrayHelper
+ *
+ * @package Baser.View.Helper
+ */
+class BcAppHelperTest extends BaserTestCase {
+	public function setUp() {
+		parent::setUp();
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+	}
+
+	public function test__construct() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function testAfterLayout() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function testDispatchEvent() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function testUrl() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function testWebroot() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+}

--- a/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
@@ -145,6 +145,14 @@ class BcBaserHelperTest extends BaserTestCase {
 		$this->assertEquals("会社沿革{$topTitle}", $this->BcBaser->getTitle());
 	}
 
+
+	public function testSetHomeTitle(){
+
+	}
+
+	public function testSetPageEditLink(){
+
+	}
 /**
  * meta タグのキーワードを設定する
  *
@@ -362,6 +370,14 @@ class BcBaserHelperTest extends BaserTestCase {
 		$this->expectOutputString('会社データ');
 		$this->BcBaser->setTitle('会社データ');
 		$this->BcBaser->contentsTitle();
+	}
+
+	public function testContentsMenu() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function testContentsName() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
 	}
 
 /**
@@ -1208,6 +1224,18 @@ class BcBaserHelperTest extends BaserTestCase {
 			['Default', '/s/about'],
 			['S', '/s/hoge'],	// 存在しないページ
 		];
+	}
+
+	public function testGetContentByEntityId() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function testGetContentCreatedDate() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function testGetContentModifiedDate() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
 	}
 
 /**
@@ -2101,5 +2129,80 @@ class BcBaserHelperTest extends BaserTestCase {
 	public function testIsContentsParentId() {
 		$this->markTestIncomplete('このメソッドは、BcContentsHelper::isContentsParentId() をラッピングしているメソッドの為スキップします。');
 	}
-	
+
+	public function test__call() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function test__construct() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function test_unsetIndexInContentsMenu() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function testAfterRender() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function testCurrentContents() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function testCurrentPrefix() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function testGetGlobalMenu() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function testGetGoogleMaps() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function testGetRelatedSiteLinks() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function testGetRoot() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function testGetSitemap() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function testGetSitePrefix() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function testGetSiteSearchForm() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function testGetSubMenu() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function testGetUpdateInfo() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function testGetWidgetArea() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function testRelatedSiteLinks() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function testUpdateInfo() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function testWebClipIcon() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
 }

--- a/lib/Baser/Test/Case/View/Helper/BcCkeditorHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcCkeditorHelperTest.php
@@ -70,4 +70,8 @@ class BcCkeditorHelperTest extends BaserTestCase {
 		];
 	}
 
+	public function test_build() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
 }

--- a/lib/Baser/Test/Case/View/Helper/BcContentsHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcContentsHelperTest.php
@@ -416,7 +416,8 @@ class BcContentsHelperTest extends BaserTestCase {
 	public function testGetContentFolderList() {
 		$this->markTestIncomplete('このメソッドは、モデルをラッピングしているメソッドの為スキップします。');
 	}
-	
+
+
 /**
  * サイトIDからサイトルートとなるコンテンツを取得する
  * 
@@ -501,5 +502,13 @@ class BcContentsHelperTest extends BaserTestCase {
 			[5, 2, false],
 			[6, 21, true]
 		];
+	}
+
+	public function test__construct(){
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+	public function test_getIconUrl(){
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
 	}
 }


### PR DESCRIPTION
・前コミット追加分のAuthテストを動かすためにBcAllAuthTestファイルを追加
・BcAppViewファイル追加のためにBcAllViewTestファイルを追加
上２つを有効化のためにBcAllTestに上２つをテスト対象に追加
・Helperにテストメソッドとファイルを追加