### PR TITLE
fix #22050 メールフォームのセレクトボックスで、記号が含まれる値を選択してメールを送信すると、CSRFエラーが発生する問題を改善

### DIFF
--- a/lib/Baser/Model/BcAppModel.php
+++ b/lib/Baser/Model/BcAppModel.php
@@ -1725,8 +1725,10 @@ class BcAppModel extends Model {
 /**
  * レコードデータの消毒をおこなう
  * @return array
+ * @deprecated 5.0.0 since 4.1.3 htmlspecialchars を利用してください。
  */
 	public function sanitizeRecord($record) {
+		trigger_error(deprecatedMessage('メソッド：BcAppModel::sanitizeRecord()', '4.0.0', '5.0.0', 'htmlspecialchars を利用してください。'), E_USER_DEPRECATED);
 		foreach ($record as $key => $value) {
 				$record[$key] = $this->sanitize($value);
 		}
@@ -1738,8 +1740,10 @@ class BcAppModel extends Model {
  * 配列には対応しない
  * @param $data
  * @return mixed|string
+ * @deprecated 5.0.0 since 4.1.3 htmlspecialchars を利用してください。
  */
 	public function sanitize($value) {
+		trigger_error(deprecatedMessage('メソッド：BcAppModel::sanitizeRecord()', '4.0.0', '5.0.0', 'htmlspecialchars を利用してください。'), E_USER_DEPRECATED);
 		if (!is_array($value)) {
 			// 既に htmlspecialchars を実行済のものについて一旦元の形式に復元した上で再度サイニタイズ処理をかける。
 			$value = str_replace("&lt;!--", "<!--", $value);

--- a/lib/Baser/Plugin/Mail/Controller/MailController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailController.php
@@ -209,8 +209,6 @@ class MailController extends MailAppController {
 				}
 			}
 			$this->request->data = $this->MailMessage->getDefaultValue($this->request->params['named']);
-		} else {
-			$this->request->data['MailMessage'] = $this->MailMessage->sanitizeData($this->request->data['MailMessage']);
 		}
 
 		$this->set('freezed', false);
@@ -279,7 +277,6 @@ class MailController extends MailAppController {
 				$this->request->data['MailMessage']['captcha_id'] = null;
 				$this->setMessage(__('エラー : 入力内容を確認して再度送信してください。'), true);
 			}
-			$this->request->data['MailMessage'] = $this->MailMessage->sanitizeData($this->request->data['MailMessage']);
 		}
 
 		if ($this->dbDatas['mailFields']) {
@@ -379,7 +376,6 @@ class MailController extends MailAppController {
 				$this->setMessage('Error : Confirm your entries and send again.', true);
 				$this->request->data['MailMessage']['auth_captcha'] = null;
 				$this->request->data['MailMessage']['captcha_id'] = null;
-				$this->request->data['MailMessage'] = $this->MailMessage->sanitizeData($this->request->data['MailMessage']);
 				$this->action = 'index'; //viewのボタンの表示の切り替えに必要なため変更
 				if ($this->dbDatas['mailFields']) {
 					$this->set('mailFields', $this->dbDatas['mailFields']);
@@ -437,7 +433,7 @@ class MailController extends MailAppController {
 		$userMail = '';
 
 		// データを整形
-		$data = $this->MailMessage->restoreData($this->MailMessage->convertToDb($this->request->data));
+		$data = $this->MailMessage->convertToDb($this->request->data);
 		$data['message'] = $data['MailMessage'];
 		unset($data['MailMessage']);
 		$data['mailFields'] = $this->dbDatas['mailFields'];

--- a/lib/Baser/Plugin/Mail/Model/MailAppModel.php
+++ b/lib/Baser/Plugin/Mail/Model/MailAppModel.php
@@ -20,16 +20,20 @@ class MailAppModel extends AppModel {
 /**
  * データの消毒をおこなう
  * @return array
+ * @deprecated 5.0.0 since 4.1.3 htmlspecialchars を利用してください。
  */
 	public function sanitizeData($datas) {
+		trigger_error(deprecatedMessage('メソッド：BcAppModel::sanitizeData()', '4.0.0', '5.0.0', 'htmlspecialchars を利用してください。'), E_USER_DEPRECATED);
 		return $this->sanitizeRecord($datas);
 	}
 
 /**
  * サニタイズされたデータを復元する
  * @return array
+ * @deprecated 5.0.0 since 4.1.3 htmlspecialchars_decode を利用してください。
  */
 	public function restoreData($datas) {
+		trigger_error(deprecatedMessage('メソッド：MailAppModel::restoreData()', '4.1.3', '5.0.0', 'htmlspecialchars_decode を利用してください。'), E_USER_DEPRECATED);
 		foreach ($datas as $key => $data) {
 			if (!is_array($data)) {
 				$data = str_replace("<br />", "", $data);

--- a/lib/Baser/Plugin/Mail/Test/Case/Model/MailAppTest.php
+++ b/lib/Baser/Plugin/Mail/Test/Case/Model/MailAppTest.php
@@ -37,21 +37,4 @@ class MailAppTest extends BaserTestCase {
 		parent::tearDown();
 	}
 
-/**
- * データの消毒をおこなう
- * @return array
- */
-	public function testSanitizeAndRestoreData() {
-		
-		$datas = array('<!--', '<a href="test">Test</a>');
-		$expected = array('&lt;!--', '&lt;a href=&quot;test&quot;&gt;Test&lt;/a&gt;');
-
-		$resultSanitized = $this->MailApp->sanitizeData($datas);
-		$this->assertEquals($expected, $resultSanitized, 'データのサニタイズを正しく行えません');
-
-		$resultRestored = $this->MailApp->restoreData($expected);
-		$this->assertEquals($datas, $resultRestored, 'サニタイズされたデータを正しく復元できません');
-	
-	}
-
 }

--- a/lib/Baser/Plugin/Mail/View/Helper/MailformHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MailformHelper.php
@@ -39,7 +39,7 @@ class MailformHelper extends BcFreezeHelper {
  * @return string フォームコントロールのHTMLタグ
  */
 	public function control($type, $fieldName, $options, $attributes = array()) {
-		$attributes['escape'] = false;
+		$attributes['escape'] = true;
 		$out = '';
 		switch ($type) {
 

--- a/lib/Baser/Test/Case/Model/BcAppTest.php
+++ b/lib/Baser/Test/Case/Model/BcAppTest.php
@@ -961,44 +961,4 @@ class BcAppTest extends BaserTestCase {
 		];
 	}
 
-/**
- * 単体データをサニタイズ処理する関数
- *
- * @param $data
- * @param $expect
- * @dataProvider sanitizeDataProvider
- */
-	public function testSanitize($data, $expect) {
-		$result = $this->BcApp->sanitize($data);
-		$this->assertEquals($expect, $result);
-	}
-
-	public function sanitizeDataProvider() {
-		return[
-			['<', '&lt;'],
-			['>', '&gt;'],
-			['"', '&quot;'],
-			['\\', '\\']
-		];
-	}
-
-/**
- * レコードデータをサニタイズ処理する関数
- * @param $data
- * @param $expect
- * @dataProvider sanitizeRecordDataProvider
- */
-	public function testSanitizeRecord($data, $expect) {
-		$result = $this->BcApp->sanitizeRecord($data);
-		$this->assertEquals($expect, $result);
-	}
-
-	public function sanitizeRecordDataProvider() {
-		return[
-			[['aa', '\"', '<', '>'], ['aa', '\&quot;', '&lt;', '&gt;']],
-			[["aa", "\"", "<", ">"], ['aa', '&quot;', '&lt;', '&gt;']],
-			[[["aa", "\"", "<", ">"], '\"', '<', '>'], [['aa', '"', '<', '>'], '\&quot;', '&lt;', '&gt;']],
-		];
-	}
-
 }


### PR DESCRIPTION
@gondoh 時間ある際にレビューお願いします。

http://project.e-catchup.jp/issues/22050