### PR TITLE
Content::getUrlById()をidが見つからなかった場合に空文字を戻すよう変更

### DIFF
--- a/lib/Baser/Model/Content.php
+++ b/lib/Baser/Model/Content.php
@@ -1087,7 +1087,10 @@ class Content extends AppModel {
  */
 	public function getUrlById($id, $full = false) {
 		$data = $this->find('first', ['conditions' => ['Content.id' => $id]]);
-		return $this->getUrl($data['Content']['url'], $full, $data['Site']['use_subdomain']);
+		if ($data) {
+			return $this->getUrl($data['Content']['url'], $full, $data['Site']['use_subdomain']);
+		}
+		return '';
 	}
 
 /**

--- a/lib/Baser/Test/Case/Model/ContentTest.php
+++ b/lib/Baser/Test/Case/Model/ContentTest.php
@@ -374,26 +374,9 @@ class ContentTest extends BaserTestCase {
 		return [
 			// ノーマルURL
 			[1, false, '/'],
-			[2, false, '/m/'],
-			[3, false, '/'],									// 同一URL
-			[4, false, '/'],									// /index
-			[5, false, '/service/'],
-			[7, false, '/service/contact/'],
-			[14, false, '/'],									// サブドメイン
-			[16, false, '/service/contact/'],					// 同一URL
-			[19, false, '/news/'],								// サブドメイン
-			[24, false, '/service/service1'],					// サブドメイン
-			// フルURL
-			[1, true, 'http://main.com/'],
-			[2, true, 'http://main.com/m/'],
-			[3, true, 'http://main.com/'],						// 同一URL
-			[4, true, 'http://main.com/'],						// /index
-			[5, true, 'http://main.com/service/'],
-			[7, true, 'http://main.com/service/contact/'],
-			[14, true, 'http://sub.main.com/'],					// サブドメイン
-			[16, true, 'http://main.com/service/contact/'],		// 同一URL
-			[19, true, 'http://sub.main.com/news/'],			// サブドメイン
-			[24, true, 'http://sub.main.com/service/service1']	// サブドメイン
+			[1, true, 'http://main.com/'],	// フルURL
+			[999, false, ''],				// 存在しないid
+			['あ', false, '']				// 異常系
 		];
 	}
 

--- a/lib/Baser/Test/Case/Model/ContentTest.php
+++ b/lib/Baser/Test/Case/Model/ContentTest.php
@@ -352,11 +352,49 @@ class ContentTest extends BaserTestCase {
 		$this->markTestIncomplete('このテストは、まだ実装されていません。');
 	}
 
-/**
- * コンテンツIDよりURLを取得する
- */
-	public function testGetUrlById() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	/**
+	 * コンテンツIDよりURLを取得する
+	 *
+	 * @param int $id コンテンツID
+	 * @param bool $full http からのフルのURLかどうか
+	 * @param string $expects 期待するURL
+	 * @dataProvider getUrlByIdDataProvider
+	 */
+	public function testGetUrlById($id, $full, $expects) {
+		$siteUrl = Configure::read('BcEnv.siteUrl');
+		Configure::write('BcEnv.siteUrl', 'http://main.com');
+
+		$result = $this->Content->getUrlById($id, $full);
+		$this->assertEquals($expects, $result);
+
+		Configure::write('BcEnv.siteUrl', $siteUrl);
+	}
+
+	public function getUrlByIdDataProvider() {
+		return [
+			// ノーマルURL
+			[1, false, '/'],
+			[2, false, '/m/'],
+			[3, false, '/'],									// 同一URL
+			[4, false, '/'],									// /index
+			[5, false, '/service/'],
+			[7, false, '/service/contact/'],
+			[14, false, '/'],									// サブドメイン
+			[16, false, '/service/contact/'],					// 同一URL
+			[19, false, '/news/'],								// サブドメイン
+			[24, false, '/service/service1'],					// サブドメイン
+			// フルURL
+			[1, true, 'http://main.com/'],
+			[2, true, 'http://main.com/m/'],
+			[3, true, 'http://main.com/'],						// 同一URL
+			[4, true, 'http://main.com/'],						// /index
+			[5, true, 'http://main.com/service/'],
+			[7, true, 'http://main.com/service/contact/'],
+			[14, true, 'http://sub.main.com/'],					// サブドメイン
+			[16, true, 'http://main.com/service/contact/'],		// 同一URL
+			[19, true, 'http://sub.main.com/news/'],			// サブドメイン
+			[24, true, 'http://sub.main.com/service/service1']	// サブドメイン
+		];
 	}
 
 /**


### PR DESCRIPTION
## 概要
* Content::getUrlById()をidが見つからなかった場合に空文字を戻すよう変更しました。
* 併せてContentTest::testGetUrlById()のテストデータ量も減らしてあります。

## 動機
#841 でテストデータ量を削除することにしたためその実装をしていたところ、
Content::getUrlById()でidが存在しない場合や異常系の引数が与えられた場合エラーになってしまうことに気づいたため、そのような場合空文字を戻すよう変更しました。

## 補足
PHP標準関数で文字列を戻す関数では異常系の引数が与えられた場合に空文字を戻すことに倣っています。

## テスト
/Model/Contentのテスト群が通ることを確認済みです。
  
  