### PR TITLE
fix #22281 BcAppModel::expects()がテストモック関連のメソッド名と同名でテスト作成に問題が出るためリネーム

### DIFF
--- a/lib/Baser/Model/BcAppModel.php
+++ b/lib/Baser/Model/BcAppModel.php
@@ -1240,7 +1240,7 @@ class BcAppModel extends Model {
  * @param boolean $reset バインド時に１回の find でリセットするかどうか
  * @return void
  */
-	public function expects($arguments, $reset = true) {
+	public function reduceAssociations($arguments, $reset = true) {
 		$models = [];
 
 		foreach ($arguments as $index => $argument) {
@@ -1300,7 +1300,7 @@ class BcAppModel extends Model {
 					$this->__backInnerAssociation = [];
 				}
 				$this->__backInnerAssociation[] = $model;
-				$this->$model->expects(true, $children);
+				$this->$model->reduceAssociations(true, $children);
 			}
 		}
 

--- a/lib/Baser/Plugin/Blog/Model/BlogPost.php
+++ b/lib/Baser/Plugin/Blog/Model/BlogPost.php
@@ -888,7 +888,7 @@ class BlogPost extends BlogAppModel {
 				$query['preview'], $query['sort'], $query['direction'], $query['num'], 
 				$query['force'],$query['no'], $query['siteId'], $query['contentUrl']);
 
-			$this->expects($expects, false);
+			$this->reduceAssociations($expects, false);
 			
 			$this->BlogContent->unbindModel([
 				'hasMany' => ['BlogPost', 'BlogCategory']

--- a/lib/Baser/Plugin/Blog/Test/Case/View/Helper/BlogHelperTest.php
+++ b/lib/Baser/Plugin/Blog/Test/Case/View/Helper/BlogHelperTest.php
@@ -101,7 +101,7 @@ class BlogHelperTest extends BaserTestCase {
 		$this->Blog = new BlogHelper($this->View);
 
 		$this->BlogContent = ClassRegistry::init('Blog.BlogContent');
-		$this->BlogContent->expects([]);
+		$this->BlogContent->reduceAssociations([]);
 		$this->Blog->setContent(1);
 	}
 

--- a/lib/Baser/Plugin/Mail/View/Helper/MailHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MailHelper.php
@@ -49,7 +49,7 @@ class MailHelper extends AppHelper {
 		}
 		if ($mailContentId) {
 			$MailContent = ClassRegistry::init('Mail.MailContent');
-			$MailContent->expects(array());
+			$MailContent->reduceAssociations([]);
 			$this->mailContent = Hash::extract($MailContent->read(null, $mailContentId), 'MailContent');
 		} elseif (isset($this->_View->viewVars['mailContent'])) {
 			$this->mailContent = $this->_View->viewVars['mailContent']['MailContent'];

--- a/lib/Baser/Test/Case/Model/BcAppTest.php
+++ b/lib/Baser/Test/Case/Model/BcAppTest.php
@@ -745,10 +745,10 @@ class BcAppTest extends BaserTestCase {
  * @param array $auguments アソシエーションを除外しないモデル
  * @param array $expectedHasKey 期待する存在するキー
  * @param array $expectedNotHasKey 期待する存在しないキー
- * @dataProvider expectsDataProvider
+ * @dataProvider reduceAssociationsDataProvider
  */
-	public function testExpects($arguments, $expectedHasKeys, $expectedNotHasKeys) {
-		$this->User->expects($arguments);
+	public function testReduceAssociations($arguments, $expectedHasKeys, $expectedNotHasKeys) {
+		$this->User->reduceAssociations($arguments);
 		$result = $this->User->find('first', ['recursive' => 1]);
 
 		// 存在するキー
@@ -762,7 +762,7 @@ class BcAppTest extends BaserTestCase {
 		}
 	}
 
-	public function expectsDataProvider() {
+	public function reduceAssociationsDataProvider() {
 		return [
 			[[], ['User'], ['UserGroup', 'Favorite']],
 			[['UserGroup'], ['User', 'UserGroup'], ['Favorite']],
@@ -999,6 +999,21 @@ class BcAppTest extends BaserTestCase {
 			[["aa", "\"", "<", ">"], ['aa', '&quot;', '&lt;', '&gt;']],
 			[[["aa", "\"", "<", ">"], '\"', '<', '>'], [['aa', '"', '<', '>'], '\&quot;', '&lt;', '&gt;']],
 		];
+	}
+
+/**
+ * @test モデルのモックが作成できるかテスト
+ */
+	public function testGetMock() {
+		$expect = 'do not save!';
+		$Model = $this->getMockForModel('BcAppModel', ['save']);
+		$Model->expects($this->any())
+			->method('save')
+			->will($this->returnValue($expect));
+
+		$actual = $Model->save(['Hoge' => ['name' => 'fuga']]);
+		$this->assertEquals($expect, $actual, 'スタブが正しく実行されること');
+
 	}
 
 }


### PR DESCRIPTION
## Ticket URL
- [http://project.e-catchup.jp/issues/22281](http://project.e-catchup.jp/issues/22281)

## Technical Changes Overview
- BcAppModel::expects()とMockModel::expects()が被るため、モックを利用してのテストができない状態のため、リネームが必要です。
- メソッド名は「expects()」ですが、実際の機能は「指定したアソシエーションモデル名以外のアソシエーションをunbindする」ということですので、「reduceAssociations()」という名前に変更しました。

## Dependency PRs
- #952 
