### PR TITLE
「ブログアカウント名」という表現を「ブログのコンテンツ名」に変更

### DIFF
--- a/lib/Baser/Plugin/Blog/Test/Case/View/Helper/BlogHelperTest.php
+++ b/lib/Baser/Plugin/Blog/Test/Case/View/Helper/BlogHelperTest.php
@@ -158,12 +158,12 @@ class BlogHelperTest extends BaserTestCase {
 	}
 
 /**
- * ブログアカウント名を取得する
+ * ブログのコンテンツ名を取得する
  */
 	public function testGetBlogName() {
 		$result = $this->Blog->getBlogName();
 		$expects = 'news';
-		$this->assertEquals($expects, $result, 'ブログアカウント名を正しく取得できません');
+		$this->assertEquals($expects, $result, 'ブログのコンテンツ名を正しく取得できません');
 	}
 
 /**

--- a/lib/Baser/Plugin/Blog/View/Helper/BlogBaserHelper.php
+++ b/lib/Baser/Plugin/Blog/View/Helper/BlogBaserHelper.php
@@ -156,7 +156,7 @@ class BlogBaserHelper extends AppHelper {
 /**
  * Blogの基本情報を全て取得する
  *
- * @param string $name ブログアカウント名を指定するとそのブログのみの基本情報を返す。空指定(default)で、全てのブログの基本情報。 ex) 'news' （初期値 : ''）
+ * @param string $name ブログのコンテンツ名を指定するとそのブログのみの基本情報を返す。空指定(default)で、全てのブログの基本情報。 ex) 'news' （初期値 : ''）
  * @param array $options オプション（初期値 :array()）
  *	- `sort` : データのソート順 取得出来るフィールドのどれかでソートができる ex) 'created DESC'（初期値 : 'id'）
  *  - `siteId` : サブサイトIDで絞り込む場合に指定する（初期値：0）

--- a/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
+++ b/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
@@ -117,7 +117,7 @@ class BlogHelper extends AppHelper {
 	}
 
 /**
- * ブログアカウント名を出力する
+ * ブログのコンテンツ名を出力する
  *
  * @return void
  */
@@ -126,7 +126,7 @@ class BlogHelper extends AppHelper {
 	}
 
 /**
- * ブログアカウント名を取得する
+ * ブログのコンテンツ名を取得する
  *
  * @return string
  */
@@ -1619,7 +1619,7 @@ class BlogHelper extends AppHelper {
 /**
  * Blogの基本情報を全て取得する
  *
- * @param string $name ブログアカウント名を指定するとそのブログのみの基本情報を返す。空指定(default)で、全てのブログの基本情報。 ex) 'news' （初期値 : ''）
+ * @param string $name ブログのコンテンツ名を指定するとそのブログのみの基本情報を返す。空指定(default)で、全てのブログの基本情報。 ex) 'news' （初期値 : ''）
  * @param array $options オプション（初期値 :array()）
  *	- `sort` : データのソート順 取得出来るフィールドのどれかでソートができる ex) 'created DESC'（初期値 : 'id'）
  *  - `siteId` : サブサイトIDで絞り込む場合に指定する（初期値：0）


### PR DESCRIPTION
「ブログアカウント名」という4系では無くなった表現になっている箇所を「ブログのコンテンツ名」に変更しました。

よろしくお願いします。