### PR TITLE
サブフォルダにインストールした際にbcColumnのスマホ用メニューのアイコンが表示されない問題を修正

### DIFF
--- a/lib/Baser/Config/theme/bccolumn/js/startup.js
+++ b/lib/Baser/Config/theme/bccolumn/js/startup.js
@@ -105,15 +105,16 @@ $(function() {
  *--------------------------------------------------------------------------*/
 
 $(function(){
+	var baseUrl = $('#Logo a').attr('href');
 	if( window.matchMedia('(max-width:768px)').matches ){
 		var flg = "close";
 		$("#BtnMenu img").click(function(){
 			$('#GrobalNavi > ul').slideToggle();
 			if(flg=="close") {
-				this.src = "/theme/bccolumn/img/sp/btn_close.png";
+				this.src = baseUrl + "theme/bccolumn/img/sp/btn_close.png";
 				flg = "open";
 			} else {
-				this.src = "/theme/bccolumn/img/sp/btn_menu.png";
+				this.src = baseUrl + "theme/bccolumn/img/sp/btn_menu.png";
 				flg = "close";
 			}
 		});


### PR DESCRIPTION
スマホ表示時、右上のハンバーガーメニューをクリックした際に、画像が表示されなくなる問題を修正しています。

原因は、JS内で画像パスをルートパスで指定しているため、baserをサブフォルダにインストール際に正しいパス解決が行われないことでした。

ロゴのリンク先のURLをベースURLとして、画像の絶対パスを使用するように変更しています。

ご確認をよろしくお願いします。