### PR TITLE
fix #22282 システム管理者以外のアカウントで、コード欄を使用しているページを保存すると、すでにファイルに出力されているコードが消える問題を修正

### DIFF
--- a/lib/Baser/Model/Page.php
+++ b/lib/Baser/Model/Page.php
@@ -172,10 +172,10 @@ class Page extends AppModel {
  */
 	public function afterSave($created, $options = []) {
 
-		$data = $this->data;
-		// タイトルタグと説明文を追加
 		if (empty($data['Page']['id'])) {
-			$data['Page']['id'] = $this->id;
+			$data = $this->read(null, $this->id);
+		} else {
+			$data = $this->read(null, $data['Page']['id']);
 		}
 
 		if ($this->fileSave) {

--- a/lib/Baser/Model/Page.php
+++ b/lib/Baser/Model/Page.php
@@ -200,7 +200,7 @@ class Page extends AppModel {
  * @return array
  */
 	public function createSearchIndex($data) {
-		if (!isset($data['Page']) || !isset($data['Content'])) {
+		if (!isset($data['Page']['id']) || !isset($data['Content']['id'])) {
 			return false;
 		}
 		$page = $data['Page'];


### PR DESCRIPTION
□問題点
システム管理者以外のアカウントで、コード欄を使用しているページを保存すると、すでにファイルに出力されているコードが消える

□期待値
システム管理者以外での固定ページ保存時に、コード欄の出力に対して影響を与えないこと

□再現方法
1. システム管理者アカウントで固定ページにテキストを入力
2. 運営者アカウントで該当固定ページを保存
-> システム管理者が固定ページに入力したテキストが出力ファイルから消える

□原因
システム管理者以外でページを保存した際のリクエストデータには、コード欄の内容が含まれておらず、そのデータをもとに固定ページの出力を行っているため

□修正点
固定ページ作成に使用するデータをリクエストデータではなく、DBから取得したデータに変更


ご確認をよろしくお願いします。
http://project.e-catchup.jp/issues/22282