### PR TITLE
fix #22593 アップローダープラグインで、公開期間を指定している既存のファイルと同一のファイル名のファイルをアップロードする事が可能な問題を修正

### DIFF
--- a/lib/Baser/Plugin/Uploader/Model/UploaderFile.php
+++ b/lib/Baser/Plugin/Uploader/Model/UploaderFile.php
@@ -31,7 +31,8 @@ class UploaderFile extends AppModel {
  */
 	public $actsAs = [
 		'BcUpload' => [
-			'saveDir' => "uploads",
+			'saveDir' => 'uploads',
+			'existsCheckDirs' => ['uploads/limited'],
 			'fields' => [
 				'name' => ['type'	=> 'all']
 	]]];


### PR DESCRIPTION
□問題
アップローダープラグインで、公開期間を指定している既存のファイルと、同一のファイル名のファイルをアップロードする事が可能です。
これによって以下の問題が発生します。

- 同一ファイル名の他のファイルの画像が誤って表示される
- 新規に登録したファイルに対して公開期間を指定することで、既存のファイルが上書きされる
- 既存のファイルの公開期間を解除することで、新規に登録したファイルが上書きされる

□原因
現在、BcUploadBehaviorには、保存先のフォルダに同一のファイルが存在する場合はファイル名をリネームする処理が存在します。
しかし、保存先以外のフォルダ（例: limitedフォルダ）は考慮しないため、今回の問題が発生します。

□変更点
BcUploadBehaviorに新しいオプション"existsCheckDirs"を追加しています。
ファイルアップロード時に、"existsCheckDirs"に指定したフォルダのリストすべてを対象にファイルの重複チェックを行い、いずれかのフォルダに同一のファイル名のファイルが存在する場合は、アップロードファイルをリネームします。

また、UploaderFileモデルにて、'existsCheckDirs'オプションを利用するよう変更しています。

ご確認をよろしくお願いします。

http://project.e-catchup.jp/issues/22593