### PR TITLE
fix #22085 グループ化されたメールフィールドの最後が「利用しない」設定となっているとき、HTMLの閉じタグが正しい構造で表示されないため調整

### DIFF
--- a/lib/Baser/Plugin/Mail/Controller/MailMessagesController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailMessagesController.php
@@ -101,12 +101,9 @@ class MailMessagesController extends MailAppController {
 			'limit' => $this->passedArgs['num']
 		);
 		$messages = $this->paginate('MailMessage');
-		$mailFields = $this->MailField->find('all', array(
-			'conditions' => array('MailField.mail_content_id' => $mailContentId),
-			'order' => 'MailField.sort'
-		));
-		$this->set(compact('mailFields'));
-		$this->set(compact('messages'));
+		$mailFields = $this->MailMessage->mailFields;
+
+		$this->set(compact('messages', 'mailFields'));
 
 		if ($this->RequestHandler->isAjax() || !empty($this->request->query['ajax'])) {
 			$this->render('ajax_index');
@@ -133,13 +130,10 @@ class MailMessagesController extends MailAppController {
 			'conditions' => array('MailMessage.id' => $messageId),
 			'order' => 'created DESC'
 		));
-		$mailFields = $this->MailField->find('all', array(
-			'conditions' => array('MailField.mail_content_id' => $mailContentId),
-			'order' => 'MailField.sort'
-		));
+		$mailFields = $this->MailMessage->mailFields;
+
 		$this->crumbs[] = array('name' => __d('baser', '受信メール一覧'), 'url' => array('controller' => 'mail_messages', 'action' => 'index', $this->params['pass'][0]));
-		$this->set(compact('mailFields'));
-		$this->set(compact('message'));
+		$this->set(compact('message', 'mailFields'));
 		$this->pageTitle = __d('baser', '受信メール詳細');
 	}
 

--- a/lib/Baser/Plugin/Mail/Model/MailMessage.php
+++ b/lib/Baser/Plugin/Mail/Model/MailMessage.php
@@ -69,16 +69,14 @@ class MailMessage extends MailAppModel {
 		// 利用するメールフィールド取得
 		App::uses('MailField', 'Mail.Model');
 		$MailContent = ClassRegistry::init('Mail.MailContent');
+		$MailContent->hasMany['MailField']['conditions'] = ['MailField.mail_content_id' => $mailContentId, 'MailField.use_field' => true];
+		$MailContent->hasMany['MailField']['order'] = 'MailField.sort ASC';
 		$mailContent = $MailContent->find('first', ['conditions' => ['MailContent.id' => $mailContentId], 'recursive' => 1]);
 		$this->mailContent = ['MailContent' => $mailContent['MailContent']];
-
-		$MailField = ClassRegistry::init('Mail.MailField');
- 		$mailFields = $MailField->find('all', array(
-			'conditions' => array('MailField.mail_content_id' => $mailContentId, 'MailField.use_field' => true),
- 			'order' => 'MailField.sort ASC',
- 		));
-		if ($mailFields) {
-			$this->mailFields = $mailFields;
+		if(!empty($mailContent['MailField'])) {
+			foreach($mailContent['MailField'] as $value) {
+				$this->mailFields[]	= ['MailField' => $value];
+			}
 		}
 
 		// アップロード設定

--- a/lib/Baser/Plugin/Mail/Model/MailMessage.php
+++ b/lib/Baser/Plugin/Mail/Model/MailMessage.php
@@ -71,11 +71,16 @@ class MailMessage extends MailAppModel {
 		$MailContent = ClassRegistry::init('Mail.MailContent');
 		$mailContent = $MailContent->find('first', ['conditions' => ['MailContent.id' => $mailContentId], 'recursive' => 1]);
 		$this->mailContent = ['MailContent' => $mailContent['MailContent']];
-		if(!empty($mailContent['MailField'])) {
-			foreach($mailContent['MailField'] as $value) {
-				$this->mailFields[]	= ['MailField' => $value];
-			}
+
+		$MailField = ClassRegistry::init('Mail.MailField');
+ 		$mailFields = $MailField->find('all', array(
+			'conditions' => array('MailField.mail_content_id' => $mailContentId, 'MailField.use_field' => true),
+ 			'order' => 'MailField.sort ASC',
+ 		));
+		if ($mailFields) {
+			$this->mailFields = $mailFields;
 		}
+
 		// アップロード設定
 		$this->setupUpload($mailContentId);
 		return true;


### PR DESCRIPTION
アドバイスを元に再調整入れてみました。
https://github.com/baserproject/basercms/pull/938#discussion_r207727397
可能な際に取込検討お願いします
http://project.e-catchup.jp/issues/22085
