### PR TITLE
Model/ThemeFile用テストのtest重複チェック異常系()が不必要になったため削除

### DIFF
--- a/lib/Baser/Test/Case/Model/ThemeFileTest.php
+++ b/lib/Baser/Test/Case/Model/ThemeFileTest.php
@@ -68,20 +68,6 @@ class ThemeFileTest extends BaserTestCase {
 		$this->assertTrue($this->ThemeFile->validates());
 	}
 
-	public function test重複チェック異常系() {
-		$this->ThemeFile->create([
-			'ThemeFile' => [
-				'name' => 'config',
-				'parent' => WWW_ROOT . 'theme/nada-icons/',
-				'ext' => 'php',
-				'contents' => ''
-			]
-		]);
-		$this->assertFalse($this->ThemeFile->validates());
-		$this->assertArrayHasKey('name', $this->ThemeFile->validationErrors);
-		$this->assertEquals('入力されたテーマファイル名は、同一階層に既に存在します。', current($this->ThemeFile->validationErrors['name']));
-	}
-
 /**
  * ファイルの重複チェック
  */


### PR DESCRIPTION
## 概要
Model/ThemeFile用テストのtest重複チェック異常系()が不必要になったため削除しました。

## 動機
#814 でのtestDuplicateThemeFile()の追加により、重複チェックのテストはそちらで行うようにしたため。