### PR TITLE
Mail.beforeSendEmailにてメール送信のオプションを設定できるようにする

### DIFF
--- a/lib/Baser/Plugin/Mail/Controller/MailController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailController.php
@@ -42,16 +42,16 @@ class MailController extends MailAppController {
  *
  * @var array
  */
-	public $uses = array('Mail.MailMessage', 'Mail.MailContent', 'Mail.MailField', 'Mail.MailConfig');
+	public $uses = ['Mail.MailMessage', 'Mail.MailContent', 'Mail.MailField', 'Mail.MailConfig'];
 
 /**
  * ヘルパー
  *
  * @var array
  */
-	public $helpers = array(
+	public $helpers = [
 		'BcFreeze', 'BcArray', 'BcTime', 'Mail.Mailform', 'Mail.Maildata', 'Mail.Mailfield', 'Mail.Mail', 'Js'
-	);
+	];
 
 /**
  * Array of components a controller will use
@@ -65,21 +65,21 @@ class MailController extends MailAppController {
 	//
 	// 2013/03/14 ryuring
 	// baserCMS２系より必須要件をPHP5以上とした為、SecurityComponent を標準で設定する方針に変更
-	public $components = array('BcAuth', 'Cookie', 'BcAuthConfigure', 'Email', 'BcEmail', 'BcCaptcha', 'Security', 'BcContents');
+	public $components = ['BcAuth', 'Cookie', 'BcAuthConfigure', 'Email', 'BcEmail', 'BcCaptcha', 'Security', 'BcContents'];
 
 /**
  * CSS
  *
  * @var array
  */
-	public $css = array('mail/form');
+	public $css = ['mail/form'];
 
 /**
  * サブメニューエレメント
  *
  * @var array
  */
-	public $subMenuElements = array();
+	public $subMenuElements = [];
 
 /**
  * データベースデータ
@@ -93,7 +93,7 @@ class MailController extends MailAppController {
  *
  * @var array
  */
-	public $crumbs = array();
+	public $crumbs = [];
 
 /**
  * MailController constructor.
@@ -133,7 +133,7 @@ class MailController extends MailAppController {
 			$this->contentId = isset($this->request->params['entityId']) ? $this->request->params['entityId'] : null;
 		}
 
-		$this->subMenuElements = array('default');
+		$this->subMenuElements = ['default'];
 
 		// 2013/03/14 ryuring
 		// baserCMS２系より必須要件をPHP5以上とした為、SecurityComponent を標準で設定する方針に変更
@@ -143,7 +143,7 @@ class MailController extends MailAppController {
 		} else {
 			// PHP4でセキュリティコンポーネントがうまくいかなかったので利用停止
 			// 詳細はコンポーネント設定のコメントを参照
-			$disabledFields = array('MailMessage.mode', 'x', 'y', 'MAX_FILE_SIZE');
+			$disabledFields = ['MailMessage.mode', 'x', 'y', 'MAX_FILE_SIZE'];
 			// type="file" を除外
 			foreach($this->MailMessage->mailFields as $field) {
 				if (isset($field['MailField']['type']) && $field['MailField']['type'] == 'file') {
@@ -156,7 +156,7 @@ class MailController extends MailAppController {
 			// SSL設定
 			if ($this->dbDatas['mailContent']['MailContent']['ssl_on']) {
 				$this->Security->blackHoleCallback = 'sslFail';
-				$this->Security->requireSecure = am($this->Security->requireSecure, array('index', 'confirm', 'submit'));
+				$this->Security->requireSecure = am($this->Security->requireSecure, ['index', 'confirm', 'submit']);
 			}
 		}
 
@@ -218,7 +218,7 @@ class MailController extends MailAppController {
 
 		$user = BcUtil::loginUser('admin');
 		if (!empty($user)) {
-			$this->set('editLink', array('admin' => true, 'plugin' => 'mail', 'controller' => 'mail_contents', 'action' => 'edit', $this->dbDatas['mailContent']['MailContent']['id']));
+			$this->set('editLink', ['admin' => true, 'plugin' => 'mail', 'controller' => 'mail_contents', 'action' => 'edit', $this->dbDatas['mailContent']['MailContent']['id']]);
 		}
 		$this->set('mailContent', $this->dbDatas['mailContent']);
 		$this->render($this->dbDatas['mailContent']['MailContent']['form_template'] . DS . 'index');
@@ -284,7 +284,7 @@ class MailController extends MailAppController {
 		}
 		$user = BcUtil::loginUser('admin');
 		if (!empty($user)) {
-			$this->set('editLink', array('admin' => true, 'plugin' => 'mail', 'controller' => 'mail_contents', 'action' => 'edit', $this->dbDatas['mailContent']['MailContent']['id']));
+			$this->set('editLink', ['admin' => true, 'plugin' => 'mail', 'controller' => 'mail_contents', 'action' => 'edit', $this->dbDatas['mailContent']['MailContent']['id']]);
 		}
 		$this->set('mailContent', $this->dbDatas['mailContent']);
 		$this->render($this->dbDatas['mailContent']['MailContent']['form_template'] . DS . 'confirm');
@@ -343,14 +343,14 @@ class MailController extends MailAppController {
 					$this->request->data = $result;
 					
 					/*** Mail.beforeSendEmail ***/
-					$event = $this->dispatchEvent('beforeSendEmail', array(
+					$event = $this->dispatchEvent('beforeSendEmail', [
 						'data' => $this->request->data
-					));
-					$sendEmailOptions = array();
+					]);
+					$sendEmailOptions = [];
 					if ($event !== false) {
 						$this->request->data = $event->result === true ? $event->data['data'] : $event->result;
-						if (!empty($event->data['options'])) {
-							$sendEmailOptions = $event->data['options'];
+						if (!empty($event->data['sendEmailOptions'])) {
+							$sendEmailOptions = $event->data['sendEmailOptions'];
 						}
 					}
 
@@ -360,9 +360,9 @@ class MailController extends MailAppController {
 					$this->Session->delete('Mail.valid');
 
 					/*** Mail.afterSendEmail ***/
-					$this->dispatchEvent('afterSendEmail', array(
+					$this->dispatchEvent('afterSendEmail', [
 						'data' => $this->request->data
-					));
+					]);
 				} else {
 
 					$this->setMessage(__('エラー : 送信中にエラーが発生しました。しばらくたってから再度送信お願いします。'), true);
@@ -392,7 +392,7 @@ class MailController extends MailAppController {
 		}
 		$user = BcUtil::loginUser('admin');
 		if (!empty($user)) {
-			$this->set('editLink', array('admin' => true, 'plugin' => 'mail', 'controller' => 'mail_contents', 'action' => 'edit', $this->dbDatas['mailContent']['MailContent']['id']));
+			$this->set('editLink', ['admin' => true, 'plugin' => 'mail', 'controller' => 'mail_contents', 'action' => 'edit', $this->dbDatas['mailContent']['MailContent']['id']]);
 		}
 	}
 
@@ -421,7 +421,7 @@ class MailController extends MailAppController {
 		// <<<
 		$user = BcUtil::loginUser('admin');
 		if (!empty($user)) {
-			$this->set('editLink', array('admin' => true, 'plugin' => 'mail', 'controller' => 'mail_contents', 'action' => 'edit', $this->dbDatas['mailContent']['MailContent']['id']));
+			$this->set('editLink', ['admin' => true, 'plugin' => 'mail', 'controller' => 'mail_contents', 'action' => 'edit', $this->dbDatas['mailContent']['MailContent']['id']]);
 		}
 		$this->set('mailContent', $this->dbDatas['mailContent']);
 		$this->render($this->dbDatas['mailContent']['MailContent']['form_template'] . DS . 'index');
@@ -434,10 +434,10 @@ class MailController extends MailAppController {
  */
 	protected function _sendEmail($options) {
 		$options = array_merge(
-			array(
-				'toUser' => array(),
-				'toAdmin' => array(),
-			),
+			[
+				'toUser' => [],
+				'toAdmin' => [],
+			],
 			$options
 		);
 
@@ -467,7 +467,7 @@ class MailController extends MailAppController {
 			$fromAdmin = $adminMail;
 		}
 
-		$attachments = array();
+		$attachments = [];
 		$settings = $this->MailMessage->Behaviors->BcUpload->settings['MailMessage'];
 		foreach ($this->dbDatas['mailFields'] as $mailField) {
 			$field = $mailField['MailField']['field_name'];
@@ -508,14 +508,14 @@ class MailController extends MailAppController {
 			}
 			$data['other']['mode'] = 'user';
 			$toUserOptions = array_merge(
-				array(
+				[
 					'fromName' => $mailContent['sender_name'],
 					'from' => $fromAdmin,
 					'template' => 'Mail.' . $mailContent['mail_template'],
 					'replyTo' => $fromAdmin,
 					'agentTemplate' => $agentTemplate,
 					'additionalParameters' => '-f ' . $fromAdmin,
-				),
+				],
 				$options['toUser']
 			);
 			$this->sendMail($userMail, $mailContent['subject_user'], $data, $toUserOptions);
@@ -529,7 +529,7 @@ class MailController extends MailAppController {
 			}
 			$data['other']['mode'] = 'admin';
 			$toAdminOptions = array_merge(
-				array(
+				[
 					'fromName' => $mailContent['sender_name'],
 					'replyTo' => $userMail,
 					'from' => $fromAdmin,
@@ -538,7 +538,7 @@ class MailController extends MailAppController {
 					'agentTemplate' => false,
 					'attachments' => $attachments,
 					'additionalParameters' => '-f ' . $fromAdmin,
-				),
+				],
 				$options['toAdmin']
 			);
 			$this->sendMail($adminMail, $mailContent['subject_admin'], $data, $toAdminOptions);

--- a/lib/Baser/Plugin/Mail/Controller/MailController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailController.php
@@ -523,6 +523,9 @@ class MailController extends MailAppController {
 				'attachments'	=> $attachments,
 				'additionalParameters'	 => '-f ' . $fromAdmin,
 			);
+			if (!empty($mailContent['sender_cc'])) {
+				$options['cc'] = $mailContent['sender_cc'];
+			}
 			$this->sendMail($adminMail, $mailContent['subject_admin'], $data, $options);
 		}
 	}


### PR DESCRIPTION
メール送信完了時、管理者あてに送信されるメールのオプションにccを追加しています。

このオプションを追加すると、任意のプラグインのControllerEventListenerで以下の関数を定義することで、ccを設定することができるようになります。

```
public function mailMailBeforeSendEmail(CakeEvent $event) {
	$Controller = $event->subject();
	$Controller->dbDatas['mailContent']['MailContent']['sender_cc'] = 'cc@test.test';
	return true;
}
```

理想的には、メールフォームの管理画面で「CC用送信先メールアドレス」を設定できるといいのですが、DBの変更が必要になってくるので、ひとまずオプションの追加のみ行っています。

ご確認をよろしくお願いします。