### PR TITLE
BlogHelper の getPostTitle() で、リンクしない場合のエスケープを追加

### DIFF
--- a/lib/Baser/Plugin/Blog/Test/Case/View/Helper/BlogHelperTest.php
+++ b/lib/Baser/Plugin/Blog/Test/Case/View/Helper/BlogHelperTest.php
@@ -187,21 +187,31 @@ class BlogHelperTest extends BaserTestCase {
 
 /**
  * 記事タイトルを取得する
+ * @param string $name タイトル
+ * @param bool $link リンクをつけるかどうか
+ * @param array $options オプション
+ * @param string $expected 期待値
+ * @dataProvider getPostTitleDataProvider
  */
-	public function testGetPostTitle() {
+	public function testGetPostTitle($name, $link, $options, $expected) {
 		$post = ['BlogPost' => [
 			'blog_content_id' => 1,
-			'name' => 'test-name',
+			'name' => $name,
 			'no' => 4,
 		]];
+		$result = $this->Blog->getPostTitle($post, $link, $options);
+		$this->assertEquals($expected, $result, '記事タイトルを正しく取得できません');
+	}
 
-		// $link = true
-		$result = $this->Blog->getPostTitle($post);
-		$this->assertEquals('<a href="/news/archives/4">test-name</a>', $result, '記事タイトルを正しく取得できません');
-
-		// $link = false
-		$result  = $this->Blog->getPostTitle($post, false);
-		$this->assertEquals('test-name', $result, '記事タイトルを正しく取得できません');
+	public function getPostTitleDataProvider() {
+		return [
+			['test-name', true, [], '<a href="/news/archives/4">test-name</a>'],
+			['test-name', false, [], 'test-name'],
+			['<script></script>', false, [], '&lt;script&gt;&lt;/script&gt;'],
+			['<script></script>', true, [], '<a href="/news/archives/4">&lt;script&gt;&lt;/script&gt;</a>'],
+			['test-name<br>2行目', false, ['escape' => false], 'test-name<br>2行目'],
+			['test-name<br>2行目', true, ['escape' => false], '<a href="/news/archives/4">test-name<br>2行目</a>'],
+		];
 	}
 
 /**

--- a/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
+++ b/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
@@ -190,8 +190,8 @@ class BlogHelper extends AppHelper {
  * @param boolean $link 詳細ページへのリンクをつける場合には、true を指定する（初期値 : true）
  * @return void
  */
-	public function postTitle($post, $link = true) {
-		echo $this->getPostTitle($post, $link);
+	public function postTitle($post, $link = true, $options = []) {
+		echo $this->getPostTitle($post, $link, $options);
 	}
 
 /**
@@ -199,14 +199,24 @@ class BlogHelper extends AppHelper {
  *
  * @param array $post ブログ記事データ
  * @param boolean $link 詳細ページへのリンクをつける場合には、true を指定する（初期値 : true）
+ * @param array $options オプション（初期値：arary()）
+ * 	- `escape` : エスケープ処理を行うかどうか
+ * 	※ その他のオプションについては、HtmlHelper::link() を参照
  * @return string 記事タイトル
  */
-	public function getPostTitle($post, $link = true) {
+	public function getPostTitle($post, $link = true, $options = []) {
+		$options = array_merge([
+			'escape' => true
+		], $options);
+		$title = $post['BlogPost']['name'];
 		if ($link) {
-			return $this->getPostLink($post, $post['BlogPost']['name']);
+			$title = $this->getPostLink($post, $title, $options);
 		} else {
-			return $post['BlogPost']['name'];
+			if(!empty($options['escape'])) {
+				$title = h($title);
+			}
 		}
+		return $title;
 	}
 
 /**


### PR DESCRIPTION
- そもそもリンクする場合は既にエスケープするようになっていた
- オプションによって、エスケープしないようにもできるようにした
	$this->Blog->getPostTitle($post, false, ['escape' => false]);