### PR TITLE
BlogTest/testDuplicateBlogCategory追加

### DIFF
--- a/lib/Baser/Plugin/Blog/Test/Case/Model/BlogCategoryTest.php
+++ b/lib/Baser/Plugin/Blog/Test/Case/Model/BlogCategoryTest.php
@@ -190,14 +190,6 @@ class BlogCategoryTest extends BaserTestCase {
 			[['title' => 'プレスリリース'], false],
 			[['title' => '親子関係なしカテゴリ'], false],
 			[['title' => 'hoge'], true],
-			//arrayの先頭だけで判断(完全一致かどうかは関係ない)
-			[['name' => 'hoge', 'title' => 'hoge'], true],
-			[['name' => 'release', 'title' => 'プレスリリース'], false],
-			[['name' => 'release', 'title' => '親子関係なしカテゴリ'], false],
-			[['name' => 'release', 'title' => 'hoge'], false],
-			//arrayの順番でTFが変わる
-			[['name' => 'hoge', 'title' => '親子関係なしカテゴリ'], true],
-			[['title' => '親子関係なしカテゴリ', 'name' => 'hoge'], false],
 		];
 	}
 


### PR DESCRIPTION
BlogTest/testDuplicateBlogCategory追加しました。

引数の[]に複数の値が入るのかわからなかったので、いれてます。
複数の場合は配列の１つ目しか判定してないみたいなので、複数のフィルターで判定はできてないみたいです。