### PR TITLE
fix #21466 公開側サイト内検索に content_id を指定できるようにするため

### DIFF
--- a/lib/Baser/Controller/SearchIndicesController.php
+++ b/lib/Baser/Controller/SearchIndicesController.php
@@ -177,6 +177,9 @@ class SearchIndicesController extends AppController {
 		if (isset($data['SearchIndex']['s'])) {
 			$conditions['SearchIndex.site_id'] = $data['SearchIndex']['s'];
 		}
+		if (isset($data['SearchIndex']['ci'])) {
+			$conditions['SearchIndex.content_id'] = $data['SearchIndex']['ci'];
+		}
 		if (!empty($data['SearchIndex']['f'])) {
 			$content = $this->Content->find('first', ['fields' => ['lft', 'rght'], 'conditions' => ['Content.id' => $data['SearchIndex']['f']], 'recursive' => -1]);
 			$conditions['SearchIndex.rght <'] = $content['Content']['rght'];

--- a/lib/Baser/Model/Content.php
+++ b/lib/Baser/Model/Content.php
@@ -933,12 +933,12 @@ class Content extends AppModel {
 			'Content.plugin',
 			'Content.title',
 		];
-		$contentType = $this->find('all', array(
+		$contentType = $this->find('all', [
 			'conditions' => $conditions,
 			'fields'	 => $fields,
 			'order'		 => $options['order'],
 			'recursive'	 => $options['recursive'],
-		));
+		]);
 
 		return $contentType;
 	}

--- a/lib/Baser/Model/Content.php
+++ b/lib/Baser/Model/Content.php
@@ -905,13 +905,12 @@ class Content extends AppModel {
 		$options = array_merge([
 			'excludeId'		 => null,
 			'excludeType'	 => ['ContentFolder', 'Page'],
+			'unpublish'		 => false,
 			'order'			 => 'Content.id ASC',
 			'recursive'		 => -1,
 			], $options);
 
-		$conditions = [
-			'alias_id' => null
-		];
+		$conditions = ['alias_id' => null];
 		if (!is_null($siteId)) {
 			$conditions['site_id'] = $siteId;
 		}
@@ -920,6 +919,9 @@ class Content extends AppModel {
 		}
 		if ($options['excludeType']) {
 			$conditions['type <>'] = $options['excludeType'];
+		}
+		if (!$options['unpublish']) {
+			$conditions = array_merge($conditions, $this->getConditionAllowPublish());
 		}
 
 		if (!empty($options['conditions'])) {

--- a/lib/Baser/Model/Content.php
+++ b/lib/Baser/Model/Content.php
@@ -895,6 +895,79 @@ class Content extends AppModel {
 	}
 
 /**
+ * タイプ別のコンテンツを取得する
+ *
+ * @param int $siteId
+ * @param array $options
+ * @return array|bool
+ */
+	public function getContentType($siteId = null, $options = []) {
+		$options = array_merge([
+			'excludeId'		 => null,
+			'excludeType'	 => ['ContentFolder', 'Page'],
+			'order'			 => 'Content.id ASC',
+			'recursive'		 => -1,
+			], $options);
+
+		$conditions = [
+			'alias_id' => null
+		];
+		if (!is_null($siteId)) {
+			$conditions['site_id'] = $siteId;
+		}
+		if ($options['excludeId']) {
+			$conditions['id <>'] = $options['excludeId'];
+		}
+		if ($options['excludeType']) {
+			$conditions['type <>'] = $options['excludeType'];
+		}
+
+		if (!empty($options['conditions'])) {
+			$conditions = array_merge($conditions, $options['conditions']);
+		}
+
+		$fields = [
+			'DISTINCT Content.type',
+			'Content.id',
+			'Content.name',
+			'Content.plugin',
+			'Content.title',
+		];
+		$contentType = $this->find('all', array(
+			'conditions' => $conditions,
+			'fields'	 => $fields,
+			'order'		 => $options['order'],
+			'recursive'	 => $options['recursive'],
+		));
+
+		return $contentType;
+	}
+
+/**
+ * タイプ別のコンテンツリストを取得する
+ * コンボボックス用
+ * 
+ * @param int $siteId
+ * @param array $options
+ * @return array|bool
+ */
+	public function getContentTypeList($siteId = null, $options = []) {
+		$options = array_merge([
+			'key'	 => 'id',
+			'value'	 => 'title',
+			'group'	 => null,
+			], $options);
+
+		$contentType	 = $this->getContentType($siteId, $options);
+		$contentTypeList = Hash::combine($contentType,
+			"{n}.Content.{$options['key']}",
+			"{n}.Content.{$options['value']}",
+			"{n}.Content.{$options['group']}");
+
+		return $contentTypeList;
+	}
+
+/**
  * ツリー構造のデータを コンボボックスのデータ用に変換する
  * @param $nodes
  * @return array

--- a/lib/Baser/Test/Case/Model/ContentTest.php
+++ b/lib/Baser/Test/Case/Model/ContentTest.php
@@ -688,4 +688,18 @@ class ContentTest extends BaserTestCase {
 		];
 	}
 
+/**
+ * タイプ別のコンテンツを取得する
+ */
+	public function testGetContentType() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+/**
+ * タイプ別のコンテンツリストを取得する
+ */
+	public function testGetContentTypeList() {
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
 }

--- a/lib/Baser/Test/Case/View/Helper/BcContentsHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcContentsHelperTest.php
@@ -506,4 +506,18 @@ class BcContentsHelperTest extends BaserTestCase {
 	public function test_getIconUrl(){
 		$this->markTestIncomplete('このテストは、まだ実装されていません。');
 	}
+
+/**
+ * タイプ別のコンテンツを取得する
+ */
+	public function testGetContentType(){
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
+
+/**
+ * タイプ別のコンテンツリストを取得する
+ */
+	public function testGetContentTypeList(){
+		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+	}
 }

--- a/lib/Baser/View/Elements/site_search_form.php
+++ b/lib/Baser/View/Elements/site_search_form.php
@@ -22,6 +22,7 @@ if (!empty($this->passedArgs['num'])) {
 	$url = ['plugin' => null, 'controller' => 'search_indices', 'action' => 'search'];
 }
 $folders = $this->BcContents->getContentFolderList($this->request->params['Site']['id'], ['excludeId' => $this->BcContents->getSiteRootId($this->request->params['Site']['id'])]);
+$contentList = $this->BcContents->getContentTypeList($this->request->params['Site']['id']);
 ?>
 
 
@@ -32,6 +33,11 @@ $folders = $this->BcContents->getContentFolderList($this->request->params['Site'
 		<?php echo $this->BcForm->label('SearchIndex.f', __d('baser', 'カテゴリ')) ?><br>
 		<?php echo $this->BcForm->input('SearchIndex.f', ['type' => 'select', 'options' => $folders, 'empty' => __d('baser', '指定しない'), 'escape' => false]) ?><br>
 	<?php endif ?>
+	<?php if ($contentList): ?>
+		<?php echo $this->BcForm->label('SearchIndex.ci', __d('baser', 'コンテンツ')); ?><br>
+		<?php echo $this->BcForm->input('SearchIndex.ci', ['type' => 'select', 'options' => $contentList, 'empty' => __d('baser', '指定しない'), 'escape' => false]); ?><br>
+	<?php endif; ?>
+		
 	<?php echo $this->BcForm->input('SearchIndex.q', ['placeholder' => __d('baser', 'キーワード')]) ?>
 	<?php echo $this->BcForm->hidden('SearchIndex.s', ['value' => $this->request->params['Site']['id']]) ?>
 	<?php echo $this->BcForm->submit(__d('baser', '検索'), ['div' => false, 'class' => 'submit_button']) ?>

--- a/lib/Baser/View/Helper/BcContentsHelper.php
+++ b/lib/Baser/View/Helper/BcContentsHelper.php
@@ -430,7 +430,29 @@ class BcContentsHelper extends AppHelper {
 	public function getContentFolderList($siteId = null, $options = []) {
 		return $this->_Content->getContentFolderList($siteId, $options);
 	}
-	
+
+/**
+ * タイプ別のコンテンツを取得する
+ * 
+ * @param int $siteId
+ * @param array $options
+ * @return array|bool
+ */
+	public function getContentType($siteId = null, $options = []) {
+		return $this->_Content->getContentType($siteId, $options);
+	}
+
+/**
+ * タイプ別のコンテンツリストを取得する
+ * 
+ * @param int $siteId
+ * @param array $options
+ * @return array|bool
+ */
+	public function getContentTypeList($siteId = null, $options = []) {
+		return $this->_Content->getContentTypeList($siteId, $options);
+	}
+
 /**
  * サイトIDからサイトルートとなるコンテンツを取得する
  * 


### PR DESCRIPTION
コンテンツ別の絞り込みがコアにあったら良いなとの要望を受けたので実装してみました。
可能な際に取込検討していただけたらうれしいです。
よろしくお願いします_(．．)_
http://project.e-catchup.jp/issues/21466
