### PR TITLE
fix #20448 メールフォーム　和暦で入力値が一桁だと確認画面で値が空になってしまう問題を改善

### DIFF
--- a/lib/Baser/View/Helper/BcTimeHelper.php
+++ b/lib/Baser/View/Helper/BcTimeHelper.php
@@ -40,7 +40,7 @@ class BcTimeHelper extends TimeHelper {
  *
  * @var string
  */
-	public $warekiRegex = '!^(?<nengo>[mtsh])-(?<year>[0-9]{2})([/\-])(?<month>0?[0-9]|1[0-2])([/\-])(?<day>[0-2][0-9]|3[01])$!';
+	public $warekiRegex = '!^(?<nengo>[mtsh])-(?<year>[0-9]{1,2})([/\-])(?<month>0?[0-9]|1[0-2])([/\-])(?<day>[0-2][0-9]|3[01])$!';
 
 /**
  * 年号を取得


### PR DESCRIPTION
説明

メールフィールド「和暦日付」を使用した際に、
選択肢平成1〜9年を選ぶと、確認画面で年の表示が消え、
書き直し画面に戻ると値が空になるため、

lib/Baser/View/Helper/BcTimeHalper.php 43行目の正規表現の判定を修正しました。
