### PR TITLE
fix フィードが正しく出力されない点を修正

### DIFF
--- a/lib/Baser/Plugin/Blog/View/Blog/rss/index.php
+++ b/lib/Baser/Plugin/Blog/View/Blog/rss/index.php
@@ -28,7 +28,6 @@ function transformRSS($data) {
 		'url' => '',
 		'type' => '',
 		'length' => '',
-		'yj:caption' => '',
 	];
 	if (!empty($data['BlogPost']['eye_catch'])) {
 		$eyeCatch['url'] = Router::url($blogHelper->getEyeCatch($data, ['imgsize' => '', 'output' => 'url']), true);

--- a/lib/Baser/Plugin/Blog/View/Blog/rss/mobile/index.php
+++ b/lib/Baser/Plugin/Blog/View/Blog/rss/mobile/index.php
@@ -28,7 +28,6 @@ function transformRSS($data) {
 		'url' => '',
 		'type' => '',
 		'length' => '',
-		'yj:caption' => '',
 	];
 	if (!empty($data['BlogPost']['eye_catch'])) {
 		$eyeCatch['url'] = Router::url($blogHelper->getEyeCatch($data, ['imgsize' => 'mobile_thumb', 'output' => 'url']), true);


### PR DESCRIPTION
以下の問題を見つけたため、修正のコミットをお届けします。
可能な際に取込検討を、どうかよろしくお願いします。
- enclosure のyj:caption属性が存在すると、フィードが正しく解釈されないケースがあるため（例: Firefox）
- yj:caption属性はYahooRSSの独自仕様のようで、本来は他の3つまでが正しい要素のため
