### PR TITLE
ThemeFilesController::admin_view()でwarningが出る不具合を修正

### DIFF
--- a/lib/Baser/Controller/ThemeFilesController.php
+++ b/lib/Baser/Controller/ThemeFilesController.php
@@ -484,6 +484,7 @@ class ThemeFilesController extends AppController {
 		$this->crumbs[] = ['name' => $this->_tempalteTypes[$type], 'url' => ['controller' => 'theme_files', 'action' => 'index', $theme, $type]];
 		$this->subMenuElements = ['theme_files'];
 		$this->set('currentPath', str_replace(ROOT, '', dirname($fullpath)) . '/');
+		$this->set('isWritable', is_writable($fullpath));
 		$this->set('theme', $theme);
 		$this->set('plugin', $plugin);
 		$this->set('type', $type);


### PR DESCRIPTION
ThemeFilesController::admin_view()で、viewVersにisWritableが存在しないためエラーが出る不具合を修正しました。