### PR TITLE
fix #22639 固定ページの複製時、複製先ページ名が50文字を超えるものとなる場合に、複製処理が完了しない点を修正

### DIFF
--- a/lib/Baser/Model/Page.php
+++ b/lib/Baser/Model/Page.php
@@ -1168,11 +1168,14 @@ class Page extends AppModel {
 		if ($result) {
 			return $result;
 		} else {
-			if (isset($this->validationErrors['name']) && $this->validationErrors['name'] != 'ページ名は50文字以内で入力してください。') {
-				return $this->copy(null, $data);
-			} else {
-				return false;
+			if (isset($this->validationErrors['name'])) {
+				foreach ($this->validationErrors['name'] as $validationErrorName) {
+					if ($validationErrorName != 'ページ名は50文字以内で入力してください。') {
+						return $this->copy(null, $data);
+					}
+				}
 			}
+			return false;
 		}
 	}
 

--- a/lib/Baser/Model/Page.php
+++ b/lib/Baser/Model/Page.php
@@ -1168,15 +1168,18 @@ class Page extends AppModel {
 		if ($result) {
 			return $result;
 		} else {
-			if (isset($this->validationErrors['name'])) {
-				foreach ($this->validationErrors['name'] as $validationErrorName) {
-					if ($validationErrorName != 'ページ名は50文字以内で入力してください。') {
-						return $this->copy(null, $data);
-					}
+			$isAvairableCopy = true;
+			foreach ($this->validationErrors['name'] as $validationErrorName) {
+				if ($validationErrorName === 'ページ名は50文字以内で入力してください。') {
+					$isAvairableCopy = false;
 				}
 			}
-			return false;
+			if ($isAvairableCopy) {
+				return $this->copy(null, $data);
+			}
 		}
+
+		return false;
 	}
 
 /**


### PR DESCRIPTION
問題内容の詳細です。
http://project.e-catchup.jp/issues/22639
可能な際に、検討取込をお願いします。
