### PR TITLE
ContentTest::testGetSiteRoot()がdataProviderを使用するよう変更

### DIFF
--- a/lib/Baser/Test/Case/Model/ContentTest.php
+++ b/lib/Baser/Test/Case/Model/ContentTest.php
@@ -507,14 +507,29 @@ class ContentTest extends BaserTestCase {
 
 /**
  * サイトルートコンテンツを取得する
+ *
+ * @param int $siteId
+ * @param mixed $expects 期待するコンテントのid (存在しない場合はから配列)
+ * @dataProvider getSiteRootDataProvider
  */
-	public function testGetSiteRoot() {
-		$this->loadFixtures('ContentStatusCheck');
-		$this->assertEquals(1, $this->Content->getSiteRoot(0)['Content']['id']);
-		$this->assertEquals(2, $this->Content->getSiteRoot(1)['Content']['id']);
-		$this->assertEquals(3, $this->Content->getSiteRoot(2)['Content']['id']);
-		$this->assertEmpty($this->Content->getSiteRoot(3));
+	public function testGetSiteRoot($siteId, $expects) {
+		$result = $this->Content->getSiteRoot($siteId);
+		if ($result) {
+			$result = $result['Content']['id'];
+		}
+
+		$this->assertEquals($expects, $result);
 	}
+
+	public function getSiteRootDataProvider() {
+		return [
+			[0, 1],
+			[1, 2],
+			[2, 3],
+			[7, []],		// 存在しないsiteId
+		];
+	}
+
 
 /**
  * 親のテンプレートを取得する


### PR DESCRIPTION
## 概要
ContentTest::testGetSiteRoot()がdataProviderを使用するよう変更しました。

## 補足
あわせて異常系として$siteIDの入力に 'あ' なども追加しようと思い、空配列が返ってくることを期待しましたが、なぜかコンテントが取得できるので不思議に思ったところ、MySQLのクエリのWHERE句で、以下のような原因で 'あ' が0に変換されており取得できてしまっていたという学びがありました。

> MySQLでは、左辺と右辺の型が異なる場合、どちらかに合わせて（変換して）比較が行われる。
文字列と文字列であれば変換は発生しないので意図した通りの結果になるが、今回は左辺が文字列で右辺が数値になっている。この場合、MySQLでは左辺と右辺の両方を数値に変換してから比較を行う。今回のケースでは左辺には既存のレコードの値が入ってくるが、数字になり得ないもの（ aaaaa, bbbbb, aa033e など）が来た場合は全て0に変換されてしまう。

(引用: https://haushinka2dx.blogspot.jp/2012/09/mysqlvarcharint.html)

そのため異常系については追加しておりません。