### PR TITLE
fix #20256 メールフォームで「マルチチェックボックス」フィールドを「メール送信しない」設定で利用すると不正なリクエストと判断される問題を改善

### DIFF
--- a/lib/Baser/Config/theme/bc_sample/Elements/mail_input.php
+++ b/lib/Baser/Config/theme/bc_sample/Elements/mail_input.php
@@ -1,15 +1,11 @@
 <?php
 /**
- * [PUBLISH] メールフォーム本体
+ * メールフォーム入力欄
+ * 呼出箇所：メールフォーム入力ページ、メールフォーム入力内容確認ページ
  *
- * baserCMS :  Based Website Development Project <http://basercms.net>
- * Copyright (c) baserCMS Users Community <http://basercms.net/community/>
- *
- * @copyright		Copyright (c) baserCMS Users Community
- * @link			http://basercms.net baserCMS Project
- * @package			Mail.View
- * @since			baserCMS v 0.1.0
- * @license			http://basercms.net/license/index.html
+ * @var int $blockStart 表示するフィールドの開始NO
+ * @var int $blockEnd 表示するフィールドの終了NO
+ * @var bool $freezed 確認画面かどうか
  */
 $group_field = null;
 $iteration = 0;
@@ -52,12 +48,7 @@ if (!empty($mailFields)) {
 				echo '<span class="mail-before-attachment">' . $field['before_attachment'] . '</span>';
 			}
 
-			if ($field['no_send'] && $freezed) {
-				// メール送信しないフィールドの場合、確認画面では、hidden タグを表示する
-				echo $this->Mailform->control('hidden', "MailMessage." . $field['field_name'] . "", $this->Mailfield->getOptions($record), $this->Mailfield->getAttributes($record));
-			} else {
-				echo $this->Mailform->control($field['type'], "MailMessage." . $field['field_name'] . "", $this->Mailfield->getOptions($record), $this->Mailfield->getAttributes($record));
-			}
+			echo $this->Mailform->control($field['type'], "MailMessage." . $field['field_name'] . "", $this->Mailfield->getOptions($record), $this->Mailfield->getAttributes($record));
 
 			if (!$freezed || $this->Mailform->value("MailMessage." . $field['field_name']) !== '') {
 				echo '<span class="mail-after-attachment">' . $field['after_attachment'] . '</span>';

--- a/lib/Baser/Config/theme/bc_sample/Elements/mail_input.php
+++ b/lib/Baser/Config/theme/bc_sample/Elements/mail_input.php
@@ -48,7 +48,18 @@ if (!empty($mailFields)) {
 				echo '<span class="mail-before-attachment">' . $field['before_attachment'] . '</span>';
 			}
 
-			echo $this->Mailform->control($field['type'], "MailMessage." . $field['field_name'] . "", $this->Mailfield->getOptions($record), $this->Mailfield->getAttributes($record));
+			// =========================================================================================================
+			// 2018/02/06 ryuring
+			// no_send オプションは、確認画面に表示しないようにするために利用されている可能性が高い
+			//（メールアドレスのダブル入力、プライバシーポリシーへの同意に利用されている）
+			// 本来であれば、not_display_confirm 等のオプションを別途準備し、そちらを利用するべきだが、
+			// 後方互換のため残す
+			// =========================================================================================================
+			if ($freezed && $field['no_send']) {
+				echo $this->Mailform->control('hidden', "MailMessage." . $field['field_name'] . "", $this->Mailfield->getOptions($record), $this->Mailfield->getAttributes($record));
+			} else {
+				echo $this->Mailform->control($field['type'], "MailMessage." . $field['field_name'] . "", $this->Mailfield->getOptions($record), $this->Mailfield->getAttributes($record));
+			}
 
 			if (!$freezed || $this->Mailform->value("MailMessage." . $field['field_name']) !== '') {
 				echo '<span class="mail-after-attachment">' . $field['after_attachment'] . '</span>';

--- a/lib/Baser/Config/theme/bc_sample/Elements/smartphone/mail_input.php
+++ b/lib/Baser/Config/theme/bc_sample/Elements/smartphone/mail_input.php
@@ -2,6 +2,10 @@
 /**
  * メールフォーム入力欄（スマホ用）
  * 呼出箇所：メールフォーム入力ページ、メールフォーム入力内容確認ページ
+ *
+ * @var int $blockStart 表示するフィールドの開始NO
+ * @var int $blockEnd 表示するフィールドの終了NO
+ * @var bool $freezed 確認画面かどうか
  */
 $group_field = null;
 $iteration = 0;
@@ -44,11 +48,7 @@ if (!empty($mailFields)) {
 				echo '<span class="mail-before-attachment">' . $field['before_attachment'] . '</span>';
 			}
 
-			if ($field['no_send'] && $freezed) {
-				echo $this->Mailform->control('hidden', "MailMessage." . $field['field_name'] . "", $this->Mailfield->getOptions($record), $this->Mailfield->getAttributes($record));
-			} else {
-				echo $this->Mailform->control($field['type'], "MailMessage." . $field['field_name'] . "", $this->Mailfield->getOptions($record), $this->Mailfield->getAttributes($record));
-			}
+			echo $this->Mailform->control($field['type'], "MailMessage." . $field['field_name'] . "", $this->Mailfield->getOptions($record), $this->Mailfield->getAttributes($record));
 
 			if (!$freezed || $this->Mailform->value("MailMessage." . $field['field_name']) !== '') {
 				echo '<span class="mail-after-attachment">' . $field['after_attachment'] . '</span>';

--- a/lib/Baser/Config/theme/bc_sample/Elements/smartphone/mail_input.php
+++ b/lib/Baser/Config/theme/bc_sample/Elements/smartphone/mail_input.php
@@ -48,7 +48,18 @@ if (!empty($mailFields)) {
 				echo '<span class="mail-before-attachment">' . $field['before_attachment'] . '</span>';
 			}
 
-			echo $this->Mailform->control($field['type'], "MailMessage." . $field['field_name'] . "", $this->Mailfield->getOptions($record), $this->Mailfield->getAttributes($record));
+			// =========================================================================================================
+			// 2018/02/06 ryuring
+			// no_send オプションは、確認画面に表示しないようにするために利用されている可能性が高い
+			//（メールアドレスのダブル入力、プライバシーポリシーへの同意に利用されている）
+			// 本来であれば、not_display_confirm 等のオプションを別途準備し、そちらを利用するべきだが、
+			// 後方互換のため残す
+			// =========================================================================================================
+			if ($freezed && $field['no_send']) {
+				echo $this->Mailform->control('hidden', "MailMessage." . $field['field_name'] . "", $this->Mailfield->getOptions($record), $this->Mailfield->getAttributes($record));
+			} else {
+				echo $this->Mailform->control($field['type'], "MailMessage." . $field['field_name'] . "", $this->Mailfield->getOptions($record), $this->Mailfield->getAttributes($record));
+			}
 
 			if (!$freezed || $this->Mailform->value("MailMessage." . $field['field_name']) !== '') {
 				echo '<span class="mail-after-attachment">' . $field['after_attachment'] . '</span>';

--- a/lib/Baser/Controller/BcAppController.php
+++ b/lib/Baser/Controller/BcAppController.php
@@ -950,6 +950,7 @@ class BcAppController extends Controller {
 			unset($cc);
 		}
 
+		$toAddress = null;
 		try {
 			// to 送信先アドレス (最初の1人がTOで残りがBCC)
 			if (strpos($to, ',') !== false) {

--- a/lib/Baser/Plugin/Mail/View/Elements/mail_input.php
+++ b/lib/Baser/Plugin/Mail/View/Elements/mail_input.php
@@ -11,7 +11,12 @@
  */
 
 /**
- * [PUBLISH] メールフォーム本体
+ * メールフォーム入力欄
+ * 呼出箇所：メールフォーム入力ページ、メールフォーム入力内容確認ページ
+ * 
+ * @var int $blockStart 表示するフィールドの開始NO
+ * @var int $blockEnd 表示するフィールドの終了NO
+ * @var bool $freezed 確認画面かどうか
  */
 $group_field = null;
 $iteration = 0;
@@ -54,12 +59,7 @@ if (!empty($mailFields)) {
 				echo '<span class="mail-before-attachment">' . $field['before_attachment'] . '</span>';
 			}
 			
-			if ($field['no_send'] && $freezed) {
-				// メール送信しないフィールドの場合、確認画面では、hidden タグを表示する
-				echo $this->Mailform->control('hidden', "MailMessage." . $field['field_name'] . "", $this->Mailfield->getOptions($record), $this->Mailfield->getAttributes($record));
-			} else {
-				echo $this->Mailform->control($field['type'], "MailMessage." . $field['field_name'] . "", $this->Mailfield->getOptions($record), $this->Mailfield->getAttributes($record));
-			}
+			echo $this->Mailform->control('hidden', "MailMessage." . $field['field_name'] . "", $this->Mailfield->getOptions($record), $this->Mailfield->getAttributes($record));
 			
 			if (!$freezed || $this->Mailform->value("MailMessage." . $field['field_name']) !== '') {
 				echo '<span class="mail-after-attachment">' . $field['after_attachment'] . '</span>';

--- a/lib/Baser/Plugin/Mail/View/Elements/mail_input.php
+++ b/lib/Baser/Plugin/Mail/View/Elements/mail_input.php
@@ -58,9 +58,20 @@ if (!empty($mailFields)) {
 			if (!$freezed || $this->Mailform->value("MailMessage." . $field['field_name']) !== '') {
 				echo '<span class="mail-before-attachment">' . $field['before_attachment'] . '</span>';
 			}
-			
-			echo $this->Mailform->control('hidden', "MailMessage." . $field['field_name'] . "", $this->Mailfield->getOptions($record), $this->Mailfield->getAttributes($record));
-			
+
+			// =========================================================================================================
+			// 2018/02/06 ryuring
+			// no_send オプションは、確認画面に表示しないようにするために利用されている可能性が高い
+			//（メールアドレスのダブル入力、プライバシーポリシーへの同意に利用されている）
+			// 本来であれば、not_display_confirm 等のオプションを別途準備し、そちらを利用するべきだが、
+			// 後方互換のため残す
+			// =========================================================================================================
+			if ($freezed && $field['no_send']) {
+				echo $this->Mailform->control('hidden', "MailMessage." . $field['field_name'] . "", $this->Mailfield->getOptions($record), $this->Mailfield->getAttributes($record));
+			} else {
+				echo $this->Mailform->control($field['type'], "MailMessage." . $field['field_name'] . "", $this->Mailfield->getOptions($record), $this->Mailfield->getAttributes($record));
+			}
+
 			if (!$freezed || $this->Mailform->value("MailMessage." . $field['field_name']) !== '') {
 				echo '<span class="mail-after-attachment">' . $field['after_attachment'] . '</span>';
 			}

--- a/lib/Baser/Plugin/Mail/View/Elements/mobile/mail_input.php
+++ b/lib/Baser/Plugin/Mail/View/Elements/mobile/mail_input.php
@@ -45,8 +45,21 @@ if (!isset($blockEnd)) {
 				<?php if (!$freezed || $this->Mailform->value("MailMessage." . $record['MailField']['field_name'])): ?>
 					<font size="1"><?php echo $record['MailField']['before_attachment'] ?></font>
 				<?php endif; ?>
-				
-				<?php echo $this->Mailform->control($record['MailField']['type'], "MailMessage." . $record['MailField']['field_name'] . "", $this->Mailfield->getOptions($record), $this->Mailfield->getAttributes($record)) ?>
+
+				<?php
+				// =========================================================================================================
+				// 2018/02/06 ryuring
+				// no_send オプションは、確認画面に表示しないようにするために利用されている可能性が高い
+				//（メールアドレスのダブル入力、プライバシーポリシーへの同意に利用されている）
+				// 本来であれば、not_display_confirm 等のオプションを別途準備し、そちらを利用するべきだが、
+				// 後方互換のため残す
+				// =========================================================================================================
+				if ($freezed && $field['MailField']['no_send']) {
+					echo $this->Mailform->control('hidden', "MailMessage." . $field['MailField']['field_name'] . "", $this->Mailfield->getOptions($record), $this->Mailfield->getAttributes($record));
+				} else {
+					echo $this->Mailform->control($field['MailField']['type'], "MailMessage." . $field['MailField']['field_name'] . "", $this->Mailfield->getOptions($record), $this->Mailfield->getAttributes($record));
+				}
+				?>
 					
 				<?php if (!$freezed || $this->Mailform->value("MailMessage." . $record['MailField']['field_name'])): ?>
 					<font size="1"><?php echo $record['MailField']['after_attachment'] ?></font>

--- a/lib/Baser/Plugin/Mail/View/Helper/MailfieldHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MailfieldHelper.php
@@ -34,7 +34,9 @@ class MailfieldHelper extends AppHelper {
 		$attributes['maxlength'] = $data['maxlength'];
 		$attributes['separator'] = $data['separator'];
 		$attributes['class'] = $data['class'];
-
+		if($data['type'] == 'multi_check') {
+			$attributes['multiple'] = true;
+		}
 		if (!empty($data['options'])) {
 			$options = explode("|", $data['options']);
 			$options = call_user_func_array('aa', $options);


### PR DESCRIPTION
@gondoh 下記チケットの改善コミットです。
http://project.e-catchup.jp/issues/20256

問題としては、no_send オプションかつ、確認画面の際に、hidden タグの生成を行う仕様となっており、その際、マルチチェックボックスだと value に値が入るので処理に失敗している。

そもそもの仕様が間違っていたように思うので、判定文を除外しています。理由は以下のとおり。

- no_send オプションは、「表示しない」という事ではなく、「メールを送信しない」ということなので、確認画面では関係ない
- MailformHelper は、BcFreezeHelper を継承しているので、$freeezed での判定を用いなくても自動的に確認画面でhiddenタグに切り替わる仕様となっている。

間違うと先祖返りとなり得るコミットなのでレビューをお願いします。