### PR TITLE
fix #22592 アップローダープラグインのlimited配下のファイルの削除処理を修正

### DIFF
--- a/lib/Baser/Plugin/Uploader/Controller/UploaderFilesController.php
+++ b/lib/Baser/Plugin/Uploader/Controller/UploaderFilesController.php
@@ -422,6 +422,10 @@ class UploaderFilesController extends AppController {
 			}
 		}
 
+		if(!empty($uploaderFile['UploaderFile']['publish_begin']) || !empty($uploaderFile['UploaderFile']['publish_end'])) {
+			$this->UploaderFile->Behaviors->BcUpload->savePath['UploaderFile'] .= 'limited' . DS;
+		}
+
 		$result = $this->UploaderFile->delete($id);
 		if ($this->RequestHandler->isAjax()) {
 			echo $result;

--- a/lib/Baser/Plugin/Uploader/Model/UploaderFile.php
+++ b/lib/Baser/Plugin/Uploader/Model/UploaderFile.php
@@ -212,22 +212,6 @@ class UploaderFile extends AppModel {
 		$sizes = array('large', 'midium', 'small', 'mobile_large', 'mobile_small');
 		return preg_replace('/__(' . implode('|', $sizes) . ')\./', '.', $fileName);
 	}
-
-/**
- * Before Delete
- *
- * @param bool $cascade
- * @return bool
- */
-	public function beforeDelete($cascade = true) {
-		$data = $this->read(null, $this->id);
-		if(!empty($data['UploaderFile']['publish_begin']) || !empty($data['UploaderFile']['publish_end'])) {
-			$this->Behaviors->BcUpload->savePath .= 'limited' . DS;
-		} else {
-			$this->Behaviors->BcUpload->savePath = preg_replace('/' . preg_quote('limited' . DS, '/') . '$/', '', $this->Behaviors->BcUpload->savePath);
-		}
-		return parent::beforeDelete($cascade);
-	}
 	
 }
 


### PR DESCRIPTION
□問題
アップローダープラグインのアップロードファイル一覧にて、公開期間を指定しているファイルを削除しても、実際のファイルがディレクトリから削除されません。

□原因
現在、UploaderFileモデルのbeforeDelete関数に、公開期間を指定しているファイルを削除する際に、ファイル保存パスをlimited配下に書き換える処理が存在します。
しかし、その処理が実行される前に、BcUploadBehaviorのbeforeDelete関数によってファイルが削除されてしまい、limited配下に存在するファイルが削除されません。

□変更点
そこで、UploaderFilesControllerのadmin_delete関数にて、ファイル保存パスをlimited配下に書き換えるよう調整しています。

ご確認をよろしくお願いします。

http://project.e-catchup.jp/issues/22592