### PR TITLE
fix #22461 メールフォームView　グループでないと閉じタグが出ない問題を解決

### DIFF
--- a/lib/Baser/Plugin/Mail/View/Elements/mail_input.php
+++ b/lib/Baser/Plugin/Mail/View/Elements/mail_input.php
@@ -104,6 +104,7 @@ if (!empty($mailFields)) {
 				echo "</td>\n    </tr>\n";
 			}
 			$group_field = $field['group_field'];
+			echo !$group_field ? "</td>\n    </tr>\n": '';
 		}
 	}
 }


### PR DESCRIPTION
以前のコミットで、td trのとじタグがグループフィールド以外で出力されなくなっていたようなので、
復活しました。