### PR TITLE
BlogHelper の getPostTitle() で、リンクしない場合のエスケープを追加

### DIFF
--- a/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
+++ b/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
@@ -205,7 +205,7 @@ class BlogHelper extends AppHelper {
 		if ($link) {
 			return $this->getPostLink($post, $post['BlogPost']['name']);
 		} else {
-			return $post['BlogPost']['name'];
+			return h($post['BlogPost']['name']);
 		}
 	}
 


### PR DESCRIPTION
■概要
ブログプラグインのBlogHelperのgetPostTitle関数は、第2引数のlinkがtrueの場合は、エスケープした結果を返します。

しかし、linkがfalseの場合はエスケープせずに結果を返すため、セキュリティ上の問題が発生します。

■変更点
linkがfalseの場合に、エスケープした結果を返却するよう変更しています。

ご確認をよろしくお願いします。