### PR TITLE
modify #20718 メールフォーム設定編集画面で「送信先メールアドレス」などに255文字以上入力できるようにしたい。

### DIFF
--- a/lib/Baser/Plugin/Mail/Config/Schema/mail_contents.php
+++ b/lib/Baser/Plugin/Mail/Config/Schema/mail_contents.php
@@ -20,8 +20,8 @@ class MailContentsSchema extends CakeSchema {
 	public $mail_contents = array(
 		'id' => array('type' => 'integer', 'null' => false, 'default' => null, 'length' => 8, 'key' => 'primary'),
 		'description' => array('type' => 'text', 'null' => true, 'default' => null),
-		'sender_1' => array('type' => 'string', 'null' => true, 'default' => null),
-		'sender_2' => array('type' => 'string', 'null' => true, 'default' => null),
+		'sender_1' => array('type' => 'text', 'null' => true, 'default' => null),
+		'sender_2' => array('type' => 'text', 'null' => true, 'default' => null),
 		'sender_name' => array('type' => 'string', 'null' => true, 'default' => null, 'length' => 50),
 		'subject_user' => array('type' => 'string', 'null' => true, 'default' => null, 'length' => 50),
 		'subject_admin' => array('type' => 'string', 'null' => true, 'default' => null, 'length' => 50),

--- a/lib/Baser/Plugin/Mail/Config/update/4.1.0/alter_mail_contents.php
+++ b/lib/Baser/Plugin/Mail/Config/update/4.1.0/alter_mail_contents.php
@@ -1,0 +1,41 @@
+<?php
+
+class MailContentsSchema extends CakeSchema {
+
+	public $name = 'MailContents';
+
+	public $file = 'mail_contents.php';
+
+	public $connection = 'default';
+
+	public function before($event = array()) {
+		return true;
+	}
+
+	public function after($event = array()) {
+	}
+
+	public $mail_contents = array(
+		'id' => array('type' => 'integer', 'null' => false, 'default' => null, 'length' => 8, 'key' => 'primary'),
+		'description' => array('type' => 'text', 'null' => true, 'default' => null),
+		'sender_1' => array('type' => 'text', 'null' => true, 'default' => null),
+		'sender_2' => array('type' => 'text', 'null' => true, 'default' => null),
+		'sender_name' => array('type' => 'string', 'null' => true, 'default' => null, 'length' => 50),
+		'subject_user' => array('type' => 'string', 'null' => true, 'default' => null, 'length' => 50),
+		'subject_admin' => array('type' => 'string', 'null' => true, 'default' => null, 'length' => 50),
+		'form_template' => array('type' => 'string', 'null' => true, 'default' => null, 'length' => 20),
+		'mail_template' => array('type' => 'string', 'null' => true, 'default' => null, 'length' => 20),
+		'redirect_url' => array('type' => 'string', 'null' => true, 'default' => null),
+		'auth_captcha' => array('type' => 'boolean', 'null' => true, 'default' => null),
+		'widget_area' => array('type' => 'integer', 'null' => true, 'default' => null, 'length' => 4),
+		'ssl_on' => array('type' => 'boolean', 'null' => true, 'default' => null),
+		'save_info' => array('type' => 'boolean', 'null' => true, 'default' => null),
+		'publish_begin' => array('type' => 'datetime', 'null' => true, 'default' => null),
+		'publish_end' => array('type' => 'datetime', 'null' => true, 'default' => null),
+		'created' => array('type' => 'datetime', 'null' => true, 'default' => null),
+		'modified' => array('type' => 'datetime', 'null' => true, 'default' => null),
+		'indexes' => array('PRIMARY' => array('column' => 'id', 'unique' => 1)),
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_general_ci')
+	);
+
+}

--- a/lib/Baser/Plugin/Mail/Config/update/4.1.0/updater.php
+++ b/lib/Baser/Plugin/Mail/Config/update/4.1.0/updater.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * baserCMS :  Based Website Development Project <http://basercms.net>
+ * Copyright (c) baserCMS Users Community <http://basercms.net/community/>
+ *
+ * @copyright		Copyright (c) baserCMS Users Community
+ * @link			http://basercms.net baserCMS Project
+ * @package			Baser.Config
+ * @since			baserCMS v 4.1.0
+ * @license			http://basercms.net/license/index.html
+ */
+
+/**
+ * 4.1.0 バージョン アップデートスクリプト
+ */
+
+/**
+ * mail_contents テーブル構造変更
+ */
+    if($this->loadSchema('4.1.0', 'Mail', 'mail_contents', $filterType = 'alter')) {
+        $this->setUpdateLog('mail_contents テーブルの構造変更に成功しました。');
+    } else {
+        $this->setUpdateLog('mail_contents テーブルの構造変更に失敗しました。', true);
+    }

--- a/lib/Baser/Plugin/Mail/Model/MailContent.php
+++ b/lib/Baser/Plugin/Mail/Model/MailContent.php
@@ -78,12 +78,10 @@ class MailContent extends MailAppModel {
 			['rule' => ['maxLength', 255], 'message' => 'リダイレクトURLは255文字以内で入力してください。']
 		],
 		'sender_1' => [
-			['rule' => ['emails'], 'allowEmpty' => true, 'message' => '送信先メールアドレスの形式が不正です。'],
-			['rule' => ['maxLength', 255], 'message' => '送信先メールアドレスは255文字以内で入力してください。']
+			['rule' => ['emails'], 'allowEmpty' => true, 'message' => '送信先メールアドレスの形式が不正です。']
 		],
 		'sender_2' => [
-			['rule' => ['emails'], 'allowEmpty' => true, 'message' => '送信先メールアドレスの形式が不正です。'],
-			['rule' => ['maxLength', 255], 'message' => 'CC用送信先メールアドレスは255文字以内で入力してください。']
+			['rule' => ['emails'], 'allowEmpty' => true, 'message' => '送信先メールアドレスの形式が不正です。']
 		],
 		'ssl_on' => [
 			['rule' => 'checkSslUrl', "message" => 'SSL通信を利用するには、システム設定で、事前にSSL通信用のWebサイトURLを指定してください。']

--- a/lib/Baser/Plugin/Mail/Test/Case/Model/MailContentTest.php
+++ b/lib/Baser/Plugin/Mail/Test/Case/Model/MailContentTest.php
@@ -116,8 +116,6 @@ class MailContentTest extends BaserTestCase {
 			'form_template' => array('フォームテンプレート名は20文字以内で入力してください。'),
 			'mail_template' => array('メールテンプレート名は20文字以内で入力してください。'),
 			'redirect_url' => array('リダイレクトURLは255文字以内で入力してください。'),
-			'sender_1' => array('送信先メールアドレスは255文字以内で入力してください。'),
-			'sender_2' => array('CC用送信先メールアドレスは255文字以内で入力してください。')
 		);
 
 		$this->assertEquals($expected, $this->MailContent->validationErrors);

--- a/lib/Baser/Plugin/Mail/View/MailContents/admin/form.php
+++ b/lib/Baser/Plugin/Mail/View/MailContents/admin/form.php
@@ -51,7 +51,7 @@ $this->BcBaser->js('Mail.admin/mail_contents/edit', false);
 					'legend' => false,
 					'separator' => '<br />'))
 				?><br />
-<?php echo $this->BcForm->input('MailContent.sender_1', array('type' => 'text', 'size' => 40, 'maxlength' => 255)) ?>
+<?php echo $this->BcForm->input('MailContent.sender_1', array('type' => 'text', 'size' => 40)) ?>
 				<?php echo $this->BcForm->error('MailContent.sender_1') ?>
 			</td>
 		</tr>
@@ -162,7 +162,7 @@ $this->BcBaser->js('Mail.admin/mail_contents/edit', false);
 		<tr>
 			<th class="col-head"><?php echo $this->BcForm->label('MailContent.sender_2', 'BCC用送信先メールアドレス') ?></th>
 			<td class="col-input">
-<?php echo $this->BcForm->input('MailContent.sender_2', array('type' => 'text', 'size' => 80, 'maxlength' => 255)) ?>
+<?php echo $this->BcForm->input('MailContent.sender_2', array('type' => 'text', 'size' => 80)) ?>
 <?php echo $this->Html->image('admin/icn_help.png', array('id' => 'helpSender2', 'class' => 'btn help', 'alt' => 'ヘルプ')) ?>
 <?php echo $this->BcForm->error('MailContent.sender_2') ?>
 				<div id="helptextSender2" class="helptext">


### PR DESCRIPTION
@gondoh さんからのアドバイスを受けての下記チケットでの対応となります。
http://project.e-catchup.jp/issues/20718
メールフォーム設定編集画面で「送信先メールアドレス」、「BCC用送信先メールアドレス」に255文字以上入力できるようにしたい。

送信先メールアドレス(sender_1)、BCC用送信先メールアドレス(sender_2)の文字数制限撤廃
・DBのカラム変更　varchar(255)　→　text
・モデルバリデーション、テンプレートHTMLも文字数制限撤去

宜しくお願い致します。