### PR TITLE
fix #21985 baserCMS4系でメールプラグインのindexアクションを実行すると500エラーが発生する事象対応

### DIFF
--- a/lib/Baser/Plugin/Mail/Controller/MailController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailController.php
@@ -187,6 +187,10 @@ class MailController extends MailAppController {
  * @return void
  */
 	public function index($id = null) {
+		if (!isset($this->dbDatas['mailContent']['MailContent'])) {
+			$this->notFound();
+		}
+
 		if (!$this->MailContent->isAccepting($this->dbDatas['mailContent']['MailContent']['publish_begin'], $this->dbDatas['mailContent']['MailContent']['publish_end'])) {
 			$this->render($this->dbDatas['mailContent']['MailContent']['form_template'] . DS . 'unpublish');
 			return;


### PR DESCRIPTION
baserCMS4系でメールフォームを表示するコントローラにメールコンテンツを指定しない形でアクセスすると500エラーが発生する事象を確認しましたので修正対応を行っております。
http://project.e-catchup.jp/issues/21985

以上、何卒よろしくお願いいたします。