### PR TITLE
modify #21464 メールフォームの自動返信メールに、送信されたファイルを添付しないよう変更

### DIFF
--- a/lib/Baser/Plugin/Mail/Controller/MailController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailController.php
@@ -500,7 +500,6 @@ class MailController extends MailAppController {
 				'from'		=> $fromAdmin,
 				'template'	=> 'Mail.' . $mailContent['mail_template'],
 				'replyTo'		=> $fromAdmin,
-				'attachments'	=> $attachments,
 				'agentTemplate' => $agentTemplate,
 				'additionalParameters'	 => '-f ' . $fromAdmin,
 			);


### PR DESCRIPTION
メールフォームにおいて、「ファイル」タイプのメールフィールドに送信されたファイルを、
送信者への自動返信メールに添付しないように変更を行いました。

理由としては、以下2点です：
スマートフォンに送られた場合、パケットを大量に使用してしまう恐れがある
ウィルス配布の踏み台にされる危険性がある

よろしくお願い致します。