### PR TITLE
コンテンツ移動後にキャッシュを削除する

### DIFF
--- a/lib/Baser/Controller/ContentsController.php
+++ b/lib/Baser/Controller/ContentsController.php
@@ -687,7 +687,8 @@ class ContentsController extends AppController {
 			$data['targetId']
 		);
 
-		
+		clearDataCache();
+
 		if($data['currentParentId'] == $data['targetParentId']) {
 			// 親が違う場合は、Contentモデルで更新してくれるが同じ場合更新しない仕様の為ここで更新する
 			$this->SiteConfig->updateContentsSortLastModified();	


### PR DESCRIPTION
コンテンツ一覧でフォルダを移動した際に発生する不都合を修正しています。ご確認をよろしくお願いします。

□エラー現象
コンテンツ一覧で固定ページの入ったフォルダを、別のフォルダの中に入れたり出したりするとエラーメッセージが表示されます。
![basercms_inc_](https://user-images.githubusercontent.com/30764014/39808211-4f9d8faa-53b9-11e8-82a3-808ec1681f60.png)

□原因
コンテンツ一覧でフォルダを移動した際、フォルダ内のページに対して、ページテンプレートや検索データを作成するために、リクエストが送られます。
その際に、移動前のページに対してリクエストが送られているため、404エラーが発生し、エラーメッセージが表示されるようです。

□対策
コンテンツの移動が発生した直後にキャッシュを消す処理を入れています。