### PR TITLE
fix #21421 既存アイキャッチ画像と同じファイル名のアイキャッチ画像を別のコンテンツ等で登録した際の不具合修正

### DIFF
--- a/lib/Baser/Model/Behavior/BcUploadBehavior.php
+++ b/lib/Baser/Model/Behavior/BcUploadBehavior.php
@@ -1043,8 +1043,10 @@ class BcUploadBehavior extends ModelBehavior {
 				 * ファイル名重複回避処理対応
 				 * 元画像ファイルと同様コピー画像ファイルにも適用
 				 */
-				if ($fileName !== $Model->data[$Model->alias]['name']['name']) {
-					$Model->data[$Model->alias]['name']['name'] = $fileName;
+				if (isset($Model->data[$Model->alias]['name']['name'])) {
+					if ($fileName !== $Model->data[$Model->alias]['name']['name']) {
+						$Model->data[$Model->alias]['name']['name'] = $fileName;
+					}
 				}
 				$copy['name'] = $field['name'];
 				$copy['ext'] = $field['ext'];

--- a/lib/Baser/Model/Behavior/BcUploadBehavior.php
+++ b/lib/Baser/Model/Behavior/BcUploadBehavior.php
@@ -1039,6 +1039,13 @@ class BcUploadBehavior extends ModelBehavior {
 						continue;
 					}
 				}
+				/**
+				 * ファイル名重複回避処理対応
+				 * 元画像ファイルと同様コピー画像ファイルにも適用
+				 */
+				if ($fileName !== $Model->data[$Model->alias]['name']['name']) {
+					$Model->data[$Model->alias]['name']['name'] = $fileName;
+				}
 				$copy['name'] = $field['name'];
 				$copy['ext'] = $field['ext'];
 				$ret = $this->copyImage($Model, $copy);


### PR DESCRIPTION
baserCMS4.1.0.1で既存アイキャッチ画像と同じファイル名のアイキャッチ画像を別のコンテンツ等で登録すると既存アイキャッチ画像のサムネイル画像が上書きされてしまう事象を確認しましたので修正しております。
http://project.e-catchup.jp/issues/21421

大変お手数お掛けし申し訳ございませんがご確認のほど宜しくお願い致します。

