### PR TITLE
fix #22129 固定ページをコピーした際に、オプションの説明文がコピーできない問題を解決

### DIFF
--- a/lib/Baser/Model/Page.php
+++ b/lib/Baser/Model/Page.php
@@ -730,7 +730,7 @@ class Page extends AppModel {
 		$siteId = $data['Content']['site_id'];
 		$name = $data['Content']['name'];
 		$eyeCatch = $data['Content']['eyecatch'];
-		$description = !empty($data['Content']['description']) ? __d('baser', $data['Content']['description'].'のコピー') : '';
+		$description = $data['Content']['description'];
 		unset($data['Page']['id']);
 		unset($data['Page']['created']);
 		unset($data['Page']['modified']);

--- a/lib/Baser/Model/Page.php
+++ b/lib/Baser/Model/Page.php
@@ -730,6 +730,7 @@ class Page extends AppModel {
 		$siteId = $data['Content']['site_id'];
 		$name = $data['Content']['name'];
 		$eyeCatch = $data['Content']['eyecatch'];
+		$description = !empty($data['Content']['description']) ? __d('baser', $data['Content']['description'].'のコピー') : '';
 		unset($data['Page']['id']);
 		unset($data['Page']['created']);
 		unset($data['Page']['modified']);
@@ -740,7 +741,7 @@ class Page extends AppModel {
 			'title'		=> $newTitle,
 			'author_id' => $newAuthorId,
 			'site_id' 	=> $newSiteId,
-			'description' => ''
+			'description' => $description
 		];
 		if(!is_null($newSiteId) && $siteId != $newSiteId) {
 			$data['Content']['site_id'] = $newSiteId;


### PR DESCRIPTION
案件で、固定ページを大量に作成する要件があって、
コピーした際に「説明文」がコピーできないのは困るとの指摘を受けました。

対象箇所
lib/Baser/Model/Page.php
743行目
'description' => ''
となっていて、明示的に空っぽにしてコピーするようになっている。

こちら、厳密には「description」が同じものがあってはいけないということはないが、
Google検索で問題が発生しないように
descriptionが入っている場合、descriptionの末尾に「のコピー」の文字をつけるように調整
