### PR TITLE
fix #22274 アイキャッチ設定済みのコンテンツに別の拡張子のファイルをアイキャッチに再設定した場合、旧ファイルが残ってしまう問題を修正

### DIFF
--- a/lib/Baser/Model/Behavior/BcUploadBehavior.php
+++ b/lib/Baser/Model/Behavior/BcUploadBehavior.php
@@ -671,6 +671,13 @@ class BcUploadBehavior extends ModelBehavior {
 			if (!$fieldName || ($fieldName && $fieldName == $field['name'])) {
 				if (!empty($Model->data[$Model->name][$field['name']])) {
 					$file = $Model->data[$Model->name][$field['name']];
+
+					// DBに保存されているファイル名から拡張子を取得する
+					preg_match('/\.(.+)\z/', $file, $match);
+					if (!empty($match[1])) {
+						$field['ext'] = $match[1];
+					}
+
 					$this->delFile($Model, $file, $field);
 				}
 			}


### PR DESCRIPTION
□変更点
現在、ファイルをアップロードした際には、BcUploadBehaviorのbeforeSave()から呼び出されるdeleteExistingFiles()にて、既に存在するファイルを削除する処理になっています。

その際、新しくアップロードしたファイルの拡張子をもとに、既に存在するファイルを削除しようとしているため、表題の問題が発生します。

そのため、アップロードしたファイルの拡張子ではなく、DBに保存されているファイル名の拡張子をもとにファイルを削除するよう変更を行っています。

発生条件の詳細は以下のチケットに記載されています。
http://project.e-catchup.jp/issues/22274

ご確認をよろしくお願いします。