### PR TITLE
ThemeFileTestのテスト用ThemeFileデータ生成に欠けていたキー・値を追加

### DIFF
--- a/lib/Baser/Test/Case/Model/ThemeFileTest.php
+++ b/lib/Baser/Test/Case/Model/ThemeFileTest.php
@@ -45,6 +45,9 @@ class ThemeFileTest extends BaserTestCase {
 		$this->ThemeFile->create([
 			'ThemeFile' => [
 				'name' => '',
+				'parent' => '',
+				'ext' => 'php',
+				'contents' => ''
 			]
 		]);
 		$this->assertFalse($this->ThemeFile->validates());
@@ -56,7 +59,9 @@ class ThemeFileTest extends BaserTestCase {
 		$this->ThemeFile->create([
 			'ThemeFile' => [
 				'name' => 'baser',
-				'parent' => 'hoge'
+				'parent' => 'hoge',
+				'ext' => 'php',
+				'contents' => ''
 			]
 		]);
 		$this->assertTrue($this->ThemeFile->validates());
@@ -65,8 +70,10 @@ class ThemeFileTest extends BaserTestCase {
 	public function test重複チェック異常系() {
 		$this->ThemeFile->create([
 			'ThemeFile' => [
-				'name' => 'config.php',
+				'name' => 'config',
 				'parent' => WWW_ROOT . 'theme/nada-icons/',
+				'ext' => 'php',
+				'contents' => ''
 			]
 		]);
 		$this->assertFalse($this->ThemeFile->validates());


### PR DESCRIPTION
## 概要
テスト用ThemeFileのデータ生成にextキー (拡張子) の情報が欠けていることが原因でテストが失敗していたため、extキーと値を追加しました。

## 補足
併せて他に欠けていたキー・値 (parent、contents) についても念のため追加しています。