### PR TITLE
fix #20882 セキュリティトークンの取得処理を変更

### DIFF
--- a/lib/Baser/Controller/BcManageController.php
+++ b/lib/Baser/Controller/BcManageController.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * baserCMS :  Based Website Development Project <http://basercms.net>
+ * Copyright (c) baserCMS Users Community <http://basercms.net/community/>
+ *
+ * @copyright		Copyright (c) baserCMS Users Community
+ * @link			http://basercms.net baserCMS Project
+ * @package			Baser.Controller
+ * @since			baserCMS v 4.0.11
+ * @license			http://basercms.net/license/index.html
+ */
+
+/**
+ * 管理用コントローラー
+ *
+ * @package Baser.Controller
+ * @property CakeRequest $request
+ */
+class BcManageController extends AppController {
+/**
+ * モデル
+ * @var array
+ */
+	public $uses = [];
+	
+/**
+ * セキュリティトークンを取得する
+ *
+ * @return mixed
+ */
+	public function ajax_get_token() {
+		$this->autoRender = false;
+		return $this->getToken();
+	}
+	
+}

--- a/lib/Baser/Controller/SiteConfigsController.php
+++ b/lib/Baser/Controller/SiteConfigsController.php
@@ -66,6 +66,7 @@ class SiteConfigsController extends AppController {
  * beforeFilter
  */
 	public function beforeFilter() {
+		// @deprecated 5.0.0 since 4.0.0 ajax_get_token は、BcManagerController に移行した為、次のバージョンで削除
 		$this->BcAuth->allow('admin_ajax_credit', 'jquery_base_url', 'ajax_get_token');
 		parent::beforeFilter();
 	}
@@ -304,6 +305,7 @@ class SiteConfigsController extends AppController {
  * admin用Token取得アクション
  *
  * @return string
+ * @deprecated 5.0.0 since 4.0.0 ajax_get_token は、BcManagerController に移行した為、次のバージョンで削除
  */
 	public function admin_ajax_get_token() {
 		$this->autoRender = false;
@@ -314,6 +316,7 @@ class SiteConfigsController extends AppController {
  * セキュリティトークンを取得する
  *
  * @return mixed
+ * @deprecated 5.0.0 since 4.0.0 ajax_get_token は、BcManagerController に移行した為、次のバージョンで削除
  */
 	public function ajax_get_token() {
 		return $this->setAction(('admin_ajax_get_token'));

--- a/lib/Baser/Plugin/Blog/webroot/js/admin/blog_posts/form.js
+++ b/lib/Baser/Plugin/Blog/webroot/js/admin/blog_posts/form.js
@@ -45,7 +45,7 @@ $(function(){
 		form.submit();
 		form.attr('target', '_self');
 		form.attr('action', action);
-		$.get($.baseUrl + '/' + $.bcUtil.adminPrefix + '/site_configs/ajax_get_token', function(result) {
+		$.get($.baseUrl + '/bc_manage/ajax_get_token', function(result) {
 			$('input[name="data[_Token][key]"]').val(result);
 		});
 		return false;

--- a/lib/Baser/Plugin/Mail/Controller/MailController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailController.php
@@ -109,6 +109,7 @@ class MailController extends MailAppController {
  */
 	public function beforeFilter() {
 		/* 認証設定 */
+		// @deprecated 5.0.0 since 4.0.0 ajax_get_token は、BcManagerController に移行した為、次のバージョンで削除
 		$this->BcAuth->allow(
 			'index', 'mobile_index', 'smartphone_index', 'confirm', 'mobile_confirm', 'smartphone_confirm', 'submit', 'mobile_submit', 'smartphone_submit', 'captcha', 'smartphone_captcha', 'ajax_get_token', 'smartphone_ajax_get_token'
 		);

--- a/lib/Baser/Plugin/Mail/Test/Case/Controller/MailControllerTest.php
+++ b/lib/Baser/Plugin/Mail/Test/Case/Controller/MailControllerTest.php
@@ -88,18 +88,4 @@ class MailControllerTest extends BaserTestCase {
 		$this->markTestIncomplete('このテストは、まだ実装されていません。');
 	}
 
-/**
- * [ajax] Tokenのkeyを取得
- */
-	public function testAjax_get_token() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
-	}
-
-/**
- * [ajax] Tokenのkeyを取得
- */
-	public function testSmartphone_ajax_get_token() {
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
-	}
-
 }

--- a/lib/Baser/Plugin/Mail/View/Elements/mail_token.php
+++ b/lib/Baser/Plugin/Mail/View/Elements/mail_token.php
@@ -21,7 +21,7 @@ $(document).ready(function(){
 <?php else: ?>
 $(window).load(function(){
 <?php endif ?>
-	var getTokenUrl = '<?php echo $this->BcBaser->getUrl('/site_configs/ajax_get_token') ?>';
+	var getTokenUrl = '<?php echo $this->BcBaser->getUrl('/bc_manage/ajax_get_token') ?>';
 	$.ajaxSetup({cache: false});
 	$.get(getTokenUrl, function(result) {
 		$('input[name="data[_Token][key]"]').val(result);

--- a/lib/Baser/webroot/js/admin/contents/edit.js
+++ b/lib/Baser/webroot/js/admin/contents/edit.js
@@ -51,7 +51,7 @@ $(function(){
         form.submit();
         form.attr('target', '_self');
         form.attr('action', action);
-        $.get($.baseUrl + '/' + $.bcUtil.adminPrefix + '/site_configs/ajax_get_token', function(result) {
+        $.get($.baseUrl + '/bc_manage/ajax_get_token', function(result) {
             $('input[name="data[_Token][key]"]').val(result);
         });
         return false;

--- a/lib/Baser/webroot/js/admin/libs/jquery.bcToken.js
+++ b/lib/Baser/webroot/js/admin/libs/jquery.bcToken.js
@@ -41,7 +41,7 @@
 		/**
 		 * デフォルトトークンURL
 		 */
-			defaultUrl: '/' + $.bcUtil.adminPrefix + '/site_configs/ajax_get_token?requestview=false',
+			defaultUrl: '/bc_manage/ajax_get_token?requestview=false',
 
 		/**
 		 * トークンを取得しているかどうかチェックし、取得していない場合取得する

--- a/lib/Baser/webroot/js/admin/users/login.js
+++ b/lib/Baser/webroot/js/admin/users/login.js
@@ -20,7 +20,7 @@ $(function(){
 	});
 
 	$("#BtnLogin").click(function(){
-		$.bcToken.setTokenUrl('/site_configs/ajax_get_token');
+		$.bcToken.setTokenUrl('/bc_manage/ajax_get_token');
 		$("#BtnLogin").attr('disabled', 'disabled');
 		$.bcToken.check(function() {
 			$("#UserLoginForm").submit();	


### PR DESCRIPTION
- SiteConfigsControllerで取得する場合、アクセス制限管理にひっかかってしまう為、新しいコントローラーに処理を移行