### PR TITLE
fix #19453 プラグインをフォルダ内に持つテーマに切り替えた際、プラグインが利用できない場合がある 問題を修正

### DIFF
--- a/lib/Baser/Controller/Component/BcManagerComponent.php
+++ b/lib/Baser/Controller/Component/BcManagerComponent.php
@@ -1540,6 +1540,7 @@ class BcManagerComponent extends Component {
  * @return boolean
  */
 	public function installPlugin($name, $dbDataPattern = '') {
+		clearAllCache();
 
 		$paths = App::path('Plugin');
 		$exists = false;

--- a/lib/Baser/Controller/PluginsController.php
+++ b/lib/Baser/Controller/PluginsController.php
@@ -118,7 +118,6 @@ class PluginsController extends AppController {
 
 		// プラグインをインストール
 		if ($this->BcManager->installPlugin($plugin)) {
-			clearAllCache();
 			$this->setMessage('新規プラグイン「' . $plugin . '」を baserCMS に登録しました。', false, true);
 			$this->Plugin->addFavoriteAdminLink($plugin, $this->BcAuth->user());
 			$this->redirect(['action' => 'index']);
@@ -352,7 +351,6 @@ class PluginsController extends AppController {
 		} else {
 			// プラグインをインストール
 			if ($this->BcManager->installPlugin($this->request->data['Plugin']['name'])) {
-				clearAllCache();
 				$this->setMessage('新規プラグイン「' . $name . '」を baserCMS に登録しました。', false, true);
 
 				$this->Plugin->addFavoriteAdminLink($name, $this->BcAuth->user());


### PR DESCRIPTION
■原因
テーマに梱包されたプラグインをインストールする際にプラグイン情報のキャッシュの削除を行なっていないため。

■変更内容
installPlugin() 内で clearAllCache() を使用してキャッシュの削除を行なっています。
それにともない、処理が重複する部分を削除しています。