### PR TITLE
Windowsで正常にキャッシュファイルの削除が行われない場合がある問題を修正

### DIFF
--- a/lib/Cake/Cache/Engine/FileEngine.php
+++ b/lib/Cake/Cache/Engine/FileEngine.php
@@ -144,6 +144,7 @@ class FileEngine extends CacheEngine {
 		if ($this->settings['lock']) {
 			$this->_File->flock(LOCK_UN);
 		}
+		$this->_File = null;
 
 		return $success;
 	}


### PR DESCRIPTION
Windowsでファイルハンドラが閉じられていない場合に、正常にキャッシュファイルの削除が行われないことがあります。
以下の、Cake側の変更をマージして修正しています。
ご確認よろしくお願いします。

https://github.com/cakephp/cakephp/commit/c45868e871ba889c158f583b6dc7afd7746dcfe4#diff-638fa6a7b897f6b0f1f07fb2b6282c88