### PR TITLE
テーマファイルの重複チェックが機能していなかったため修正

### DIFF
--- a/lib/Baser/Model/ThemeFile.php
+++ b/lib/Baser/Model/ThemeFile.php
@@ -49,7 +49,7 @@ class ThemeFile extends AppModel {
 		if (!$check[key($check)]) {
 			return true;
 		}
-		$targetPath = $this->data['ThemeFile']['parent'] . DS . $check[key($check)];
+		$targetPath = $this->data['ThemeFile']['parent'] . $check[key($check)] . '.' . $this->data['ThemeFile']['ext'];
 		if (is_file($targetPath)) {
 			return false;
 		} else {


### PR DESCRIPTION
## 概要
テーマファイルの重複チェックの際に、重複する可能性のある対象ファイルのパスの生成が誤っていたため重複チェックが機能していなかった点を修正しました。

## テスト
手動テストで重複チェックが正しく行われるようになったことを確認しました。