### PR TITLE
fix #22475 CKEditorが<span></span>を勝手に消してしまう問題を解決

### DIFF
--- a/lib/Baser/View/Helper/BcCkeditorHelper.php
+++ b/lib/Baser/View/Helper/BcCkeditorHelper.php
@@ -315,6 +315,7 @@ class BcCkeditorHelper extends AppHelper {
 		$jscode .= "CKEDITOR.config.stylesCombo_stylesSet = '" . $editorStylesSet . "';";
 		$jscode .= "CKEDITOR.config.protectedSource.push( /<\?[\s\S]*?\?>/g );";
 		$jscode .= 'CKEDITOR.dtd.$removeEmpty["i"] = false;'; //　空「i」タグを消さないようにする
+		$jscode .= 'CKEDITOR.dtd.$removeEmpty["span"] = false;'; //　空「span」タグを消さないようにする
 
 		if ($editorEnterBr) {
 			$jscode .= "CKEDITOR.config.enterMode = CKEDITOR.ENTER_BR;";


### PR DESCRIPTION
案件で発生。
<i></i>の他に、<span></span>もCKEditorが勝手に消してしまう問題が残っていたので、
それを解決