### PR TITLE
ログイン画面上部の空白を削除

### DIFF
--- a/lib/Baser/webroot/css/admin/login.css
+++ b/lib/Baser/webroot/css/admin/login.css
@@ -13,6 +13,3 @@
 html {
 	margin-top:0;
 }
-#ToolBar {
-	position:relative;
-}


### PR DESCRIPTION
ログイン画面の上部に、空白が表示される問題を修正しています。
ご確認をよろしくお願いします。

<img width="1236" alt="_2018-11-28_17_47_35" src="https://user-images.githubusercontent.com/30764014/49139956-65698d80-f336-11e8-879a-9e2a13b871dd.png">

□環境
Mac Chrome, Firefox