### PR TITLE
fix #21985 baserCMS4系でメールプラグインのindexアクションを実行すると500エラーが発生する事象対応

### DIFF
--- a/lib/Baser/Plugin/Mail/Controller/MailController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailController.php
@@ -120,6 +120,9 @@ class MailController extends MailAppController {
 
 		parent::beforeFilter();
 
+		if (empty($this->request->params['entityId'])) {
+			$this->notFound();
+		}
 		$this->MailMessage->setup($this->request->params['entityId']);
 		$this->dbDatas['mailContent'] = $this->MailMessage->mailContent;
 		$this->dbDatas['mailFields'] = $this->MailMessage->mailFields;


### PR DESCRIPTION
こちらの件対応しております。
http://project.e-catchup.jp/issues/21985
お手数ですがご確認のほどよろしくお願いいたします。