### PR TITLE
メール送信完了後にthanksページへ遷移する

### DIFF
--- a/lib/Baser/Plugin/Mail/Controller/MailController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailController.php
@@ -115,7 +115,7 @@ class MailController extends MailAppController {
 		/* 認証設定 */
 		// @deprecated 5.0.0 since 4.0.0 ajax_get_token は、BcFormController に移行した為、次のバージョンで削除
 		$this->BcAuth->allow(
-			'index', 'mobile_index', 'smartphone_index', 'confirm', 'mobile_confirm', 'smartphone_confirm', 'submit', 'mobile_submit', 'smartphone_submit', 'captcha', 'smartphone_captcha', 'ajax_get_token', 'smartphone_ajax_get_token'
+			'index', 'mobile_index', 'smartphone_index', 'confirm', 'mobile_confirm', 'smartphone_confirm', 'submit', 'mobile_submit', 'smartphone_submit', 'thanks', 'captcha', 'smartphone_captcha', 'ajax_get_token', 'smartphone_ajax_get_token'
 		);
 
 		parent::beforeFilter();
@@ -372,8 +372,8 @@ class MailController extends MailAppController {
 					$this->set('sendError', true);
 				}
 
-				$this->set('mailContent', $this->dbDatas['mailContent']);
-				$this->render($this->dbDatas['mailContent']['MailContent']['form_template'] . DS . 'submit');
+				$this->Session->write('Mail.MailContent', $this->dbDatas['mailContent']);
+				$this->redirect($this->request->params['Content']['url'] . '/thanks');
 
 				// 入力検証エラー
 			} else {
@@ -397,6 +397,26 @@ class MailController extends MailAppController {
 		if (!empty($user)) {
 			$this->set('editLink', ['admin' => true, 'plugin' => 'mail', 'controller' => 'mail_contents', 'action' => 'edit', $this->dbDatas['mailContent']['MailContent']['id']]);
 		}
+	}
+
+/**
+ * [PUBIC] メール送信完了
+ *
+ * @return void
+ */
+	public function thanks() {
+		if (!$this->MailContent->isAccepting($this->dbDatas['mailContent']['MailContent']['publish_begin'], $this->dbDatas['mailContent']['MailContent']['publish_end'])) {
+			$this->render($this->dbDatas['mailContent']['MailContent']['form_template'] . DS . 'unpublish');
+			return;
+		}
+
+		$mailContent = $this->Session->consume('Mail.MailContent');
+		if (!$mailContent) {
+			$this->notFound();
+		}
+
+		$this->set('mailContent', $mailContent);
+		$this->render($this->dbDatas['mailContent']['MailContent']['form_template'] . DS . 'submit');
 	}
 
 /**


### PR DESCRIPTION
送信完了後にthanksページへ遷移する処理を入れています。
メールフォームの再入力画面と、メール送信完了画面のURLが両方ともsubmitのため、アクセス解析上で見分けがつかないためです。

ご確認をよろしくお願いします。