### PR TITLE
fix: 管理画面の受信メール詳細で削除した際のメッセージにメールフォームのタイトルが出力されていなかった

### DIFF
--- a/lib/Baser/Plugin/Mail/Controller/MailMessagesController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailMessagesController.php
@@ -66,7 +66,6 @@ class MailMessagesController extends MailAppController {
  */
 	public function beforeFilter() {
 		parent::beforeFilter();
-		$this->MailContent->recursive = -1;
 		$this->mailContent = $this->MailContent->read(null, $this->params['pass'][0]);
 		App::uses('MailMessage', 'Mail.Model');
 		$this->MailMessage = new MailMessage();
@@ -203,7 +202,7 @@ class MailMessagesController extends MailAppController {
 			$this->notFound();
 		}
 		if ($this->MailMessage->delete($messageId)) {
-			$this->setMessage(sprintf(__d('baser', '%s への受信データ NO「%s」 を削除しました。'), $this->mailContent['MailContent']['title'], $messageId), false, true);
+			$this->setMessage(sprintf(__d('baser', '%s への受信データ NO「%s」 を削除しました。'), $this->mailContent['Content']['title'], $messageId), false, true);
 		} else {
 			$this->setMessage(__d('baser', 'データベース処理中にエラーが発生しました。'), true);
 		}


### PR DESCRIPTION
管理画面の受信メール詳細でメールを削除すると、一覧に戻った際のメッセージで下の画像のようにフォームタイトルが表示されない問題を修正しています。

![image](https://user-images.githubusercontent.com/3647470/45024527-31066e00-b074-11e8-98c7-6181951425db.png)

お時間ある際に、ご確認の上、問題なければ取り込みをお願いします。