### PR TITLE
fix: ブログコメント投稿者へのメール中の「○○さんが...」の○○をブログ名→コメント投稿者名に訂正

### DIFF
--- a/lib/Baser/Config/theme/bc_sample/Emails/text/blog_comment_contributor.php
+++ b/lib/Baser/Config/theme/bc_sample/Emails/text/blog_comment_contributor.php
@@ -10,7 +10,7 @@
 　　　　　　　　◆◇　<?php echo __d('baser', 'コメントが投稿されました')?>　◇◆
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-<?php echo sprintf(__d('baser', '%sさんが、「%s」にコメントしました。'), $Content['name'], $BlogPost['name'])?>　
+<?php echo sprintf(__d('baser', '%sさんが、「%s」にコメントしました。'), $BlogComment['name'], $BlogPost['name'])?>　
 <?php echo $this->BcBaser->getUri($Content['url'] . '/archives/' . $BlogPost['no'], false) ?>　
  
 <?php echo ($BlogComment['message']) ?>　

--- a/lib/Baser/Plugin/Blog/View/Emails/text/blog_comment_contributor.php
+++ b/lib/Baser/Plugin/Blog/View/Emails/text/blog_comment_contributor.php
@@ -20,7 +20,7 @@
 　　　　　　　　◆◇　<?php echo __d('baser', 'コメントが投稿されました')?>　◇◆
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-<?php echo sprintf(__d('baser', '%sさんが、「%s」にコメントしました。'), $Content['name'], $BlogPost['name'])?>　
+<?php echo sprintf(__d('baser', '%sさんが、「%s」にコメントしました。'), $BlogComment['name'], $BlogPost['name'])?>　
 <?php echo $this->BcBaser->getUri($Content['url'] . '/archives/' . $BlogPost['no'], false) ?>　
  
 <?php echo ($BlogComment['message']) ?>　


### PR DESCRIPTION
$Content['name'] を出力していたため、$BlogComment['name']に訂正。