### PR TITLE
メールフォームで、グループ入力チェック設定されているフィールドのエラーメッセージを調整

### DIFF
--- a/lib/Baser/Config/theme/bc_sample/Elements/mail_input.php
+++ b/lib/Baser/Config/theme/bc_sample/Elements/mail_input.php
@@ -78,11 +78,20 @@ if (!empty($mailFields)) {
 				($field['group_field'] != $mailFields[$next_key]['MailField']['group_field'] && $this->BcArray->first($mailFields, $key))) {
 
 				if ($field['group_valid']) {
-					if ($field['valid']) {
-						echo $this->Mailform->error("MailMessage." . $field['group_field'], __("必須項目です。"));
-					}
 					echo $this->Mailform->error("MailMessage." . $field['group_field'] . "_not_same", __("入力データが一致していません。"));
 					echo $this->Mailform->error("MailMessage." . $field['group_field'] . "_not_complate", __("入力データが不完全です。"));
+
+					if (!$this->Mailform->error("MailMessage." . $field['group_field'] . "_not_same")
+						&& !$this->Mailform->error("MailMessage." . $field['group_field'] . "_not_complate")) {
+						$groupValidErrors = $this->Mailform->getGroupValidErrors($mailFields, $field['group_valid']);
+						if ($groupValidErrors) {
+							foreach ($groupValidErrors as $groupValidError) {
+								echo $groupValidError;
+							}
+						} else {
+							echo $this->Mailform->error("MailMessage." . $field['group_field'], __("必須項目です。"));
+						}
+					}
 				}
 
 				echo '</span>';

--- a/lib/Baser/Config/theme/bc_sample/Elements/smartphone/mail_input.php
+++ b/lib/Baser/Config/theme/bc_sample/Elements/smartphone/mail_input.php
@@ -78,11 +78,20 @@ if (!empty($mailFields)) {
 				($field['group_field'] != $mailFields[$next_key]['MailField']['group_field'] && $this->BcArray->first($mailFields, $key))) {
 
 				if ($field['group_valid']) {
-					if ($field['valid']) {
-						echo $this->Mailform->error("MailMessage." . $field['group_field'], __("必須項目です。"));
+					echo $this->Mailform->error("MailMessage." . $field['group_field'] . "_not_same", __("入力データが一致していません。"));
+					echo $this->Mailform->error("MailMessage." . $field['group_field'] . "_not_complate", __("入力データが不完全です。"));
+
+					if (!$this->Mailform->error("MailMessage." . $field['group_field'] . "_not_same")
+						&& !$this->Mailform->error("MailMessage." . $field['group_field'] . "_not_complate")) {
+						$groupValidErrors = $this->Mailform->getGroupValidErrors($mailFields, $field['group_valid']);
+						if ($groupValidErrors) {
+							foreach ($groupValidErrors as $groupValidError) {
+								echo $groupValidError;
+							}
+						} else {
+							echo $this->Mailform->error("MailMessage." . $field['group_field'], __("必須項目です。"));
+						}
 					}
-					echo $this->Mailform->error("MailMessage." . $field['group_field'] . "_not_same", "Input data do not match.");
-					echo $this->Mailform->error("MailMessage." . $field['group_field'] . "_not_complate", "Input data is incomplete.");
 				}
 
 				echo '</span>';

--- a/lib/Baser/Plugin/Mail/View/Elements/mail_input.php
+++ b/lib/Baser/Plugin/Mail/View/Elements/mail_input.php
@@ -89,11 +89,20 @@ if (!empty($mailFields)) {
 				($field['group_field'] != $mailFields[$next_key]['MailField']['group_field'] && $this->BcArray->first($mailFields, $key))) {
 
 				if ($field['group_valid']) {
-					if ($field['valid']) {
-						echo $this->Mailform->error("MailMessage." . $field['field_name'], __("必須項目です。"));
-					}
 					echo $this->Mailform->error("MailMessage." . $field['group_field'] . "_not_same", __("入力データが一致していません。"));
 					echo $this->Mailform->error("MailMessage." . $field['group_field'] . "_not_complate", __("入力データが不完全です。"));
+
+					if (!$this->Mailform->error("MailMessage." . $field['group_field'] . "_not_same")
+						&& !$this->Mailform->error("MailMessage." . $field['group_field'] . "_not_complate")) {
+						$groupValidErrors = $this->Mailform->getGroupValidErrors($mailFields, $field['group_valid']);
+						if ($groupValidErrors) {
+							foreach ($groupValidErrors as $groupValidError) {
+								echo $groupValidError;
+							}
+						} else {
+							echo $this->Mailform->error("MailMessage." . $field['group_field'], __("必須項目です。"));
+						}
+					}
 				}
 
 				echo '</span>';

--- a/lib/Baser/Plugin/Mail/View/Elements/mobile/mail_input.php
+++ b/lib/Baser/Plugin/Mail/View/Elements/mobile/mail_input.php
@@ -86,13 +86,23 @@ if (!isset($blockEnd)) {
 					<?php if ($field['group_valid']): ?>
 						<?php if ($this->Mailform->error("MailMessage." . $field['group_field'] . "_format", "check")): ?>
 							<font color="#FF0000"><?php echo $this->Mailform->error("MailMessage." . $field['group_field'] . "_format", __("形式が無効です。"), array('wrap' => false)) ?></font>
-						<?php else: ?>
-							<?php if ($field['valid']) : ?>
-								<font color="#FF0000"><?php echo $this->Mailform->error("MailMessage." . $field['group_field'] . "", __("必須項目です。"), array('wrap' => false)) ?></font>
-							<?php endif; ?>
 						<?php endif; ?>
 						<font color="#FF0000"><?php echo $this->Mailform->error("MailMessage." . $field['group_field'] . "_not_same", __("入力データが一致していません"), array('wrap' => false)) ?></font> 
 						<font color="#FF0000"><?php echo $this->Mailform->error("MailMessage." . $field['group_field'] . "_not_complate", __("入力データが不完全です"), array('wrap' => false)) ?></font>
+
+						<?php
+						if (!$this->Mailform->error("MailMessage." . $field['group_field'] . "_not_same")
+							&& !$this->Mailform->error("MailMessage." . $field['group_field'] . "_not_complate")) {
+							$groupValidErrors = $this->Mailform->getGroupValidErrors($mailFields, $field['group_valid'], array('wrap' => false));
+							if ($groupValidErrors) {
+								foreach ($groupValidErrors as $groupValidError) {
+									echo '<font color="#FF0000">' . $groupValidError . '</font>';
+								}
+							} else {
+								echo '<font color="#FF0000">'. $this->Mailform->error("MailMessage." . $field['group_field'], __("必須項目です。"), array('wrap' => false)) . '</font>';
+							}
+						}
+						?>
 					<?php endif; ?>
 				<?php endif; ?>
 				<?php $group_field = $field['group_field'] ?>

--- a/lib/Baser/Plugin/Mail/View/Helper/MailformHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MailformHelper.php
@@ -248,4 +248,34 @@ class MailformHelper extends BcFreezeHelper {
 		echo $output;
 	}
 
+/**
+ * 指定したgroup_validをもつフィールドのエラーを取得する
+ *
+ * @param array $mailFields
+ * @param string $groupValid
+ * @param array $options
+ * @param bool $distinct 同じエラーメッセージをまとめる
+ * @return array
+ */
+	public function getGroupValidErrors($mailFields, $groupValid, $options = [], $distinct = true) {
+		$errors = [];
+
+		foreach ($mailFields as $mailField) {
+			if ($mailField['MailField']['group_valid'] != $groupValid) {
+				continue;
+			}
+
+			$errorMessage = null;
+			if ($this->value("MailMessage." . $mailField['MailField']['field_name'])) {
+				$errorMessage = $this->error("MailMessage." . $mailField['MailField']['field_name'], null, $options);
+			}
+
+			if ($errorMessage && (!$distinct || !array_search($errorMessage, $errors))) {
+				$errors[$mailField['MailField']['field_name']] = $errorMessage;
+			}
+		}
+
+		return $errors;
+	}
+
 }


### PR DESCRIPTION
グループ入力チェック設定とバリデーション設定を行なっているメールフィールドに、
バリデーションに通らない値を入力した場合に「必須項目です。」と表示される問題を修正しています。

処理としては、指定したgroup_validをもつメールフィールド全てのエラーをチェックし、表示するようにしています。
そのための、getGroupValidErrorsというヘルパーをMailformHelperに作成しています。

ご確認をよろしくお願いします。

![default](https://user-images.githubusercontent.com/30764014/37703191-30e8a0a6-2d38-11e8-9353-92b26989295a.PNG)
