### PR TITLE
fix マルチチェックボックス時のdivを外すオプション指定が効かない点を調整

### DIFF
--- a/lib/Baser/View/Helper/BcFormHelper.php
+++ b/lib/Baser/View/Helper/BcFormHelper.php
@@ -886,7 +886,7 @@ DOC_END;
 		// CUSTOMIZE ADD 2016/01/28 ryuring
 		// checkboxのdivを外せるオプションを追加
 		// >>>
-		$div = $this->_extractOption('div', $attributes);
+		$div = (bool)$this->_extractOption('div', $attributes);
 		unset($attributes['div']);
 		// <<<
 


### PR DESCRIPTION
http://project.e-catchup.jp/issues/21979
調整してみましたので、良かったら取込検討お願いします_(．．)_
原因、対策理由とチケット説明欄で考察してます
