### PR TITLE
fix #22607 サブディレクトリ設置時管理画面アクセスのドメインが異なった場合、誤ったリダイレクトが行われる問題の修正

### DIFF
--- a/lib/Baser/Controller/BcAppController.php
+++ b/lib/Baser/Controller/BcAppController.php
@@ -273,7 +273,8 @@ class BcAppController extends Controller {
 				$siteUrl = Configure::read('BcEnv.siteUrl');				
 			}
 			if($siteUrl && siteUrl() != $siteUrl) {
-				$this->redirect($siteUrl . preg_replace('/^\//', '', Router::reverse($this->request, false)));
+				$webrootReg = '/^' . preg_quote($this->request->webroot, '/') . '/';
+				$this->redirect($siteUrl . preg_replace($webrootReg, '', Router::reverse($this->request, false)));
 			}
 		}
 


### PR DESCRIPTION
よろしくおねがいします。