### PR TITLE
fix #22463 CKEditorにページ内リンクでのアンカーボタンがない問題を解消

### DIFF
--- a/lib/Baser/View/Helper/BcCkeditorHelper.php
+++ b/lib/Baser/View/Helper/BcCkeditorHelper.php
@@ -74,7 +74,7 @@ class BcCkeditorHelper extends AppHelper {
 				'NumberedList', 'BulletedList', 'Outdent', 'Indent', 'Blockquote', '-',
 				'JustifyLeft', 'JustifyCenter', 'JustifyRight', 'JustifyBlock', '-',
 				'Smiley', 'Table', 'HorizontalRule', '-'],
-			['Styles', 'Format', 'Font', 'FontSize', 'TextColor', 'BGColor', '-', 'Link', 'Unlink', '-', 'Image'],
+			['Styles', 'Format', 'Font', 'FontSize', 'TextColor', 'BGColor', '-', 'Link', 'Unlink', 'Anchor', '-', 'Image'],
 			['Maximize', 'ShowBlocks', 'Source']
 		]
 	];


### PR DESCRIPTION
CKEditorのツールバーにページ内リンク用のIDを埋め込むボタンを追加しました。
よろしくお願いします。