### PR TITLE
modify #20718 メールフォーム設定編集画面で「送信先メールアドレス」などに255文字以上入力できるようにしたい。

### DIFF
--- a/lib/Baser/Config/update/4.1.0/updater.php
+++ b/lib/Baser/Config/update/4.1.0/updater.php
@@ -34,12 +34,3 @@
     } else {
         $this->setUpdateLog('sites テーブルの構造変更に失敗しました。', true);
     }
-
-/**
- * mail_contents テーブル構造変更
- */
-	if($this->loadSchema('4.1.0', '', 'mail_contents', $filterType = 'alter')) {
-		$this->setUpdateLog('mail_contents テーブルの構造変更に成功しました。');
-	} else {
-		$this->setUpdateLog('mail_contents テーブルの構造変更に失敗しました。', true);
-	}

--- a/lib/Baser/Plugin/Mail/Config/Schema/mail_contents.php
+++ b/lib/Baser/Plugin/Mail/Config/Schema/mail_contents.php
@@ -20,8 +20,8 @@ class MailContentsSchema extends CakeSchema {
 	public $mail_contents = array(
 		'id' => array('type' => 'integer', 'null' => false, 'default' => null, 'length' => 8, 'key' => 'primary'),
 		'description' => array('type' => 'text', 'null' => true, 'default' => null),
-		'sender_1' => array('type' => 'string', 'null' => true, 'default' => null),
-		'sender_2' => array('type' => 'string', 'null' => true, 'default' => null),
+		'sender_1' => array('type' => 'text', 'null' => true, 'default' => null),
+		'sender_2' => array('type' => 'text', 'null' => true, 'default' => null),
 		'sender_name' => array('type' => 'string', 'null' => true, 'default' => null, 'length' => 255),
 		'subject_user' => array('type' => 'string', 'null' => true, 'default' => null, 'length' => 255),
 		'subject_admin' => array('type' => 'string', 'null' => true, 'default' => null, 'length' => 255),

--- a/lib/Baser/Plugin/Mail/Config/update/4.1.0/alter_mail_contents.php
+++ b/lib/Baser/Plugin/Mail/Config/update/4.1.0/alter_mail_contents.php
@@ -1,19 +1,25 @@
 <?php
-/* MailContents schema generated on: 2011-08-20 02:08:54 : 1313774094 */
+
 class MailContentsSchema extends CakeSchema {
+
 	public $name = 'MailContents';
+
 	public $file = 'mail_contents.php';
+
 	public $connection = 'default';
+
 	public function before($event = array()) {
 		return true;
 	}
+
 	public function after($event = array()) {
 	}
+
 	public $mail_contents = array(
 		'id' => array('type' => 'integer', 'null' => false, 'default' => null, 'length' => 8, 'key' => 'primary'),
 		'description' => array('type' => 'text', 'null' => true, 'default' => null),
-		'sender_1' => array('type' => 'string', 'null' => true, 'default' => null),
-		'sender_2' => array('type' => 'string', 'null' => true, 'default' => null),
+		'sender_1' => array('type' => 'text', 'null' => true, 'default' => null),
+		'sender_2' => array('type' => 'text', 'null' => true, 'default' => null),
 		'sender_name' => array('type' => 'string', 'null' => true, 'default' => null, 'length' => 255),
 		'subject_user' => array('type' => 'string', 'null' => true, 'default' => null, 'length' => 255),
 		'subject_admin' => array('type' => 'string', 'null' => true, 'default' => null, 'length' => 255),
@@ -31,4 +37,5 @@ class MailContentsSchema extends CakeSchema {
 		'indexes' => array('PRIMARY' => array('column' => 'id', 'unique' => 1)),
 		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_general_ci')
 	);
+
 }

--- a/lib/Baser/Plugin/Mail/Config/update/4.1.0/updater.php
+++ b/lib/Baser/Plugin/Mail/Config/update/4.1.0/updater.php
@@ -1,4 +1,27 @@
 <?php
+/**
+ * baserCMS :  Based Website Development Project <http://basercms.net>
+ * Copyright (c) baserCMS Users Community <http://basercms.net/community/>
+ *
+ * @copyright		Copyright (c) baserCMS Users Community
+ * @link			http://basercms.net baserCMS Project
+ * @package			Baser.Config
+ * @since			baserCMS v 4.1.0
+ * @license			http://basercms.net/license/index.html
+ */
+
+/**
+ * 4.1.0 バージョン アップデートスクリプト
+ */
+
+/**
+ * mail_contents テーブル構造変更
+ */
+if($this->loadSchema('4.1.0', 'Mail', 'mail_contents', $filterType = 'alter')) {
+	$this->setUpdateLog('mail_contents テーブルの構造変更に成功しました。');
+} else {
+	$this->setUpdateLog('mail_contents テーブルの構造変更に失敗しました。', true);
+}
 
 /**
  * MailMessage テーブルデータ更新

--- a/lib/Baser/Plugin/Mail/Model/MailContent.php
+++ b/lib/Baser/Plugin/Mail/Model/MailContent.php
@@ -78,12 +78,10 @@ class MailContent extends MailAppModel {
 			['rule' => ['maxLength', 255], 'message' => 'リダイレクトURLは255文字以内で入力してください。']
 		],
 		'sender_1' => [
-			['rule' => ['emails'], 'allowEmpty' => true, 'message' => '送信先メールアドレスの形式が不正です。'],
-			['rule' => ['maxLength', 255], 'message' => '送信先メールアドレスは255文字以内で入力してください。']
+			['rule' => ['emails'], 'allowEmpty' => true, 'message' => '送信先メールアドレスの形式が不正です。']
 		],
 		'sender_2' => [
-			['rule' => ['emails'], 'allowEmpty' => true, 'message' => '送信先メールアドレスの形式が不正です。'],
-			['rule' => ['maxLength', 255], 'message' => 'CC用送信先メールアドレスは255文字以内で入力してください。']
+			['rule' => ['emails'], 'allowEmpty' => true, 'message' => '送信先メールアドレスの形式が不正です。']
 		],
 		'ssl_on' => [
 			['rule' => 'checkSslUrl', "message" => 'SSL通信を利用するには、システム設定で、事前にSSL通信用のWebサイトURLを指定してください。']

--- a/lib/Baser/Plugin/Mail/Test/Case/Model/MailContentTest.php
+++ b/lib/Baser/Plugin/Mail/Test/Case/Model/MailContentTest.php
@@ -116,8 +116,6 @@ class MailContentTest extends BaserTestCase {
 			'form_template' => array('フォームテンプレート名は20文字以内で入力してください。'),
 			'mail_template' => array('メールテンプレート名は20文字以内で入力してください。'),
 			'redirect_url' => array('リダイレクトURLは255文字以内で入力してください。'),
-			'sender_1' => array('送信先メールアドレスは255文字以内で入力してください。'),
-			'sender_2' => array('CC用送信先メールアドレスは255文字以内で入力してください。')
 		);
 
 		$this->assertEquals($expected, $this->MailContent->validationErrors);

--- a/lib/Baser/Plugin/Mail/View/MailContents/admin/form.php
+++ b/lib/Baser/Plugin/Mail/View/MailContents/admin/form.php
@@ -51,7 +51,7 @@ $this->BcBaser->js('Mail.admin/mail_contents/edit', false);
 					'legend' => false,
 					'separator' => '<br />'))
 				?><br />
-<?php echo $this->BcForm->input('MailContent.sender_1', array('type' => 'text', 'size' => 40, 'maxlength' => 255)) ?>
+<?php echo $this->BcForm->input('MailContent.sender_1', array('type' => 'text', 'size' => 40)) ?>
 				<?php echo $this->BcForm->error('MailContent.sender_1') ?>
 			</td>
 		</tr>
@@ -162,7 +162,7 @@ $this->BcBaser->js('Mail.admin/mail_contents/edit', false);
 		<tr>
 			<th class="col-head"><?php echo $this->BcForm->label('MailContent.sender_2', 'BCC用送信先メールアドレス') ?></th>
 			<td class="col-input">
-<?php echo $this->BcForm->input('MailContent.sender_2', array('type' => 'text', 'size' => 80, 'maxlength' => 255)) ?>
+<?php echo $this->BcForm->input('MailContent.sender_2', array('type' => 'text', 'size' => 80)) ?>
 <?php echo $this->Html->image('admin/icn_help.png', array('id' => 'helpSender2', 'class' => 'btn help', 'alt' => 'ヘルプ')) ?>
 <?php echo $this->BcForm->error('MailContent.sender_2') ?>
 				<div id="helptextSender2" class="helptext">


### PR DESCRIPTION
#882 #884 を受けて改めてプルリクエストを追加致します。
お手数ですが宜しくお願い致します。
※マージミス修正しております。
※安部さん変更分のスキーマ構造変更のスクリプトはメールプラグインのものでしたのでMailプラグイン側に移動しております。