### PR TITLE
BcUploadBehavior->delFilesの拡張子取得処理を改善

### DIFF
--- a/lib/Baser/Model/Behavior/BcUploadBehavior.php
+++ b/lib/Baser/Model/Behavior/BcUploadBehavior.php
@@ -673,7 +673,7 @@ class BcUploadBehavior extends ModelBehavior {
 					$file = $Model->data[$Model->name][$field['name']];
 
 					// DBに保存されているファイル名から拡張子を取得する
-					preg_match('/\.(.+)\z/', $file, $match);
+					preg_match('/\.([^.]+)\z/', $file, $match);
 					if (!empty($match[1])) {
 						$field['ext'] = $match[1];
 					}


### PR DESCRIPTION
昨日マージいただいたコミットに不都合があったので修正しています。

BcUploadのnameformatにドットが含まれる場合に、正常にファイルの削除が行われないため、拡張子の取得処理を改善しています。

お手数ですが、よろしくお願いします。

・昨日のプルリク
fix #22274 アイキャッチ設定済みのコンテンツに別の拡張子のファイルをアイキャッチに再設定した場合、旧ファイルが残ってしまう問題を修正
https://github.com/baserproject/basercms/pull/956