### PR TITLE
fix #22284 BcAppModel::expects() にて、再帰的な bind 定義を行うとエラーになる問題を改善

### DIFF
--- a/lib/Baser/Model/BcAppModel.php
+++ b/lib/Baser/Model/BcAppModel.php
@@ -1236,7 +1236,9 @@ class BcAppModel extends Model {
 /**
  * 指定したモデル以外のアソシエーションを除外する
  *
- * @param array $auguments アソシエーションを除外しないモデル
+ * @param array $auguments アソシエーションを除外しないモデル。
+ * 　「.（ドット）」で区切る事により、対象モデルにアソシエーションしているモデルがさらに定義しているアソシエーションを対象とする事ができる
+ * 　（例）UserGroup.Permission
  * @param boolean $reset バインド時に１回の find でリセットするかどうか
  * @return void
  */
@@ -1300,7 +1302,7 @@ class BcAppModel extends Model {
 					$this->__backInnerAssociation = [];
 				}
 				$this->__backInnerAssociation[] = $model;
-				$this->$model->expects(true, $children);
+				$this->$model->expects($children, $reset);
 			}
 		}
 

--- a/lib/Baser/Test/Case/Model/BcAppTest.php
+++ b/lib/Baser/Test/Case/Model/BcAppTest.php
@@ -20,6 +20,7 @@ App::uses('Content', 'Model');
  * @property Page $Page
  * @property SiteConfig $SiteConfig
  * @property Content $Content
+ * @property User $User
  */
 
 class BcAppTest extends BaserTestCase {
@@ -749,7 +750,7 @@ class BcAppTest extends BaserTestCase {
  */
 	public function testExpects($arguments, $expectedHasKeys, $expectedNotHasKeys) {
 		$this->User->expects($arguments);
-		$result = $this->User->find('first', ['recursive' => 1]);
+		$result = $this->User->find('first', ['conditions' => ['User.id' => 2], 'recursive' => 2]);
 
 		// 存在するキー
 		foreach ($expectedHasKeys as $key) {
@@ -766,6 +767,8 @@ class BcAppTest extends BaserTestCase {
 		return [
 			[[], ['User'], ['UserGroup', 'Favorite']],
 			[['UserGroup'], ['User', 'UserGroup'], ['Favorite']],
+			[['UserGroup.Permission'], [], ['Permission']],
+			[['User', 'UserGroup', 'Favorite'], [], ['Permission']],
 		];
 	}
 


### PR DESCRIPTION
@MASA-P レビューお願いします！