### PR TITLE
BcBaserHelperTestの不要テストコメントアウト

### DIFF
--- a/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
@@ -1851,19 +1851,10 @@ class BcBaserHelperTest extends BaserTestCase {
 
 /**
  * テーマのURLを出力する
- *
+ * BcBaserHelper:getThemeUrl()のラッパーの為、テスト不要
  * @return void
  */
-	public function testThemeUrl() {
-		$this->BcBaser->request = $this->_getRequest('/');
-		$this->BcBaser->request->webroot = '/';
-		$this->siteConfig['theme'] = 'nada-icons';
-		$expects = $this->BcBaser->request->webroot . 'theme' . '/' . $this->siteConfig['theme'] . '/';
-		ob_start();
-		$this->BcBaser->themeUrl();
-		$result = ob_get_clean();
-		$this->assertEquals($expects, $result);
-	}
+	public function testThemeUrl() {}
 
 /**
  * ベースとなるURLを取得する

--- a/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
@@ -544,16 +544,11 @@ class BcBaserHelperTest extends BaserTestCase {
 /**
  * baserCMSの設置フォルダを考慮したURLを出力する
  * 
- * BcBaserHelper::getUrl() をラッピングしているだけなので、最低限のテストのみ
+ * BcBaserHelper::getUrl() のラッパーの為、テスト不要
  *
  * @return void
  */
-	public function testUrl() {
-		$this->expectOutputString('/basercms/index.php/about');
-		Configure::write('App.baseUrl', '/basercms/index.php');
-		$this->BcBaser->request = $this->_getRequest('/');
-		$this->BcBaser->url('/about');
-	}
+	public function testUrl() {}
 
 /**
  * baserCMSの設置フォルダを考慮したURLを取得する
@@ -644,14 +639,11 @@ class BcBaserHelperTest extends BaserTestCase {
 /**
  * エレメントテンプレートを出力する
  * 
- * BcBaserHelper::getElement() をラッピングしているだけなので、最低限のテストのみ
+ * BcBaserHelper::getElement() をラッパーの為、テスト不要
  *
  * @return void
  */
-	public function testElement() {
-		$this->expectOutputRegex('/<div id="Footer">/s');
-		$this->BcBaser->element(('footer'));
-	}
+	public function testElement() {}
 
 /**
  * ヘッダーテンプレートを出力する
@@ -2143,10 +2135,9 @@ class BcBaserHelperTest extends BaserTestCase {
 
 /**
  * IDがコンテンツ自身の親のIDかを判定する
+ * BcContentsHelper::isContentsParentId()のラッパーなのでテスト不要
  */
-	public function testIsContentsParentId() {
-		$this->markTestIncomplete('このメソッドは、BcContentsHelper::isContentsParentId() をラッピングしているメソッドの為スキップします。');
-	}
+	public function testIsContentsParentId() {}
 
 	public function test__call() {
 		$this->markTestIncomplete('このテストは、まだ実装されていません。');

--- a/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
@@ -395,8 +395,9 @@ class BcBaserHelperTest extends BaserTestCase {
 /**
  * コンテンツを特定する文字列を出力する
  * BcBaserHelper::getContentsName() のラッパーの為、テスト不要
+ *
+ * public function testContentsName() {}
  */
-	public function testContentsName() {}
 
 /**
  * タイトルタグを出力する
@@ -543,12 +544,12 @@ class BcBaserHelperTest extends BaserTestCase {
 
 /**
  * baserCMSの設置フォルダを考慮したURLを出力する
- * 
  * BcBaserHelper::getUrl() のラッパーの為、テスト不要
  *
  * @return void
+ *
+ * public function testUrl() {}
  */
-	public function testUrl() {}
 
 /**
  * baserCMSの設置フォルダを考慮したURLを取得する
@@ -642,8 +643,9 @@ class BcBaserHelperTest extends BaserTestCase {
  * BcBaserHelper::getElement() をラッパーの為、テスト不要
  *
  * @return void
+ *
+ * public function testElement() {}
  */
-	public function testElement() {}
 
 /**
  * ヘッダーテンプレートを出力する
@@ -978,8 +980,9 @@ class BcBaserHelperTest extends BaserTestCase {
  * BcBaserHelper:getLink()のラッパーの為、テスト不要
  *
  * @return void
+ *
+ * public function testLink() {}
  */
-	public function testLink() {}
 
 /**
  * アンカータグを取得する
@@ -1237,8 +1240,9 @@ class BcBaserHelperTest extends BaserTestCase {
 /**
  * エンティティIDからコンテンツの情報を取得
  * BcContents:getContentByEntityId()のラッパーの為、テスト不要
+ *
+ * public function testGetContentByEntityId() {}
  */
-	public function testGetContentByEntityId() {}
 
 	public function testGetContentCreatedDate() {
 		$this->markTestIncomplete('このテストは、まだ実装されていません。');
@@ -1419,8 +1423,7 @@ class BcBaserHelperTest extends BaserTestCase {
 
 	public function testGetSitemap($siteId, $expected) {
 		$message = 'サイトマップを正しく出力できません';
-		$this->expectOutputRegex('/' . $expected . '/s', $message);
-		$this->BcBaser->getSitemap($siteId);
+		$this->assertRegExp('/' . $expected . '/s', $this->BcBaser->getSitemap($siteId));
 	}
 
 	public function getSitemapDataProvider() {
@@ -1433,8 +1436,9 @@ class BcBaserHelperTest extends BaserTestCase {
 
 /**
  * BcBaserHelper:getSitemapのラッパーの為、テスト不要
+ *
+ * public function testSitemap() {}
  */
-	public function testSitemap() {}
 
 /**
  * Flashを表示する
@@ -1611,10 +1615,7 @@ class BcBaserHelperTest extends BaserTestCase {
 	public function testGetWidgetArea($url, $no, $expected) {
 		App::uses('BlogHelper', 'Blog.View/Helper');
 		$this->BcBaser->request = $this->_getRequest($url);
-		ob_start();
-		$this->BcBaser->getWidgetArea($no);
-		$result = ob_get_clean();
-		$this->assertRegExp('/' . $expected . '/', $result);
+		$this->assertRegExp('/' . $expected . '/', $this->BcBaser->getWidgetArea($no));
 	}
 
 	public function getWidgetAreaDataProvider() {
@@ -1628,8 +1629,9 @@ class BcBaserHelperTest extends BaserTestCase {
 /**
  * ウィジェットエリアを出力する
  * BcBaserHelper:getWidgetAreaのラッパーの為、テスト不要
+ *
+ * public function testWidgetArea() {}
  */
-	public function testWidgetArea() {}
 
 /**
  * 指定したURLが現在のURLかどうか判定する
@@ -1853,8 +1855,9 @@ class BcBaserHelperTest extends BaserTestCase {
  * テーマのURLを出力する
  * BcBaserHelper:getThemeUrl()のラッパーの為、テスト不要
  * @return void
+ *
+ * public function testThemeUrl() {}
  */
-	public function testThemeUrl() {}
 
 /**
  * ベースとなるURLを取得する
@@ -1900,8 +1903,9 @@ class BcBaserHelperTest extends BaserTestCase {
 /**
  * ベースとなるURLを出力する
  *　BcBaserHelper:getBaserUrl()のラッパーの為、テスト不要
+ *
+ * public function testBaseUrl() {}
  */
-	public function testBaseUrl() {}
 
 /**
  * サブメニューを取得する
@@ -1983,6 +1987,7 @@ class BcBaserHelperTest extends BaserTestCase {
 /**
  * Google Maps を出力する
  * BcBaserHelper:getGoogleMapsのラッパーの為、テスト不要
+ *
  * public function testGoogleMaps() {}
  */
 
@@ -2096,11 +2101,11 @@ class BcBaserHelperTest extends BaserTestCase {
 	}
 
 /**
- * 親フォルダを取得する 
+ * 親フォルダを取得する
+ * BcContentsHelper::getParent()のラッパーの為、テスト不要
+ *
+ * public function testGetParentFolder() {}
  */
-	public function testGetParentFolder() {
-		$this->markTestIncomplete('このメソッドは、BcContentsHelper::getParent() をラッピングしているメソッドの為スキップします。');
-	}
 
 /**
  * コンテンツ管理用のURLより、正式なURLを取得する 
@@ -2131,9 +2136,10 @@ class BcBaserHelperTest extends BaserTestCase {
 
 /**
  * IDがコンテンツ自身の親のIDかを判定する
- * BcContentsHelper::isContentsParentId()のラッパーなのでテスト不要
+ * BcContentsHelper::isContentsParentId()のラッパーの為、テスト不要
+ *
+ * 	public function testIsContentsParentId() {}
  */
-	public function testIsContentsParentId() {}
 
 	public function test__call() {
 		$this->markTestIncomplete('このテストは、まだ実装されていません。');

--- a/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
@@ -1904,15 +1904,22 @@ class BcBaserHelperTest extends BaserTestCase {
 	public function testBaseUrl() {}
 
 /**
- * サブメニューを出力する
+ * サブメニューを取得する
  *
  * @return void
  */
-	public function testSubMenu() {
+	public function testGetSubMenu() {
 		$this->BcBaser->setSubMenus(["default"]);
 		$this->expectOutputRegex('/<div class="sub-menu-contents">.*<a href="\/admin\/users\/login" target="_blank">管理者ログイン<\/a>.*<\/li>.*<\/ul>.*<\/div>/s');
-		$this->BcBaser->subMenu();
+		$this->BcBaser->getSubMenu();
 	}
+
+/**
+ * サブメニューを出力する
+ * BcBaserHelper:getSubMenuのラッパーの為、テスト不要
+ *
+ * public function testSubMenu() {}
+ * /
 
 /**
  * コンテンツナビを出力する
@@ -2159,10 +2166,6 @@ class BcBaserHelperTest extends BaserTestCase {
 	}
 
 	public function testGetSiteSearchForm() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
-	}
-
-	public function testGetSubMenu() {
 		$this->markTestIncomplete('このテストは、まだ実装されていません。');
 	}
 

--- a/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
@@ -1879,40 +1879,6 @@ class BcBaserHelperTest extends BaserTestCase {
 			['', '/index', '/'],
 			['', '/contact/index', '/'],
 			['', '/blog/blog/index', '/'],
-			// サブフォルダ
-			['/basercms', '/', '/basercms/'],
-			['/basercms', '/index', '/basercms/'],
-			['/basercms', '/contact/index', '/basercms/'],
-			['/basercms', '/blog/blog/index', '/basercms/'],
-		];
-	}
-
-/**
- * ベースとなるURLを出力する
- *
- * @param string $smartUrl スマートURLのオン・オフ、サブディレクトリ配置のスマートURLのオン・オフ
- * @param string $url アクセスした時のURL
- * @param string $expects 期待値
- * @return void
- * 
- * @dataProvider baseUrlDataProvider
- */
-	public function testBaseUrl($smartUrl, $url, $expects) {
-		Configure::write('App.baseUrl', $smartUrl);
-		$this->BcBaser->request = $this->_getRequest($url);
-		ob_start();
-		$this->BcBaser->baseUrl();
-		$result = ob_get_clean();
-		$this->assertEquals($expects, $result);
-	}
-
-	public function baseUrlDataProvider() {
-		return [
-			// ノーマル
-			['', '/', '/'],
-			['', '/index', '/'],
-			['', '/contact/index', '/'],
-			['', '/blog/blog/index', '/'],
 			// スマートURLオフ
 			['index.php', '/', '/index.php/'],
 			['index.php', '/index', '/index.php/'],
@@ -1930,6 +1896,12 @@ class BcBaserHelperTest extends BaserTestCase {
 			['/basercms/index.php', '/blog/blog/index', '/basercms/index.php/']
 		];
 	}
+
+/**
+ * ベースとなるURLを出力する
+ *　BcBaserHelper:getBaserUrl()のラッパーの為、テスト不要
+ */
+	public function testBaseUrl() {}
 
 /**
  * サブメニューを出力する

--- a/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
@@ -975,13 +975,11 @@ class BcBaserHelperTest extends BaserTestCase {
 
 /**
  * アンカータグを出力する
+ * BcBaserHelper:getLink()のラッパーの為、テスト不要
  *
  * @return void
  */
-	public function testLink() {
-		$this->expectOutputString('<a href="/about">会社案内</a>');
-		$this->BcBaser->link('会社案内', '/about');
-	}
+	public function testLink() {}
 
 /**
  * アンカータグを取得する
@@ -1236,9 +1234,11 @@ class BcBaserHelperTest extends BaserTestCase {
 		];
 	}
 
-	public function testGetContentByEntityId() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
-	}
+/**
+ * エンティティIDからコンテンツの情報を取得
+ * BcContents:getContentByEntityId()のラッパーの為、テスト不要
+ */
+	public function testGetContentByEntityId() {}
 
 	public function testGetContentCreatedDate() {
 		$this->markTestIncomplete('このテストは、まだ実装されていません。');
@@ -1414,15 +1414,16 @@ class BcBaserHelperTest extends BaserTestCase {
  *	- null : 仕様確認要
  * @param string $recursive 取得する階層
  * @param boolean $expected 期待値
- * @dataProvider sitemapDataProvider
+ * @dataProvider getSitemapDataProvider
  */
-	public function testSitemap($siteId, $expected) {
+
+	public function testGetSitemap($siteId, $expected) {
 		$message = 'サイトマップを正しく出力できません';
 		$this->expectOutputRegex('/' . $expected . '/s', $message);
-		$this->BcBaser->sitemap($siteId);
+		$this->BcBaser->getSitemap($siteId);
 	}
 
-	public function sitemapDataProvider() {
+	public function getSitemapDataProvider() {
 		return [
 			[0, '<li class="menu-content li-level-1">.*?<a href="\/">トップページ<\/a>.*?<\/li>'],
 			[1, '<a href="\/m\/">トップページ.*<\/li>.*<\/ul>'],
@@ -1430,6 +1431,11 @@ class BcBaserHelperTest extends BaserTestCase {
 		];
 	}
 
+/**
+ * BcBaserHelper:getSitemapのラッパーの為、テスト不要
+ */
+	public function testSitemap() {}
+	
 /**
  * Flashを表示する
  *
@@ -2176,10 +2182,6 @@ class BcBaserHelperTest extends BaserTestCase {
 	}
 
 	public function testGetRoot() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
-	}
-
-	public function testGetSitemap() {
 		$this->markTestIncomplete('このテストは、まだ実装されていません。');
 	}
 

--- a/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
@@ -2001,24 +2001,21 @@ class BcBaserHelperTest extends BaserTestCase {
 	}
 
 /**
- * サイト内検索フォームを出力
+ * サイト内検索フォームを取得
  *
  * @return void
  */
-	public function testSiteSearchForm() {
+	public function testGetSiteSearchForm() {
 		$this->expectOutputRegex('/<div class="section search-box">.*<input.*?type="submit" value="検索"\/>.*<\/form><\/div>/s');
-		$this->BcBaser->siteSearchForm();
+		$this->BcBaser->getSiteSearchForm();
 	}
 
 /**
- * WEBサイト名を出力する
+ * サイト内検索フォームを出力
+ * BcBaserHelper:getSiteSearchForm()のラッパーの為、テスト不要
  *
- * @return void
+ * public function testSiteSearchForm() {}
  */
-	public function testSiteName() {
-		$this->expectOutputString('baserCMS inc. [デモ]');
-		$this->BcBaser->siteName();
-	}
 
 /**
  * WEBサイト名を取得する
@@ -2030,18 +2027,13 @@ class BcBaserHelperTest extends BaserTestCase {
 	}
 
 /**
- * WEBサイトURLを出力する
+ * WEBサイト名を出力する
+ * BcBaserHelper:getSiteName()のラッパーのため、テスト不要
  *
  * @return void
+ *
+ * public function testSiteName() {}
  */
-	public function testSiteUrl() {
-
-		Configure::write('BcEnv.siteUrl', 'http://basercms.net/');
-		Configure::write('BcEnv.sslUrl', 'https://basercms.net/');
-
-		$this->expectOutputString('http://basercms.net/');
-		$this->BcBaser->siteUrl();
-	}
 
 /**
  * WEBサイトURLを取得する
@@ -2058,6 +2050,15 @@ class BcBaserHelperTest extends BaserTestCase {
 		//https
 		$this->assertEquals('https://basercms.net/', $this->BcBaser->getSiteUrl(true));
 	}
+
+
+/**
+ * WEBサイトURLを出力する
+ * BcBaserHelper:getSiteUrl()のラッパーの為、テスト不要
+ * @return void
+ *
+ * public function testSiteUrl() {}
+ */
 
 /**
  * URLのパラメータ情報を返す
@@ -2167,10 +2168,6 @@ class BcBaserHelperTest extends BaserTestCase {
 	}
 
 	public function testGetSitePrefix() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
-	}
-
-	public function testGetSiteSearchForm() {
 		$this->markTestIncomplete('このテストは、まだ実装されていません。');
 	}
 

--- a/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
@@ -1943,14 +1943,21 @@ class BcBaserHelperTest extends BaserTestCase {
 	}
 
 /**
- * グローバルメニューを出力する
+ * グローバルメニューを取得する
  *
  * @return void
  */
-	public function testGlobalMenu() {
+	public function testGetGlobalMenu() {
 		$this->expectOutputRegex('/<ul class="global-menu .*?">.*<a href="\/sitemap">サイトマップ<\/a>.*<\/li>.*<\/ul>/s');
-		$this->BcBaser->globalMenu();
+		$this->BcBaser->getGlobalMenu();
 	}
+
+/**
+ * グローバルメニューを出力する
+ * BcBaserHelper:getGlobalMenu()のラッパーの為、テスト不要
+ *
+ * 	public function testGlobalMenu() {}
+ */
 
 /**
  * Google Analytics のトラッキングコードを出力する
@@ -1963,15 +1970,21 @@ class BcBaserHelperTest extends BaserTestCase {
 	}
 
 /**
- * Google Maps を出力する
+ * Google Maps を取得する
  *
  * @return void
  */
-	public function testGoogleMaps() {
+	public function testGetGoogleMaps() {
 		$this->markTestIncomplete('このテストは、まだ実装されていません。');
 		$this->expectOutputRegex('/<div id="map"/');
-		$this->BcBaser->googleMaps();
+		$this->BcBaser->getGoogleMaps();
 	}
+
+/**
+ * Google Maps を出力する
+ * BcBaserHelper:getGoogleMapsのラッパーの為、テスト不要
+ * public function testGoogleMaps() {}
+ */
 
 /**
  * 表示件数設定機能を出力する
@@ -2142,14 +2155,6 @@ class BcBaserHelperTest extends BaserTestCase {
 	}
 
 	public function testCurrentPrefix() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
-	}
-
-	public function testGetGlobalMenu() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
-	}
-
-	public function testGetGoogleMaps() {
 		$this->markTestIncomplete('このテストは、まだ実装されていません。');
 	}
 

--- a/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
@@ -2141,6 +2141,17 @@ class BcBaserHelperTest extends BaserTestCase {
  * 	public function testIsContentsParentId() {}
  */
 
+	public function testGetUpdateInfo() {
+		$this->assertRegExp('//',$this->BcBaser->getUpdateInfo());
+	}
+
+/**
+ *
+ * BcBaserHelper:getUpdateInfo()のラッパーの為、テスト不要
+ *
+ * public function testUpdateInfo() {}
+ */
+
 	public function test__call() {
 		$this->markTestIncomplete('このテストは、まだ実装されていません。');
 	}
@@ -2177,15 +2188,7 @@ class BcBaserHelperTest extends BaserTestCase {
 		$this->markTestIncomplete('このテストは、まだ実装されていません。');
 	}
 
-	public function testGetUpdateInfo() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
-	}
-
 	public function testRelatedSiteLinks() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
-	}
-
-	public function testUpdateInfo() {
 		$this->markTestIncomplete('このテストは、まだ実装されていません。');
 	}
 

--- a/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
@@ -1435,7 +1435,7 @@ class BcBaserHelperTest extends BaserTestCase {
  * BcBaserHelper:getSitemapのラッパーの為、テスト不要
  */
 	public function testSitemap() {}
-	
+
 /**
  * Flashを表示する
  *
@@ -1606,24 +1606,30 @@ class BcBaserHelperTest extends BaserTestCase {
  * @param string $url 現在のURL
  * @param int $no 
  * @param string $expected 期待値
- * @dataProvider widgetAreaDataProvider
+ * @dataProvider getWidgetAreaDataProvider
  */
-	public function testWidgetArea($url, $no, $expected) {
+	public function testGetWidgetArea($url, $no, $expected) {
 		App::uses('BlogHelper', 'Blog.View/Helper');
 		$this->BcBaser->request = $this->_getRequest($url);
 		ob_start();
-		$this->BcBaser->widgetArea($no);
+		$this->BcBaser->getWidgetArea($no);
 		$result = ob_get_clean();
 		$this->assertRegExp('/' . $expected . '/', $result);
 	}
 
-	public function widgetAreaDataProvider() {
+	public function getWidgetAreaDataProvider() {
 		return [
 			['/company', 1, '<div class="widget-area widget-area-1">'],
 			['/company', 2, '<div class="widget-area widget-area-2">'],
 			['/company', null, '<div class="widget-area widget-area-1">'],
 		];
 	}
+
+/**
+ * ウィジェットエリアを出力する
+ * BcBaserHelper:getWidgetAreaのラッパーの為、テスト不要
+ */
+	public function testWidgetArea() {}
 
 /**
  * 指定したURLが現在のURLかどうか判定する
@@ -2198,10 +2204,6 @@ class BcBaserHelperTest extends BaserTestCase {
 	}
 
 	public function testGetUpdateInfo() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
-	}
-
-	public function testGetWidgetArea() {
 		$this->markTestIncomplete('このテストは、まだ実装されていません。');
 	}
 

--- a/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
@@ -1967,7 +1967,7 @@ class BcBaserHelperTest extends BaserTestCase {
  * @return void
  */
 	public function testGoogleAnalytics() {
-		$this->assertRegExp('/<script>.*ga\(\'create\', \'hoge\', \'auto\'\)\;/s', $this->BcBaser->googleAnalytics());
+		$this->expectOutputRegex('/<script>.*ga\(\'create\', \'hoge\', \'auto\'\)\;/s', $this->BcBaser->googleAnalytics());
 	}
 
 /**
@@ -2142,11 +2142,23 @@ class BcBaserHelperTest extends BaserTestCase {
 	}
 
 /**
- *
+ * 関連サイトのリンク一覧を取得
  * BcBaserHelper:getUpdateInfo()のラッパーの為、テスト不要
  *
  * public function testUpdateInfo() {}
  */
+
+	public function testGetRelatedSiteLinks() {
+		$this->assertRegExp('/<ul class="related-site-links">/s', $this->BcBaser->getRelatedSiteLinks());
+	}
+
+/**
+ * 関連サイトのリンク一覧を出力
+ * BcBaserHelper:testGetRelatadStimenksのラッパーの為、テスト不要
+ *
+ * public function testRelatedSiteLinks() {}
+ */
+
 
 	public function test__call() {
 		$this->markTestIncomplete('このテストは、まだ実装されていません。');
@@ -2172,10 +2184,6 @@ class BcBaserHelperTest extends BaserTestCase {
 		$this->markTestIncomplete('このテストは、まだ実装されていません。');
 	}
 
-	public function testGetRelatedSiteLinks() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
-	}
-
 	public function testGetRoot() {
 		$this->markTestIncomplete('このテストは、まだ実装されていません。');
 	}
@@ -2184,9 +2192,6 @@ class BcBaserHelperTest extends BaserTestCase {
 		$this->markTestIncomplete('このテストは、まだ実装されていません。');
 	}
 
-	public function testRelatedSiteLinks() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
-	}
 
 	public function testWebClipIcon() {
 		$this->markTestIncomplete('このテストは、まだ実装されていません。');

--- a/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
@@ -155,14 +155,6 @@ class BcBaserHelperTest extends BaserTestCase {
 		$this->BcBaser->setHomeTitle('hoge');
 		$this->assertEquals('hoge', $this->_View->viewVars['homeTitle'], 'タイトルをセットできません。');
 	}
-	
-/**
-* ページにeditLinkを追加する
-*/
-	public function testSetPageEditLink() {
-		// 存在しない
-		$this->BcBaser->setPageEditLink(1);
-		$this->assertEquals(true, empty($this->_View->viewVars['editLink']));
 
 /**
 * ページにeditLinkを追加する
@@ -400,9 +392,11 @@ class BcBaserHelperTest extends BaserTestCase {
 		$this->markTestIncomplete('このテストは、まだ実装されていません。');
 	}
 
-	public function testContentsName() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
-	}
+/**
+ * コンテンツを特定する文字列を出力する
+ * BcBaserHelper::getContentsName() のラッパーの為、テスト不要
+ */
+	public function testContentsName() {}
 
 /**
  * タイトルタグを出力する

--- a/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
@@ -1914,8 +1914,7 @@ class BcBaserHelperTest extends BaserTestCase {
  */
 	public function testGetSubMenu() {
 		$this->BcBaser->setSubMenus(["default"]);
-		$this->expectOutputRegex('/<div class="sub-menu-contents">.*<a href="\/admin\/users\/login" target="_blank">管理者ログイン<\/a>.*<\/li>.*<\/ul>.*<\/div>/s');
-		$this->BcBaser->getSubMenu();
+		$this->assertRegExp('/<div class="sub-menu-contents">.*<a href="\/admin\/users\/login" target="_blank">管理者ログイン<\/a>.*<\/li>.*<\/ul>.*<\/div>/s', $this->BcBaser->getSubMenu());
 	}
 
 /**
@@ -1952,8 +1951,7 @@ class BcBaserHelperTest extends BaserTestCase {
  * @return void
  */
 	public function testGetGlobalMenu() {
-		$this->expectOutputRegex('/<ul class="global-menu .*?">.*<a href="\/sitemap">サイトマップ<\/a>.*<\/li>.*<\/ul>/s');
-		$this->BcBaser->getGlobalMenu();
+		$this->assertRegExp('/<ul class="global-menu .*?">.*<a href="\/sitemap">サイトマップ<\/a>.*<\/li>.*<\/ul>/s', $this->BcBaser->getGlobalMenu());
 	}
 
 /**
@@ -1969,8 +1967,7 @@ class BcBaserHelperTest extends BaserTestCase {
  * @return void
  */
 	public function testGoogleAnalytics() {
-		$this->expectOutputRegex('/<script>.*ga\(\'create\', \'hoge\', \'auto\'\)\;/s');
-		$this->BcBaser->googleAnalytics();
+		$this->assertRegExp('/<script>.*ga\(\'create\', \'hoge\', \'auto\'\)\;/s', $this->BcBaser->googleAnalytics());
 	}
 
 /**
@@ -2011,8 +2008,7 @@ class BcBaserHelperTest extends BaserTestCase {
  * @return void
  */
 	public function testGetSiteSearchForm() {
-		$this->expectOutputRegex('/<div class="section search-box">.*<input.*?type="submit" value="検索"\/>.*<\/form><\/div>/s');
-		$this->BcBaser->getSiteSearchForm();
+		$this->assertRegExp('/<div class="section search-box">.*<input.*?type="submit" value="検索"\/>.*<\/form><\/div>/s', $this->BcBaser->getSiteSearchForm());
 	}
 
 /**


### PR DESCRIPTION
BcBaserHelperTestの不要テストコメントアウトしました。

ラッパーメソッドの整理、移行した際のテスト失敗を修正