### PR TITLE
メールプラグインのフィールドタイプに「電話番号（type='tel'）」を選べるようにした。

### DIFF
--- a/lib/Baser/Plugin/Mail/Model/MailField.php
+++ b/lib/Baser/Plugin/Mail/Model/MailField.php
@@ -92,6 +92,7 @@ class MailField extends MailAppModel {
 			'pref'				=> __d('baser', '都道府県リスト'),
 			'date_time_wareki'	=> __d('baser', '和暦日付'),
 			'date_time_calender'=> __d('baser', 'カレンダー'),
+			'tel'				=> __d('baser', '電話番号'),
 			'hidden'			=> __d('baser', '隠しフィールド')
 		];
 		$source['valid'] = [

--- a/lib/Baser/Plugin/Mail/View/Helper/MaildataHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MaildataHelper.php
@@ -53,6 +53,7 @@ class MaildataHelper extends BcTextHelper {
 
 		switch ($type) {
 			case 'text':
+			case 'tel':
 			case 'textarea':
 			case 'email':
 			case 'hidden':

--- a/lib/Baser/Plugin/Mail/View/Helper/MailfieldHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MailfieldHelper.php
@@ -36,6 +36,8 @@ class MailfieldHelper extends AppHelper {
 		$attributes['class'] = $data['class'];
 		if($data['type'] == 'multi_check') {
 			$attributes['multiple'] = true;
+		} elseif ($data['type'] == 'tel') {
+			$attributes['type'] = 'tel';
 		}
 		if (!empty($data['options'])) {
 			$options = explode("|", $data['options']);

--- a/lib/Baser/Plugin/Mail/View/Helper/MailformHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MailformHelper.php
@@ -197,6 +197,15 @@ class MailformHelper extends BcFreezeHelper {
 				}
 				$out = $this->textarea($fieldName, $attributes);
 				break;
+
+			case 'tel':
+				unset($attributes['separator']);
+				unset($attributes['rows']);
+				unset($attributes['empty']);
+				$attributes['type'] = 'tel';
+				$out = $this->tel($fieldName, $attributes);
+				break;
+				
 			case 'hidden':
 				unset($attributes['separator']);
 				unset($attributes['rows']);

--- a/lib/Baser/View/Helper/BcFreezeHelper.php
+++ b/lib/Baser/View/Helper/BcFreezeHelper.php
@@ -441,6 +441,35 @@ class BcFreezeHelper extends BcFormHelper {
 	}
 
 /**
+ * TELボックスを表示する
+ * 
+ * @param string $fieldName フィールド文字列
+ * @param array $attributes html属性
+ * @return	string	htmlタグ
+ * @access	public
+ */
+	public function tel($fieldName, $attributes = []) {
+
+		if ($this->freezed) {
+			list($model, $field) = explode('.', $fieldName);
+			if (isset($attributes)) {
+				$attributes = $attributes + ['type' => 'hidden'];
+			} else {
+				$attributes = ['type' => 'hidden'];
+			}
+			if (isset($attributes["value"])) {
+				$value = $attributes["value"];
+			} else {
+				$value = $this->request->data[$model][$field];
+			}
+			$attributes['type'] = 'hidden';
+			return parent::tel($fieldName, $attributes) . $value;
+		} else {
+			return parent::tel($fieldName, $attributes);
+		}
+	}
+
+/**
  * JsonList
  * TODO 確認画面用の実装は全くしてない
  * 


### PR DESCRIPTION
お世話になります。メールプラグインでフィールドを作成する際、スマホで使う「type="tel"」の入力フォームが作れなくて困ったので、選択できるようにしてみました。もっとスマートな実装方法があれば教えてください。。。