### PR TITLE
Model/Content用テストのtestGetSiteRoot()を実装

### DIFF
--- a/lib/Baser/Test/Case/Model/ContentTest.php
+++ b/lib/Baser/Test/Case/Model/ContentTest.php
@@ -25,7 +25,7 @@ class ContentTest extends BaserTestCase {
 		'baser.Routing.Route.BcContentsRoute.SiteBcContentsRoute',
 		'baser.Routing.Route.BcContentsRoute.ContentBcContentsRoute',
 		'baser.Default.SiteConfig',
-		'baser.Default.User',
+		'baser.Default.User'
 	];
 
 /**
@@ -450,7 +450,11 @@ class ContentTest extends BaserTestCase {
  * サイトルートコンテンツを取得する
  */
 	public function testGetSiteRoot() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+		$this->loadFixtures('ContentStatusCheck');
+		$this->assertEquals(1, $this->Content->getSiteRoot(0)['Content']['id']);
+		$this->assertEquals(2, $this->Content->getSiteRoot(1)['Content']['id']);
+		$this->assertEquals(3, $this->Content->getSiteRoot(2)['Content']['id']);
+		$this->assertEmpty($this->Content->getSiteRoot(3));
 	}
 
 /**

--- a/lib/Baser/Test/Case/Model/ContentTest.php
+++ b/lib/Baser/Test/Case/Model/ContentTest.php
@@ -25,7 +25,7 @@ class ContentTest extends BaserTestCase {
 		'baser.Routing.Route.BcContentsRoute.SiteBcContentsRoute',
 		'baser.Routing.Route.BcContentsRoute.ContentBcContentsRoute',
 		'baser.Default.SiteConfig',
-		'baser.Default.User'
+		'baser.Default.User',
 	];
 
 /**


### PR DESCRIPTION
## 概要
Model/Content用テストのtestGetSiteRoot()を実装しました。

## 補足
取得したサイトルートコンテンツについて、保持する全てのデータについてはチェックせず、idのみチェックして正しいものであるかどうか判断させています。