### PR TITLE
スペシャルサンクスの取得元URLを修正

### DIFF
--- a/lib/Baser/Config/setting.php
+++ b/lib/Baser/Config/setting.php
@@ -53,7 +53,7 @@ $config['BcApp'] = array(
 	'testTheme' => 'nada-icons',
 	'marketThemeRss' => 'https://market.basercms.net/themes.rss',
 	'marketPluginRss' => 'https://market.basercms.net/plugins.rss',
-	'specialThanks'	=> 'http://basercms.net/special_thanks/special_thanks/ajax_users'
+	'specialThanks' => 'https://basercms.net/special_thanks/special_thanks/ajax_users'
 );
 
 /**


### PR DESCRIPTION
SSL化後のURLに変更しています。
一部の環境において、クレジットの取得に失敗する場合があるためです。
http://forum.basercms.net/modules/newbb/viewtopic.php?viewmode=flat&topic_id=3109&forum=5