### PR TITLE
Model/User用のtestDeleteFavorites()を実装

### DIFF
--- a/lib/Baser/Test/Case/Model/UserTest.php
+++ b/lib/Baser/Test/Case/Model/UserTest.php
@@ -370,10 +370,10 @@ class UserTest extends BaserTestCase {
  * ユーザーに関連するよく使う項目を削除する
  */
 	public function testDeleteFavorites() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
-		$this->User->Favorite->deleteAll(1);
-		$result = $this->User->Favorite->find('all');
-		$expected = [];
-		$this->assertEquals($expected, $result, 'ユーザーに関連するよく使う項目を削除できません');
+		$user = $this->User->find('first', ['conditions' => ['User.id' => 1]]);
+		$this->assertTrue(isset($user['Favorite'][0]['id']), 'ユーザーに関連するよく使う項目の削除対象がありません。');
+		$this->User->deleteFavorites(1);
+		$user = $this->User->find('first', ['conditions' => ['User.id' => 1]]);
+		$this->assertFalse(isset($user['Favorite'][0]['id']), 'ユーザーに関連するよく使う項目を削除できません。');
 	}
 }


### PR DESCRIPTION
Model/User用のtestDeleteFavorites()を実装しました。
既存のものがテスト対象を間違えたテストだったため書き直しています。

@ryuring さんに作成していただいたものです。