### PR TITLE
Content::getUrlById()をidが見つからなかったり整数でない値を渡した場合に空文字を戻すよう変更

### DIFF
--- a/lib/Baser/Model/Content.php
+++ b/lib/Baser/Model/Content.php
@@ -1086,6 +1086,9 @@ class Content extends AppModel {
  * @return string
  */
 	public function getUrlById($id, $full = false) {
+		if (!is_int($id)) {
+			return '';
+		}
 		$data = $this->find('first', ['conditions' => ['Content.id' => $id]]);
 		if ($data) {
 			return $this->getUrl($data['Content']['url'], $full, $data['Site']['use_subdomain']);

--- a/lib/Baser/Model/Content.php
+++ b/lib/Baser/Model/Content.php
@@ -1087,7 +1087,10 @@ class Content extends AppModel {
  */
 	public function getUrlById($id, $full = false) {
 		$data = $this->find('first', ['conditions' => ['Content.id' => $id]]);
-		return $this->getUrl($data['Content']['url'], $full, $data['Site']['use_subdomain']);
+		if ($data) {
+			return $this->getUrl($data['Content']['url'], $full, $data['Site']['use_subdomain']);
+		}
+		return '';
 	}
 
 /**

--- a/lib/Baser/Test/Case/Model/ContentTest.php
+++ b/lib/Baser/Test/Case/Model/ContentTest.php
@@ -374,26 +374,9 @@ class ContentTest extends BaserTestCase {
 		return [
 			// ノーマルURL
 			[1, false, '/'],
-			[2, false, '/m/'],
-			[3, false, '/'],									// 同一URL
-			[4, false, '/'],									// /index
-			[5, false, '/service/'],
-			[7, false, '/service/contact/'],
-			[14, false, '/'],									// サブドメイン
-			[16, false, '/service/contact/'],					// 同一URL
-			[19, false, '/news/'],								// サブドメイン
-			[24, false, '/service/service1'],					// サブドメイン
-			// フルURL
-			[1, true, 'http://main.com/'],
-			[2, true, 'http://main.com/m/'],
-			[3, true, 'http://main.com/'],						// 同一URL
-			[4, true, 'http://main.com/'],						// /index
-			[5, true, 'http://main.com/service/'],
-			[7, true, 'http://main.com/service/contact/'],
-			[14, true, 'http://sub.main.com/'],					// サブドメイン
-			[16, true, 'http://main.com/service/contact/'],		// 同一URL
-			[19, true, 'http://sub.main.com/news/'],			// サブドメイン
-			[24, true, 'http://sub.main.com/service/service1']	// サブドメイン
+			[1, true, 'http://main.com/'],	// フルURL
+			[999, false, ''],				// 存在しないid
+			['あ', false, '']				// 異常系
 		];
 	}
 


### PR DESCRIPTION
## 概要
#846 に加え、テストがPostgreSQLにも対応できるよう$idが整数でなかった場合に空文字を戻すように変更しました。