### PR TITLE
fix #21515 ブログ記事を保存した際に、検索コンテンツのURLにスラッシュが2重で登録される

### DIFF
--- a/lib/Baser/Plugin/Blog/Model/BlogPost.php
+++ b/lib/Baser/Plugin/Blog/Model/BlogPost.php
@@ -571,7 +571,7 @@ class BlogPost extends BlogAppModel {
 		$_data['SearchIndex']['site_id'] = $content['Content']['site_id'];
 		$_data['SearchIndex']['title'] = $data['name'];
 		$_data['SearchIndex']['detail'] = $data['content'] . ' ' . $data['detail'];
-		$_data['SearchIndex']['url'] = $content['Content']['url'] . '/archives/' . $data['no'];
+		$_data['SearchIndex']['url'] = $content['Content']['url'] . 'archives/' . $data['no'];
 		$_data['SearchIndex']['status'] = $this->allowPublish($data);
 		$_data['SearchIndex']['content_filter_id'] = $data['blog_category_id'];
 		return $_data;


### PR DESCRIPTION
気づいたので調整入れてみました。可能な際に取込検討よろしくお願いします。
http://project.e-catchup.jp/issues/21515
