### PR TITLE
BcColumnのブログ詳細ページのシンタックスエラーを修正

### DIFF
--- a/lib/Baser/Config/theme/bccolumn/Blog/topics/single.php
+++ b/lib/Baser/Config/theme/bccolumn/Blog/topics/single.php
@@ -36,7 +36,7 @@ $(function(){
 <?php $this->BcBaser->element('blog_tag', array('post' => $post)) ?>
 </div>
 <div class="post-navi">
-	<?php $this->Blog->prevLink($post, "＜ ". __('前の記事') ?>
+	<?php $this->Blog->prevLink($post, "＜ ". __('前の記事')) ?>
 	&nbsp;  &nbsp;
 	<?php $this->BcBaser->link(__('一覧へ'), '/'.$this->request->params['Content']['name'].'/index') ?>
 	&nbsp;  &nbsp;	<?php $this->Blog->nextLink($post, __('後の記事'). " ＞") ?>


### PR DESCRIPTION
カッコが足りない部分がありましたので修正しています。
ご確認をよろしくお願いします。