### PR TITLE
fix #19456 固定ページ編集画面でよく使う項目を編集して保存すると、処理が正常に終わらず管理画面が崩れる

### DIFF
--- a/lib/Baser/Controller/FavoritesController.php
+++ b/lib/Baser/Controller/FavoritesController.php
@@ -77,6 +77,7 @@ class FavoritesController extends AppController {
  * @return void
  */
 	public function admin_ajax_edit($id) {
+		$this->autoRender = false;
 		if (!$id) {
 			$this->ajaxError(500, '無効な処理です。');
 		}
@@ -85,6 +86,7 @@ class FavoritesController extends AppController {
 			$this->Favorite->set($this->request->data);
 			$data = $this->Favorite->save();
 			if ($data) {
+				$this->autoLayout = false;
 				$this->set('favorite', $data);
 				$this->render('ajax_form');
 				return;
@@ -92,8 +94,7 @@ class FavoritesController extends AppController {
 				$this->ajaxError(500, $this->Favorite->validationErrors);
 			}
 		}
-
-		exit();
+		return;
 	}
 
 /**


### PR DESCRIPTION
調整しましたので、取込検討をよろしくお願いします。
http://project.e-catchup.jp/issues/19456
