### PR TITLE
ThemeFilesController内の扱えるファイルやフォルダ関連のリスト等を設定ファイルで設定できるように変更

### DIFF
--- a/lib/Baser/Controller/ThemeFilesController.php
+++ b/lib/Baser/Controller/ThemeFilesController.php
@@ -186,13 +186,13 @@ class ThemeFilesController extends AppController {
  * @return string preg_match()で用いるパターン文字列
  */
 	public function _getFileTypePattern($type) {
-	    //typeに対応する拡張子を入手する
-	    $extensions = $this->_getFileTypeExtensions($type);
+		//typeに対応する拡張子を入手する
+		$extensions = $this->_getFileTypeExtensions($type);
 
-	    //拡張子が得られない場合はヒットしないパターン
-	    if (empty($extensions)) {
-	        return '/^$/';
-        }
+		//拡張子が得られない場合はヒットしないパターン
+		if (empty($extensions)) {
+			return '/^$/';
+		}
 
 		//pregのパターン作成
 		$pattern = '';
@@ -204,33 +204,33 @@ class ThemeFilesController extends AppController {
 		return $pattern;
 	}
 
-    /**
-     * ファイルタイプに対応する拡張子のリストを入手
-     * 設定からリストを入手し、存在しなかったらデフォルト値を得ます
-     *
-     * @param string $type タイプ(text|image)
-     * @return array 指定したタイプに対応する拡張子のリスト
-     */
+	/**
+	 * ファイルタイプに対応する拡張子のリストを入手
+	 * 設定からリストを入手し、存在しなかったらデフォルト値を得ます
+	 *
+	 * @param string $type タイプ(text|image)
+	 * @return array 指定したタイプに対応する拡張子のリスト
+	 */
 	public function _getFileTypeExtensions($type) {
-        //デフォルトの拡張子
-        $default = [
-            'text' => ['ctp', 'php', 'css', 'js'],
-            'image' => ['png', 'gif', 'jpg', 'jpeg'],
-        ];
+		//デフォルトの拡張子
+		$default = [
+			'text' => ['ctp', 'php', 'css', 'js'],
+			'image' => ['png', 'gif', 'jpg', 'jpeg'],
+		];
 
-        //設定に拡張子登録があったら読み込む
-        $extensions = Configure::read("ThemeFile.fileType.{$type}");
-        if ($extensions === null) {
-            //なかったらデフォルトを読み込む
-            $extensions = Hash::get($default, $type);
-            //ファイルタイプが見つからない場合は何もマッチしない
-            if ($extensions === null) {
-                return [];
-            }
-        }
+		//設定に拡張子登録があったら読み込む
+		$extensions = Configure::read("ThemeFile.fileType.{$type}");
+		if ($extensions === null) {
+			//なかったらデフォルトを読み込む
+			$extensions = Hash::get($default, $type);
+			//ファイルタイプが見つからない場合は何もマッチしない
+			if ($extensions === null) {
+				return [];
+			}
+		}
 
-        return $extensions;
-    }
+		return $extensions;
+	}
 
 /**
  * テーマファイル作成
@@ -293,7 +293,7 @@ class ThemeFilesController extends AppController {
 		$this->set('plugin', $plugin);
 		$this->set('type', $type);
 		$this->set('path', $path);
-        $this->set('createTextExtensionList', $this->_getCreateTextExtensions());
+		$this->set('createTextExtensionList', $this->_getCreateTextExtensions());
 		$this->help = 'theme_files_form';
 		$this->render('form');
 	}
@@ -785,11 +785,11 @@ class ThemeFilesController extends AppController {
 		}
 
 		if (empty($data['type'])) {
-		    //設定でデフォルトタイプがあったらそれを採用する
-            $data['type'] = Configure::read('ThemeFile.defaultType');
-            if (empty($data['type'])) {
-                $data['type'] = 'Layouts';
-            }
+			//設定でデフォルトタイプがあったらそれを採用する
+			$data['type'] = Configure::read('ThemeFile.defaultType');
+			if (empty($data['type'])) {
+				$data['type'] = 'Layouts';
+			}
 		}
 
 		if (!empty($args)) {
@@ -1015,12 +1015,12 @@ class ThemeFilesController extends AppController {
 		return $list;
 	}
 
-    /**
-     * テンプレートタイプの入手
-     * 設定からリストを入手し、存在しなかったらデフォルト値を得ます
-     *
-     * @return array
-     */
+	/**
+	 * テンプレートタイプの入手
+	 * 設定からリストを入手し、存在しなかったらデフォルト値を得ます
+	 *
+	 * @return array
+	 */
 	public function _getTemplateTypes() {
 		$list = Configure::read('ThemeFile.templateTypes');
 		if ($list === null) {
@@ -1038,20 +1038,20 @@ class ThemeFilesController extends AppController {
 		return $list;
 	}
 
-    /**
-     * テキストタイプで有効な拡張子を入手
-     * 設定からリストを入手し、存在しなかったらデフォルト値を得ます
-     *
-     * @return array
-     */
+	/**
+	 * テキストタイプで有効な拡張子を入手
+	 * 設定からリストを入手し、存在しなかったらデフォルト値を得ます
+	 *
+	 * @return array
+	 */
 	public function _getCreateTextExtensions() {
-        $list = [];
-        $extensions = $this->_getFileTypeExtensions('text');
-        foreach ($extensions as $extension) {
-            $dot = empty($extension) ? '' : '.';
-            $list[$extension] = "{$dot}{$extension}";
-        }
+		$list = [];
+		$extensions = $this->_getFileTypeExtensions('text');
+		foreach ($extensions as $extension) {
+			$dot = empty($extension) ? '' : '.';
+			$list[$extension] = "{$dot}{$extension}";
+		}
 
-        return $list;
-    }
+		return $list;
+	}
 }

--- a/lib/Baser/Test/Case/Controller/ThemeFilesControllerTest.php
+++ b/lib/Baser/Test/Case/Controller/ThemeFilesControllerTest.php
@@ -349,7 +349,7 @@ class ThemeFilesControllerTest extends BaserTestCase {
  * @test [functional] テンプレートタイプの入手するテスト
  * @dataProvider provider_getTemplateTypes
  * @param array $setting Configureで設定する値。nullの場合は設定しない(デフォルトを使うため)
- * @param string $expect 結果で得られる除外リスト
+ * @param string $expect 結果で得られるテンプレートタイプのリスト
  */
 	public function test_getTemplateTypes($setting, $expect) {
 		//コントローラを作成

--- a/lib/Baser/Test/Case/Controller/ThemeFilesControllerTest.php
+++ b/lib/Baser/Test/Case/Controller/ThemeFilesControllerTest.php
@@ -145,4 +145,290 @@ class ThemeFilesControllerTest extends BaserTestCase {
 		$this->markTestIncomplete('このテストは、まだ実装されていません。');
 	}
 
+/**
+ * @test [functional] ファイルタイプに対応する拡張子のリストを入手するテスト
+ * @dataProvider provider_getFileTypePattern
+ * @param string $type タイプ名
+ * @param array $setting Configureで設定する値。nullの場合は設定しない(デフォルトを使うため)
+ * @param string $expect 結果で得られる正規表現パターン
+ */
+	public function test_getFileTypePattern($type, $setting, $expect) {
+		//コントローラを作成
+		$Controller = new ThemeFilesController(new CakeRequest(), new CakeResponse());
+
+		//$settingがnullでなければ設定を登録
+		if ($setting !== null) {
+			Configure::write("ThemeFile.fileType.{$type}", $setting);
+		}
+		$actual = $Controller->_getFileTypePattern($type);
+		$this->assertEquals($expect, $actual);
+	}
+
+/**
+ * @param array
+ */
+	public function provider_getFileTypePattern() {
+		return [
+			'デフォルトのtextの拡張子リストが入手できること' => [
+				'text',
+				null,
+				'/^(.+?)(\.ctp|\.php|\.css|\.js)$/is',
+			],
+			'デフォルトのimageの拡張子リストが入手できること' => [
+				'image',
+				null,
+				'/^(.+?)(\.png|\.gif|\.jpg|\.jpeg)$/is',
+			],
+			'カスタマイズしたtextの拡張子リストが入手できること' => [
+				'text',
+				['php'],
+				'/^(.+?)(\.php)$/is',
+			],
+			'デフォルトのimageの拡張子リストが入手できること' => [
+				'image',
+				['jpg'],
+				'/^(.+?)(\.jpg)$/is',
+			],
+			'存在しないタイプの場合はデフォルトではマッチしないパターンが入手できること' => [
+				'css',
+				null,
+				'/^$/',
+			],
+		];
+	}
+
+/**
+ * @test [functional] ファイルタイプに対応する拡張子のリストを入手するテスト
+ * @dataProvider provider_getFileTypeExtensions
+ * @param string $type タイプ名
+ * @param array $setting Configureで設定する値。nullの場合は設定しない(デフォルトを使うため)
+ * @param string $expect 結果で得られる拡張子の列挙
+ */
+	public function test_getFileTypeExtensions($type, $setting, $expect) {
+		//コントローラを作成
+		$Controller = new ThemeFilesController(new CakeRequest(), new CakeResponse());
+
+		//$settingがnullでなければ設定を登録
+		if ($setting !== null) {
+			Configure::write("ThemeFile.fileType.{$type}", $setting);
+		}
+		$actual = $Controller->_getFileTypeExtensions($type);
+		$this->assertEquals($expect, $actual);
+	}
+
+/**
+ * @param array
+ */
+	public function provider_getFileTypeExtensions() {
+		return [
+			'デフォルトのtextの拡張子リストが入手できること' => [
+				'text',
+				null,
+				['ctp', 'php', 'css', 'js'],
+			],
+			'デフォルトのimageの拡張子リストが入手できること' => [
+				'image',
+				null,
+				['png', 'gif', 'jpg', 'jpeg'],
+			],
+			'カスタマイズしたtextの拡張子リストが入手できること' => [
+				'text',
+				['php'],
+				['php'],
+			],
+			'カスタマイズしたimageの拡張子リストが入手できること' => [
+				'image',
+				['jpg'],
+				['jpg'],
+			],
+			'存在しないタイプの場合はデフォルトではemptyが入手できること' => [
+				'css',
+				null,
+				[],
+			],
+		];
+	}
+
+/**
+ * @test [functional] 除外ファイルのリストを入手するテスト
+ * @dataProvider provider_getExcludeFileList
+ * @param array $setting Configureで設定する値。nullの場合は設定しない(デフォルトを使うため)
+ * @param string $expect 結果で得られる除外リスト
+ */
+	public function test_getExcludeFileList($setting, $expect) {
+		//コントローラを作成
+		$Controller = new ThemeFilesController(new CakeRequest(), new CakeResponse());
+
+		//$settingがnullでなければ設定を登録
+		if ($setting !== null) {
+			Configure::write('ThemeFile.excludeEtcFileList', $setting);
+		}
+		$actual = $Controller->_getExcludeFileList();
+		$this->assertEquals($expect, $actual);
+	}
+
+/**
+ * @param array
+ */
+	public function provider_getExcludeFileList() {
+		return [
+			'デフォルトの除外リストが入手できること' => [
+				null,
+				[
+					'screenshot.png',
+					'VERSION.txt',
+					'config.php',
+					'AppView.php',
+					'BcAppView.php'
+				],
+			],
+			'カスタマイズした除外リストが入手できること' => [
+				[
+					'screenshot.png',
+					'VERSION.txt',
+				],
+				[
+					'screenshot.png',
+					'VERSION.txt',
+				],
+			],
+		];
+	}
+
+/**
+ * @test [functional] 除外フォルダのリストを入手するテスト
+ * @dataProvider provider_getExcludeFolderList
+ * @param array $setting Configureで設定する値。nullの場合は設定しない(デフォルトを使うため)
+ * @param string $expect 結果で得られる除外リスト
+ */
+	public function test_getExcludeFolderList($setting, $expect) {
+		//コントローラを作成
+		$Controller = new ThemeFilesController(new CakeRequest(), new CakeResponse());
+
+		//$settingがnullでなければ設定を登録
+		if ($setting !== null) {
+			Configure::write('ThemeFile.excludeEtcFolderList', $setting);
+		}
+		$actual = $Controller->_getExcludeFolderList();
+		$this->assertEquals($expect, $actual);
+	}
+
+/**
+ * @param array
+ */
+	public function provider_getExcludeFolderList() {
+		return [
+			'デフォルトの除外リストが入手できること' => [
+				null,
+				[
+					'Layouts',
+					'Elements',
+					'Emails',
+					'Pages',
+					'Helper',
+					'Config',
+					'Plugin',
+					'img',
+					'css',
+					'js',
+					'_notes',
+				],
+			],
+			'カスタマイズした除外リストが入手できること' => [
+				[
+					'_notes',
+				],
+				[
+					'_notes',
+				],
+			],
+		];
+	}
+
+/**
+ * @test [functional] テンプレートタイプの入手するテスト
+ * @dataProvider provider_getTemplateTypes
+ * @param array $setting Configureで設定する値。nullの場合は設定しない(デフォルトを使うため)
+ * @param string $expect 結果で得られる除外リスト
+ */
+	public function test_getTemplateTypes($setting, $expect) {
+		//コントローラを作成
+		$Controller = new ThemeFilesController(new CakeRequest(), new CakeResponse());
+
+		//$settingがnullでなければ設定を登録
+		if ($setting !== null) {
+			Configure::write('ThemeFile.templateTypes', $setting);
+		}
+		$actual = $Controller->_getTemplateTypes();
+		$this->assertEquals($expect, $actual);
+	}
+
+/**
+ * @param array
+ */
+	public function provider_getTemplateTypes() {
+		return [
+			'デフォルトのテンプレートタイプが入手できること' => [
+				null,
+				[
+					'Layouts'	=> __d('baser', 'レイアウトテンプレート'),
+					'Elements'	=> __d('baser', 'エレメントテンプレート'),
+					'Emails'	=> __d('baser', 'Eメールテンプレート'),
+					'etc'		=> __d('baser', 'コンテンツテンプレート'),
+					'css'		=> __d('baser', 'スタイルシート'),
+					'js'		=> 'Javascript',
+					'img'		=> __d('baser', 'イメージ')
+				],
+			],
+			'カスタマイズしたテンプレートタイプが入手できること' => [
+				[
+					'etc' => 'テーマファイル',
+				],
+				[
+					'etc' => 'テーマファイル',
+				],
+			],
+		];
+	}
+
+/**
+ * @test [functional] テキストタイプで選択可能な拡張子のプルダウンリストを入手するテスト
+ * @dataProvider provider_getCreateTextExtensions
+ * @param string $type タイプ名
+ * @param array $setting Configureで設定する値。nullの場合は設定しない(デフォルトを使うため)
+ * @param string $expect 結果で得られる拡張子リスト
+ */
+	public function test_getCreateTextExtensions($setting, $expect) {
+		//コントローラを作成
+		$Controller = new ThemeFilesController(new CakeRequest(), new CakeResponse());
+
+		//$settingがnullでなければ設定を登録
+		if ($setting !== null) {
+			Configure::write("ThemeFile.fileType.text", $setting);
+		}
+		$actual = $Controller->_getCreateTextExtensions();
+		$this->assertEquals($expect, $actual);
+	}
+
+/**
+ * @param array
+ */
+	public function provider_getCreateTextExtensions() {
+		return [
+			'デフォルトのtextのプルダウンリストが入手できること' => [
+				null,
+				[
+					'ctp' => '.ctp',
+					'php' => '.php',
+					'css' => '.css',
+					'js' => '.js'
+				],
+			],
+			'カスタマイズしたtextのプルダウンリストが入手できること' => [
+				['php'],
+				['php' => '.php'],
+			],
+		];
+	}
+
 }

--- a/lib/Baser/View/Elements/admin/submenus/theme_files.php
+++ b/lib/Baser/View/Elements/admin/submenus/theme_files.php
@@ -13,15 +13,18 @@
 /**
  * [ADMIN] テーマファイル管理メニュー
  */
-$types = [
-	'Layouts'	=> __d('baser', 'レイアウト'),
-	'Elements'	=> __d('baser', 'エレメント'),
-	'Emails'	=> __d('baser', 'Eメール'),
-	'etc'		=> __d('baser', 'コンテンツ'),
-	'css'		=> 'CSS',
-	'img'		=> __d('baser', 'イメージ'),
-	'js'		=> 'Javascript'
-];
+$types = Configure::read('ThemeFile.templateTypes');
+if ($types === null) {
+	$types = [
+		'Layouts'	=> __d('baser', 'レイアウト'),
+		'Elements'	=> __d('baser', 'エレメント'),
+		'Emails'	=> __d('baser', 'Eメール'),
+		'etc'		=> __d('baser', 'コンテンツ'),
+		'css'		=> 'CSS',
+		'img'		=> __d('baser', 'イメージ'),
+		'js'		=> 'Javascript'
+	];
+}
 if ($theme == 'core') {
 	$themeFiles = [0 => ['name' => '', 'title' => __d('baser', 'コア')]];
 	$Plugin = ClassRegistry::init('Plugin');

--- a/lib/Baser/View/ThemeFiles/admin/form.php
+++ b/lib/Baser/View/ThemeFiles/admin/form.php
@@ -17,10 +17,6 @@
  */
 $this->BcBaser->js('admin/themes/form');
 $params = explode('/', $path);
-$parentPrams = explode('/', $path);
-if ($this->request->action !== 'admin_add') {
-	unset($parentPrams[count($parentPrams)-1]);
-}
 ?>
 
 
@@ -50,9 +46,13 @@ if ($this->request->action !== 'admin_add') {
 			<td class="col-input">
 				<?php if ($this->request->action != 'admin_view'): ?>
 					<?php echo $this->BcForm->input('ThemeFile.name', ['type' => 'text', 'size' => 30, 'maxlength' => 255, 'autofocus' => true]) ?>
-					<?php if ($this->BcForm->value('ThemeFile.ext')): ?>.<?php endif ?>
-					<?php echo h($this->BcForm->value('ThemeFile.ext')) ?>
-					<?php echo $this->BcForm->input('ThemeFile.ext', ['type' => 'hidden']) ?>
+                    <?php if (in_array(Hash::get($this->request->data, 'ThemeFile.type'), ['text', null])) : ?>
+                        <?php echo $this->BcForm->input('ThemeFile.ext', ['type' => 'select', 'options' => $createTextExtensionList]) ?>
+                    <?php else : ?>
+                        <?php if ($this->BcForm->value('ThemeFile.ext')): ?>.<?php endif ?>
+                        <?php echo h($this->BcForm->value('ThemeFile.ext')) ?>
+                        <?php echo $this->BcForm->input('ThemeFile.ext', ['type' => 'hidden']) ?>
+                    <?php endif; ?>
 					<?php echo $this->Html->image('admin/icn_help.png', ['id' => 'helpName', 'class' => 'btn help', 'alt' => __d('baser', 'ヘルプ')]) ?>
 					<?php echo $this->BcForm->error('ThemeFile.name') ?>
 					<div id="helptextName" class="helptext">
@@ -94,17 +94,15 @@ if ($this->request->action !== 'admin_add') {
 <?php echo $this->BcFormTable->dispatchAfter() ?>
 
 <div class="submit">
+    <?php $this->BcBaser->link(__d('baser', '一覧に戻る'), array_merge(['action' => 'index', $theme, $plugin, $type], explode('/', dirname($path))), ['class' => 'btn-gray button']); ?>
 	<?php if ($this->request->action == 'admin_add'): ?>
-		<?php $this->BcBaser->link(__d('baser', '一覧に戻る'), array_merge(['action' => 'index', $theme, $plugin, $type], $parentPrams), ['class' => 'btn-gray button']); ?>
 		<?php echo $this->BcForm->submit(__d('baser', '保存'), ['div' => false, 'class' => 'button', 'id' => 'BtnSave']) ?>
 	<?php elseif ($this->request->action == 'admin_edit'): ?>
-		<?php $this->BcBaser->link(__d('baser', '一覧に戻る'), array_merge(['action' => 'index', $theme, $plugin, $type], $parentPrams), ['class' => 'btn-gray button']); ?>
 		<?php if($isWritable): ?>
 			<?php echo $this->BcForm->submit(__d('baser', '保存'), ['div' => false, 'class' => 'button', 'id' => 'BtnSave']) ?>
 			<?php $this->BcBaser->link(__d('baser', '削除'), array_merge(['action' => 'del', $theme, $plugin, $type], $params), ['class' => 'submit-token button'], sprintf(__d('baser', '%s を本当に削除してもいいですか？'), basename($path)), false) ?>
 		<?php endif ?>	
 	<?php else: ?>
-		<?php $this->BcBaser->link(__d('baser', '一覧に戻る'), array_merge(['action' => 'index', $theme, $plugin, $type], $parentPrams), ['class' => 'btn-gray button']); ?>
 		<?php // プラグインのアセットの場合はコピーできない ?>
 		<?php if (!$safeModeOn): ?>
 			<?php //if($theme == 'core' && !(($type == 'css' || $type == 'js' || $type == 'img') && $plugin)): ?>

--- a/lib/Baser/View/ThemeFiles/admin/form_folder.php
+++ b/lib/Baser/View/ThemeFiles/admin/form_folder.php
@@ -15,11 +15,8 @@
  *
  * @var BcAppView $this
  */
+$params = explode('/', $path);
 $this->BcBaser->js('admin/theme_files/form_folder');
-$parentPrams = $params = explode('/', $path);
-if ($this->request->action !== 'admin_add_folder') {
-	unset($parentPrams[count($parentPrams)-1]);
-}
 ?>
 
 
@@ -69,17 +66,15 @@ if ($this->request->action !== 'admin_add_folder') {
 <?php echo $this->BcFormTable->dispatchAfter() ?>
 
 <div class="submit">
+    <?php $this->BcBaser->link(__d('baser', '一覧に戻る'), array_merge(['action' => 'index', $theme, $plugin, $type], explode('/', dirname($path))), ['class' => 'btn-gray button']); ?>
 	<?php if ($this->request->action == 'admin_add_folder'): ?>
-		<?php $this->BcBaser->link(__d('baser', '一覧に戻る'), array_merge(['action' => 'index', $theme, $plugin, $type], $parentPrams), ['class' => 'btn-gray button']); ?>
 		<?php echo $this->BcForm->submit(__d('baser', '保存'), ['div' => false, 'class' => 'button', 'id' => 'BtnSave']) ?>
 	<?php elseif ($this->request->action == 'admin_edit_folder'): ?>
-		<?php $this->BcBaser->link(__d('baser', '一覧に戻る'), array_merge(['action' => 'index', $theme, $plugin, $type], $parentPrams), ['class' => 'btn-gray button']); ?>
 		<?php if($isWritable): ?>
 			<?php echo $this->BcForm->submit(__d('baser', '保存'), ['div' => false, 'class' => 'button', 'id' => 'BtnSave']) ?>
 			<?php $this->BcBaser->link(__d('baser', '削除'), array_merge(['action' => 'del', $theme, $type], $params), ['class' => 'submit-token button'], sprintf(__d('baser', '%s を本当に削除してもいいですか？'), $this->BcForm->value('ThemeFolder.name')), false	) ?>
 		<?php endif ?>	
 	<?php else: ?>
-		<?php $this->BcBaser->link(__d('baser', '一覧に戻る'), array_merge(['action' => 'index', $theme, $plugin, $type], $parentPrams), ['class' => 'btn-gray button']); ?>
 		<?php if (!$safeModeOn): ?>
 			<?php if ($theme == 'core'): ?>
 				<?php $this->BcBaser->link(__d('baser', '現在のテーマにコピー'), array_merge(['action' => 'copy_folder_to_theme', $theme, $plugin, $type], $params), ['class' => 'submit-token btn-red button'], sprintf(__d('baser', "本当に現在のテーマ「 %s 」にコピーしてもいいですか？\n既に存在するファイルは上書きされます。"), Inflector::camelize($siteConfig['theme']))); ?>


### PR DESCRIPTION
- テーマファイル編集画面内で、扱えるファイルやフォルダを設定ファイルに登録することでカスタマイズできるように変更しました
  - タイプが `etc` (テンプレート)の場合の除外ファイルを `ThemeFile.excludeEtcFileList` に設定することで扱えるファイルをカスタマイズできます
  - タイプが `etc` (テンプレート)の場合の除外フォルダを `ThemeFile.excludeEtcFolderList` に設定することで扱えるファイルをカスタマイズできます
  - サブメニューの内容を `ThemeFile.templateTypes` に設定することでメニューをカスタマイズできます。順番も変更できます。またデフォルトの編集画面を `ThemeFile.defaultType` で設定できます
  - `ThemeFile.fileType` にテキスト編集可能なファイルの拡張子を設定できます。またファイルの新規作成で、今まではPHPファイルしか扱えませんでしたが、これらの拡張子を選択することができるようになりました
- ファイル編集時の「一覧に戻る」の戻り先がファイルになってしまう不具合を修正しました