### PR TITLE
fix #22085 グループ化されたメールフィールドの最後が「利用しない」設定となっているとき、HTMLの閉じタグが正しい構造で表示されないため調整

### DIFF
--- a/lib/Baser/Plugin/Mail/Controller/MailController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailController.php
@@ -126,6 +126,18 @@ class MailController extends MailAppController {
 		$this->MailMessage->setup($this->request->params['entityId']);
 		$this->dbDatas['mailContent'] = $this->MailMessage->mailContent;
 		$this->dbDatas['mailFields'] = $this->MailMessage->mailFields;
+
+		$usedMailFieldList = [];
+		if ($this->dbDatas['mailFields']) {
+			foreach ($this->dbDatas['mailFields'] as $mailFieldList) {
+				if ($mailFieldList['MailField']['use_field']) {
+					$usedMailFieldList[] = $mailFieldList;
+				}
+			}
+			$usedMailFieldList = Hash::sort($usedMailFieldList, '{n}.MailField.sort', 'asc');
+			$this->dbDatas['mailFields'] = $usedMailFieldList;
+		}
+
 		$this->dbDatas['mailConfig'] = $this->MailConfig->find();
 		
 		// ページタイトルをセット

--- a/lib/Baser/Plugin/Mail/Controller/MailMessagesController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailMessagesController.php
@@ -134,7 +134,7 @@ class MailMessagesController extends MailAppController {
 			'order' => 'created DESC'
 		));
 		$mailFields = $this->MailField->find('all', array(
-			'conditions' => array('MailField.mail_content_id' => $mailContentId),
+			'conditions' => array('MailField.mail_content_id' => $mailContentId, 'MailField.use_field' => true),
 			'order' => 'MailField.sort'
 		));
 		$this->crumbs[] = array('name' => __d('baser', '受信メール一覧'), 'url' => array('controller' => 'mail_messages', 'action' => 'index', $this->params['pass'][0]));


### PR DESCRIPTION
調整入れてみましたので、可能な際に取込検討お願いします
http://project.e-catchup.jp/issues/22085
