### PR TITLE
ブログ記事を削除する際のアラートメッセージの改行が正常に表示されない問題を修正

### DIFF
--- a/lib/Baser/Plugin/Blog/View/BlogPosts/admin/form.php
+++ b/lib/Baser/Plugin/Blog/View/BlogPosts/admin/form.php
@@ -193,7 +193,7 @@ $this->BcBaser->js('Blog.admin/blog_posts/form', false, [
 	<?php elseif ($this->action == 'admin_edit'): ?>
 		<?php echo $this->BcForm->button('プレビュー', ['div' => false, 'class' => 'button', 'id' => 'BtnPreview']) ?>
 		<?php echo $this->BcForm->submit('保存', ['div' => false, 'class' => 'button', 'id' => 'BtnSave']) ?>
-		<?php $this->BcBaser->link('削除', ['action' => 'delete', $blogContent['BlogContent']['id'], $this->BcForm->value('BlogPost.id')], ['class' => 'submit-token button', 'id' => 'BtnDelete'], sprintf('%s を本当に削除してもいいですか？\n※ ブログ記事はゴミ箱に入らず完全に消去されます。', $this->BcForm->value('BlogPost.name')), false); ?>
+		<?php $this->BcBaser->link('削除', ['action' => 'delete', $blogContent['BlogContent']['id'], $this->BcForm->value('BlogPost.id')], ['class' => 'submit-token button', 'id' => 'BtnDelete'], sprintf("%s を本当に削除してもいいですか？\n※ ブログ記事はゴミ箱に入らず完全に消去されます。", $this->BcForm->value('BlogPost.name')), false); ?>
 	<?php endif ?>
 </div>
 


### PR DESCRIPTION
シングルクォーテーション内に改行コードが含まれていたので、ダブルクォーテーションに書き換えています。
ご確認をよろしくお願いします。