### PR TITLE
fix #22395 管理画面において、並び替えとページネーション機能を併用した際の不都合修正

### DIFF
--- a/lib/Baser/View/Elements/admin/list_num.php
+++ b/lib/Baser/View/Elements/admin/list_num.php
@@ -15,7 +15,7 @@
  */
 $currentNum = '';
 if (empty($nums)) {
-	$nums = ['10', '20', '50', '100'];
+	$nums = ['10', '30', '50', '100'];
 }
 if (!is_array($nums)) {
 	$nums = [$nums];


### PR DESCRIPTION
□ 問題
現在の一覧表示件数の仕様として、10,20,50,100件でページネーションが設定されているため、ページをまたいで並び替えを行うことができないケースがあります。

件数が100件を超えた際に、101番目以降のデータを100番目よりも前の位置に移動することができません。

□ 対策
一覧表示件数の設定を 10, 30, 50, 100件とすることで解決できます。

ご確認をよろしくお願いします。