### PR TITLE
サイト内検索のカテゴリにサブサイトのフォルダが表示される問題を修正

### DIFF
--- a/lib/Baser/Controller/SearchIndicesController.php
+++ b/lib/Baser/Controller/SearchIndicesController.php
@@ -87,6 +87,9 @@ class SearchIndicesController extends AppController {
 				}
 			}
 			$content = $Content->find('first', ['conditions' => ['Content.url' => $url], 'recursive' => 0]);
+			if (is_null($content['Site']['id'])) {
+				$content['Site'] = $this->Site->getRootMain()['Site'];
+			}
 			$this->request->params['Content'] = $content['Content'];
 			$this->request->params['Site'] = $content['Site'];
 		}


### PR DESCRIPTION
検索結果の一覧ページ内の、サイト内検索のカテゴリにサブサイトのフォルダが表示される問題を修正しています。
ご確認をよろしくお願いします。
（※キャッシュ有効時は再現しない場合があります。）

![_2018-04-05_16_11_20](https://user-images.githubusercontent.com/30764014/38353471-7ba658d0-38f1-11e8-9c3a-602c6006d120.png)
