### PR TITLE
BcTimeHelper::convertToWarekiArray()のPHPDocを実装に合わせて更新

### DIFF
--- a/lib/Baser/View/Helper/BcTimeHelper.php
+++ b/lib/Baser/View/Helper/BcTimeHelper.php
@@ -136,10 +136,10 @@ class BcTimeHelper extends TimeHelper {
 	}
 
 /**
- * 和暦変換(配列で返す)
+ * 日付を配列に分解した形で和暦変換する
  *
- * @param string $date 日付
- * @return array 和暦データ
+ * @param string|array $date 文字列形式の日付 (例: '2018/05/28')、または配列形式の和暦データ
+ * @return array|string 配列形式の和暦データ、または日付フォーマットが正しくない場合は空文字
  */
 	public function convertToWarekiArray($date) {
 		if (!$date) {


### PR DESCRIPTION
BcTimeHelper::convertToWarekiArray()のPHPDocを実装に合わせて更新しました。

メソッド内で引数にis_array()判定をしており、引数に配列も取れるようですが、判定後の処理を追うと、convertToSeirekiYear()を使用していることから、和暦を期待しているものと思われます。和暦から和暦への変換というのも妙だと思いましたが、何かしら必要な場面があるのだろうと思い、引数に和暦データを取れることもコメントしてあります。