### PR TITLE
固定ページの本文、ブログ記事の概要・本文において、Javascriptを含められないバリデーションを追加

### DIFF
--- a/lib/Baser/Model/BcAppModel.php
+++ b/lib/Baser/Model/BcAppModel.php
@@ -1762,11 +1762,20 @@ class BcAppModel extends Model {
  * @return bool
  */
 	public function containsScript($check) {
+		$events = ['onclick', 'ondblclick', 'onmousedown', 'onmouseup', 'onmouseover', 'onmousemove',
+					'onmouseout', 'onkeypress', 'onkeydown', 'onkeyup', 'onload', 'onunload',
+					'onfocus', 'onblur', 'onsubmit', 'onreset', 'onselect', 'onchange'];
 		if(BcUtil::isAdminUser() || Configure::read('BcApp.allowedPhpOtherThanAdmins')) {
 			return true;
 		}
 		$value = $check[key($check)];
-		if(preg_match('/(<\?=|<\?php|<script)/', $value)) {
+		if(preg_match('/(<\?=|<\?php|<script)/i', $value)) {
+			return false;
+		}
+		if(preg_match('/<[^>]+?(' . implode('|', $events) . ')=("|\')[^>]*?>/i', $value)) {
+			return false;
+		}
+		if(preg_match('/href=\s*?("|\')[^"\']*?javascript\s*?:/i', $value)) {
 			return false;
 		}
 		return true;

--- a/lib/Baser/Plugin/Blog/Model/BlogPost.php
+++ b/lib/Baser/Plugin/Blog/Model/BlogPost.php
@@ -127,10 +127,14 @@ class BlogPost extends BlogAppModel {
 			'name' => [
 				['rule' => ['notBlank'], 'message' => __d('baser', 'タイトルを入力してください。'), 'required' => true],
 				['rule' => ['maxLength', 255], 'message' => __d('baser', 'タイトルは255文字以内で入力してください。')]],
+			'content' => [
+				['rule' => 'containsScript', 'message' => __d('baser', '概要欄でスクリプトの入力は許可されていません。')]],
 			'detail' => [
-				['rule' => ['maxByte', 64000], 'message' => __d('baser', '本稿欄に保存できるデータ量を超えています。')]],
+				['rule' => ['maxByte', 64000], 'message' => __d('baser', '本稿欄に保存できるデータ量を超えています。')],
+				['rule' => 'containsScript', 'message' => __d('baser', '本稿欄でスクリプトの入力は許可されていません。')]],
 			'detail_draft' => [
-				['rule' => ['maxByte', 64000], 'message' => __d('baser', '草稿欄に保存できるデータ量を超えています。')]],
+				['rule' => ['maxByte', 64000], 'message' => __d('baser', '草稿欄に保存できるデータ量を超えています。')],
+				['rule' => 'containsScript', 'message' => __d('baser', '草稿欄でスクリプトの入力は許可されていません。')]],
 			'publish_begin' => [
 				['rule' => ['checkDate'], 'message' => __d('baser', '公開開始日の形式が不正です。')],
 				['rule' => ['checkDateRenge', 'publish_begin', 'publish_end'], 'message' => __d('baser', '公開期間が不正です。')]],


### PR DESCRIPTION
下記、２つの条件を満たす場合に限る
- BcApp.allowedPhpOtherThanAdmins が false の場合
- 運営ユーザーの場合