### PR TITLE
fix #22130 CKEditorが<i></i>を勝手に消してしまう問題を解決

### DIFF
--- a/lib/Baser/View/Helper/BcCkeditorHelper.php
+++ b/lib/Baser/View/Helper/BcCkeditorHelper.php
@@ -314,6 +314,7 @@ class BcCkeditorHelper extends AppHelper {
 		$jscode .= "CKEDITOR.config.extraPlugins = 'draft,showprotected';";
 		$jscode .= "CKEDITOR.config.stylesCombo_stylesSet = '" . $editorStylesSet . "';";
 		$jscode .= "CKEDITOR.config.protectedSource.push( /<\?[\s\S]*?\?>/g );";
+		$jscode .= 'CKEDITOR.dtd.$removeEmpty["i"] = false;'; //　空「i」タグを消さないようにする
 
 		if ($editorEnterBr) {
 			$jscode .= "CKEDITOR.config.enterMode = CKEDITOR.ENTER_BR;";


### PR DESCRIPTION

案件で発生

フォーラムでも同様の問題が発生 「固定ページの編集でFont Awesomeの<i>タグが消える」

CKEditorの仕様が問題
イベント処理でビューにJSを読み込ませて処理をすることもできますが
今後「Font Awesomeの<i>タグ」の使用頻度が増える可能性を考えて、コアも修正しても良いと思います。