### PR TITLE
Model/Userの不必要メソッドを削除

### DIFF
--- a/lib/Baser/Model/User.php
+++ b/lib/Baser/Model/User.php
@@ -192,58 +192,6 @@ class User extends AppModel {
 	}
 
 /**
- * afterFind
- *
- * @param array 結果セット
- * @param array $primary
- * @return array 結果セット
- */
-	public function afterFind($results, $primary = false) {
-		if (isset($results[0][$this->alias][0])) {
-			$results[0][$this->alias] = $this->convertResults($results[0][$this->alias]);
-		} else {
-			$results = $this->convertResults($results);
-		}
-		return parent::afterFind($results, $primary);
-	}
-
-/**
- * 取得結果を変換する
- * HABTM対応
- *
- * @param array 結果セット
- * @return array 結果セット
- */
-	public function convertResults($results) {
-		if ($results) {
-			if (isset($result[$this->alias]) || isset($results[0][$this->alias])) {
-				foreach ($results as $key => $result) {
-					if (isset($result[$this->alias])) {
-						if ($result[$this->alias]) {
-							$results[$key][$this->alias] = $this->convertToView($result[$this->alias]);
-						}
-					} elseif (!empty($result)) {
-						$results[$key] = $this->convertToView($result);
-					}
-				}
-			} else {
-				$results = $this->convertToView($results);
-			}
-		}
-		return $results;
-	}
-
-/**
- * View用のデータを取得する
- *
- * @param array 結果セット
- * @return array 結果セット
- */
-	public function convertToView($data) {
-		return $data;
-	}
-
-/**
  * ユーザーが許可されている認証プレフィックスを取得する
  *
  * @param string $userName ユーザーの名前

--- a/lib/Baser/Test/Case/Model/UserTest.php
+++ b/lib/Baser/Test/Case/Model/UserTest.php
@@ -261,38 +261,6 @@ class UserTest extends BaserTestCase {
 		$this->assertEquals($expected, $result, 'フォームの初期値が正しくありません');
 	}
 
-
-/**
- * afterFind
- *
- * @param array 結果セット
- * @param array $primary
- */
-	public function testAfterFind() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
-
-		// $results = $this->User->find('all');
-		// $result = $this->User->afterFind($results, true);
-		// $this->assertEquals($expected, $result, $message);
-	}
-
-/**
- * 取得結果を変換する
- * HABTM対応
- *
- * @param array 結果セット
- */
-	public function testConvertResults() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
-	}
-
-/**
- * View用のデータを取得する
- */
-	public function testConvertToView() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
-	}
-
 /**
  * ユーザーが許可されている認証プレフィックスを取得する
  *


### PR DESCRIPTION
Model/Userの以下3つの不必要メソッドと、それらを対象とするテストメソッドを削除しました。

* afterFind()
* convertToView()
* convertResults()

convertResults()が実際には変換を行わず結果セットをそのまま返しているだけで、他の2つのメソッドについても最終的にそれを呼び出しているだけだったためです。

削除後、ログインとユーザー一覧の表示が正常に動作することを確認済みです。