### PR TITLE
fix #22359 SecurityComponentのvalidatePostに引っかかる問題の修正

### DIFF
--- a/lib/Baser/Plugin/Mail/View/Helper/MailformHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MailformHelper.php
@@ -62,7 +62,8 @@ class MailformHelper extends BcFreezeHelper {
 				} else {
 					$attributes['separator'] = "&nbsp;&nbsp;";
 				}
-				$out = $this->radio($fieldName, $options, $attributes);
+				$out = $this->hidden($fieldName, array(['value' => '']));
+				$out .= $this->radio($fieldName, $options, $attributes);
 				break;
 
 			case 'select':


### PR DESCRIPTION
radioが未選択の場合postに必要カラムが抜けて送信されてしまいSecurityComponentのエラーが発生する問題の修正です。