### PR TITLE
fix #22079 固定ページの削除（ゴミ箱へ移動）をアクセス制限設定で操作不可として指定できるようにするため

### DIFF
--- a/lib/Baser/Event/BcContentsEventListener.php
+++ b/lib/Baser/Event/BcContentsEventListener.php
@@ -95,7 +95,14 @@ class BcContentsEventListener extends CakeObject implements CakeEventListener {
 			} else {
 				$deleteText = __d('baser', 'ゴミ箱へ移動');
 			}
-			$output .= $View->BcForm->button($deleteText, ['class' => 'button', 'id' => 'BtnDelete']);
+
+			// アクセス制限設定で「/admin/contents/delete」を指定できるようにするため
+			$contentsDeleteUrl	 = Router::url(['admin' => true, 'plugin' => false, 'controller' => 'contents', 'action' => 'delete']);
+			$PermissionModel	 = ClassRegistry::init('Permission');
+			$checkedPermission	 = $PermissionModel->check($contentsDeleteUrl, $View->viewVars['user']['user_group_id']);
+			if ($checkedPermission) {
+				$output .= $View->BcForm->button($deleteText, ['class' => 'button', 'id' => 'BtnDelete']);
+			}
 		}
 		$event->data['out'] = $output;
 		return $output;


### PR DESCRIPTION
button タグ箇所に対するアクセス制限指定についてやってみました。
可能な際に、取込検討お願いします。
http://project.e-catchup.jp/issues/22079
