### PR TITLE
fix #22611 パスワードのリセットメールがコントローラ直書きのため編集できない問題を解決

### DIFF
--- a/lib/Baser/Controller/UsersController.php
+++ b/lib/Baser/Controller/UsersController.php
@@ -538,8 +538,8 @@ class UsersController extends AppController {
 				$this->setMessage(__d('baser', '新しいパスワードをデータベースに保存できませんでした。'), true, false);
 				return;
 			}
-			$body = $email . ' の新しいパスワードは、 ' . $password . ' です。';
-			if (!$this->sendMail($email, __d('baser', 'パスワードを変更しました'), $body)) {
+			$body = ['email' => $email, 'password' => $password];
+			if (!$this->sendMail($email, __d('baser', 'パスワードを変更しました'), $body, ['template' => 'reset'])) {
 				$this->setMessage(__d('baser', 'メール送信時にエラーが発生しました。'), true, false);
 				return;
 			}

--- a/lib/Baser/View/Emails/text/reset.php
+++ b/lib/Baser/View/Emails/text/reset.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * baserCMS :  Based Website Development Project <http://basercms.net>
+ * Copyright (c) baserCMS Users Community <http://basercms.net/community/>
+ *
+ * @copyright		Copyright (c) baserCMS Users Community
+ * @link			http://basercms.net baserCMS Project
+ * @package			Baser.View
+ * @since			baserCMS v 0.1.0
+ * @license			http://basercms.net/license/index.html
+ */
+
+/**
+ * [EMAIL] パスワードのリセットメール
+ */
+?>
+
+                                           <?php echo date('Y-m-d H:i:s') ?>　
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+　　　　　　◆◇　<?php echo __d('baser', 'パスワードのリセット')?>　◇◆
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+　 <?php echo $email.  __d('baser', ' の新しいパスワードは、 '); ?>
+　 <?php echo $password. __d('baser', ' です。'); ?>


### PR DESCRIPTION
コントローラ直書きの状態から lib/Baser/View/Emails/text/reset.php へと、メール本文を逃がす処理を追加
メール本文は現在のもののままです。