### PR TITLE
BcAppHelper/コンストラクタテスト追加

### DIFF
--- a/lib/Baser/Test/Case/View/Helper/BcAppHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcAppHelperTest.php
@@ -10,24 +10,34 @@
  * @license			http://basercms.net/license/index.html
  */
 
-App::uses('BcAppView', 'View');
+App::uses('View', 'View');
+App::uses('BcAppHelper', 'View/Helper');
+App::uses('BcHtmlHelper', 'View/Helper');
 
 /**
  * ArrayHelper
  *
  * @package Baser.View.Helper
+ * @property BcAppHelper $BcAppHelper
+ * @property BcHtmlHelper $BcHtmlHelper
+ * @property View $View
  */
 class BcAppHelperTest extends BaserTestCase {
 	public function setUp() {
 		parent::setUp();
+		$View = new View();
+		$this->BcHtmlHelper = new BcHtmlHelper($View);
 	}
 
 	public function tearDown() {
 		parent::tearDown();
 	}
 
+	/**
+	 * コンストラクタ
+	 */
 	public function test__construct() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+		$this->assertEquals('<input type="checkbox" name="%s[]"%s />&nbsp;', $this->BcHtmlHelper->_tags['checkboxmultiple'], "コンストラクタの結果が違います。");
 	}
 
 	public function testAfterLayout() {


### PR DESCRIPTION
コンストラクタのテスト追加です。
引数のViewがBcHtmlHelper以外はtagsに空が返ってくる仕様のようなので、そこだけ見てます

修正分：tags から _tags に変更