### PR TITLE
fix #21049 メールフォームのファイルタイプで、拡張入力チェックの「ファイルアップロードサイズ制限」を指定した際のエラーメッセージが表示されない

### DIFF
--- a/lib/Baser/Model/BcAppModel.php
+++ b/lib/Baser/Model/BcAppModel.php
@@ -763,8 +763,10 @@ class BcAppModel extends Model {
  * 
  * @param array $check チェック対象データ
  * @param int $size 最大のファイルサイズ
+ * @deprecated since 4.1.0.2 アップロードしたファイルのサイズチェックに加えて、アップロード時のエラーコードをログに取るようにするため
  */
 	public function fileSize($check, $size) {
+		$this->log(__d('baser', 'メソッド：BcAppModel::fileSize()は、バージョン 4.1.0.2 より非推奨となりました。BcAppModel::fileCheck() を利用してください。'), LOG_ALERT);
 		$file = $check[key($check)];
 		if (!empty($file['name'])) {
 			// サイズが空の場合は、HTMLのMAX_FILE_SIZEの制限によりサイズオーバー
@@ -774,6 +776,72 @@ class BcAppModel extends Model {
 			}
 			if ($file['size'] > $size) {
 				return;
+			}
+		}
+		return true;
+	}
+
+/**
+ * ファイルサイズチェック
+ * 
+ * @param array $check チェック対象データ
+ * @param int $size 最大のファイルサイズ
+ * @link http://php.net/manual/ja/features.file-upload.errors.php
+ */
+	public function fileCheck($check, $size) {
+		$file = $check[key($check)];
+
+		$fileErrorCode = Hash::get($file, 'error');
+		if ($fileErrorCode) {
+			// ファイルアップロード時のエラーメッセージを取得する
+			switch ($fileErrorCode) {
+				case 1:	
+					// UPLOAD_ERR_INI_SIZE
+					// アップロードされたファイルは、php.ini の upload_max_filesize ディレクティブの値を超えています。
+					$this->log('CODE: ' . $fileErrorCode . ' ファイルサイズがアップロード可能なサイズをオーバーしています。');
+					break;
+				case 2:
+					// UPLOAD_ERR_FORM_SIZE
+					// アップロードされたファイルは、HTMLで指定された MAX_FILE_SIZE を超えています。
+					$this->log('CODE: ' . $fileErrorCode . ' ファイルサイズが指定容量をオーバーしています。');
+					break;
+				case 3:
+					// UPLOAD_ERR_PARTIAL
+					// アップロードされたファイルは一部のみしかアップロードされていません。
+					$this->log('CODE: ' . $fileErrorCode . ' アップロードされたファイルが不完全です。');
+					break;
+				case 4:
+					// UPLOAD_ERR_NO_FILE
+					// ファイルはアップロードされませんでした。
+					break;
+				case 6:
+					// UPLOAD_ERR_NO_TMP_DIR
+					// テンポラリフォルダがありません。
+					$this->log('CODE: ' . $fileErrorCode . ' 一時書込み用のフォルダがありません。');
+					break;
+				case 7:
+					// UPLOAD_ERR_CANT_WRITE
+					// ディスクへの書き込みに失敗しました。
+					$this->log('CODE: ' . $fileErrorCode . ' ディスクへの書き込みに失敗しました。');
+					break;
+				case 8:
+					// UPLOAD_ERR_EXTENSION
+					// PHPの拡張モジュールがファイルのアップロードを中止しました。
+					$this->log('CODE: ' . $fileErrorCode . ' PHPの拡張モジュールがファイルのアップロードを中止しました。');
+					break;
+				default:
+					break;
+			}
+		}
+
+		if (!empty($file['name'])) {
+			// サイズが空の場合は、HTMLのMAX_FILE_SIZEの制限によりサイズオーバー
+			// だが、post_max_size を超えた場合は、ここまで処理がこない可能性がある
+			if (!$file['size']) {
+				return false;
+			}
+			if ($file['size'] > $size) {
+				return false;
 			}
 		}
 		return true;

--- a/lib/Baser/Plugin/Mail/Model/MailMessage.php
+++ b/lib/Baser/Plugin/Mail/Model/MailMessage.php
@@ -216,10 +216,12 @@ class MailMessage extends MailAppModel {
 					switch ($valid) {
 						case 'VALID_MAX_FILE_SIZE':
 							if(!empty($options['maxFileSize'])) {
-								$this->validate[$mailField['field_name']]['fileSize'] = array(
-									'rule'	=> array('fileSize', $options['maxFileSize'] * 1000 * 1000),
+								$this->validate[$mailField['field_name']]['fileCheck'] = array(
+									'rule'	=> array('fileCheck', $options['maxFileSize'] * 1000 * 1000),
 									'message'	=> __('ファイルサイズがオーバーしています。 %s MB以内のファイルをご利用ください。', $options['maxFileSize'])
 								);
+								// 必須入力としている場合、必須エラーが優先され、ファイルサイズオーバーのエラーメッセージとならないため、バリデーションエラーの優先度を入れ替える
+								$this->validate[$mailField['field_name']] = array_reverse($this->validate[$mailField['field_name']]);
 							}
 							break;
 						case 'VALID_FILE_EXT':

--- a/lib/Baser/Test/Case/Model/BcAppTest.php
+++ b/lib/Baser/Test/Case/Model/BcAppTest.php
@@ -586,7 +586,7 @@ class BcAppTest extends BaserTestCase {
  * ファイルの拡張子チェック
  * 
  * @param string $fileName チェック対象ファイル名
- * @param string $fileSize チェック対象ファイルタイプ
+ * @param string $fileType チェック対象ファイルタイプ
  * @param boolean $expect
  * @dataProvider fileExtDataProvider
  */

--- a/lib/Baser/Test/Case/Model/BcAppTest.php
+++ b/lib/Baser/Test/Case/Model/BcAppTest.php
@@ -554,6 +554,35 @@ class BcAppTest extends BaserTestCase {
 	}
 
 /**
+ * ファイルサイズチェック
+ * 
+ * @param string $fileName チェック対象ファイル名
+ * @param string $fileSize チェック対象ファイルサイズ
+ * @param boolean $expect
+ * @dataProvider fileSizeDataProvider
+ */
+	public function testFileCheck($fileName, $fileSize, $expect) {
+		$check = [[
+				"name" => $fileName,
+				"size" => $fileSize,
+			]
+		];
+		$size = 1000;
+
+		$result = $this->BcApp->fileCheck($check, $size);
+		$this->assertEquals($expect, $result);		
+	}
+
+	public function fileCheckDataProvider() {
+		return [
+			["test.jpg", 1000, true],
+			["test.jpg", 1001, false],
+			["", 1000, true],
+			["test.jpg", null, false],
+		];
+	}
+
+/**
  * ファイルの拡張子チェック
  * 
  * @param string $fileName チェック対象ファイル名


### PR DESCRIPTION
先日はご指摘・アドバイスとありがとうございました。
内容を元に調整入れましたので、可能な際にご確認・取込検討いただけますとうれしいです。
よろしくお願いいたします！
