### PR TITLE
fix #22640 メールフォームラジオボタンなどの区切り文字に自動で「＆nbsp;＆nbsp;」が入ってしまう問題の解決方法をhelp…

### DIFF
--- a/lib/Baser/Plugin/Mail/View/Helper/MailformHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MailformHelper.php
@@ -60,7 +60,7 @@ class MailformHelper extends BcFreezeHelper {
 				if (!empty($attributes['separator'])) {
 					$attributes['separator'] = $attributes['separator'];
 				} else {
-					$attributes['separator'] = "&nbsp;&nbsp;";
+					$attributes['separator'] = '';
 				}
 				// CakePHPでは、初期値を指定していない場合に、hiddenタグを出力する仕様
 				// 初期値が設定されている、かつ、空の選択肢を選択して送信する場合に、

--- a/lib/Baser/Plugin/Mail/View/Helper/MailformHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MailformHelper.php
@@ -60,7 +60,7 @@ class MailformHelper extends BcFreezeHelper {
 				if (!empty($attributes['separator'])) {
 					$attributes['separator'] = $attributes['separator'];
 				} else {
-					$attributes['separator'] = '';
+					$attributes['separator'] = "&nbsp;&nbsp;";
 				}
 				// CakePHPでは、初期値を指定していない場合に、hiddenタグを出力する仕様
 				// 初期値が設定されている、かつ、空の選択肢を選択して送信する場合に、

--- a/lib/Baser/Plugin/Mail/View/MailFields/admin/form.php
+++ b/lib/Baser/Plugin/Mail/View/MailFields/admin/form.php
@@ -234,7 +234,14 @@ $this->BcBaser->js('Mail.admin/mail_fields/form', false);
 			<th class="col-head"><?php echo $this->BcForm->label('MailField.separator', __d('baser', '区切り文字')) ?></th>
 			<td class="col-input">
 				<?php echo $this->BcForm->input('MailField.separator', array('type' => 'text', 'size' => 40, 'maxlength' => 255)) ?>
+				<?php echo $this->BcHtml->image('admin/icn_help.png', array('id' => 'helpSeparator', 'class' => 'btn help', 'alt' => __d('baser', 'ヘルプ'))) ?>
 				<?php echo $this->BcForm->error('MailField.separator') ?>
+				<div id="helpSeparator" class="helptext">
+					<ul>
+						<li><?php echo __d('baser', '空白の場合は自動で「＆nbsp;＆nbsp;」が挿入されます')?></li>
+						<li><?php echo __d('baser', '空にしたいときは半角スペースを入力してください。')?></li>
+					</ul>
+				</div>
 			</td>
 		</tr>
 		<tr id="RowDefault">

--- a/lib/Baser/Plugin/Mail/View/MailFields/admin/form.php
+++ b/lib/Baser/Plugin/Mail/View/MailFields/admin/form.php
@@ -234,14 +234,7 @@ $this->BcBaser->js('Mail.admin/mail_fields/form', false);
 			<th class="col-head"><?php echo $this->BcForm->label('MailField.separator', __d('baser', '区切り文字')) ?></th>
 			<td class="col-input">
 				<?php echo $this->BcForm->input('MailField.separator', array('type' => 'text', 'size' => 40, 'maxlength' => 255)) ?>
-				<?php echo $this->BcHtml->image('admin/icn_help.png', array('id' => 'helpSeparator', 'class' => 'btn help', 'alt' => __d('baser', 'ヘルプ'))) ?>
 				<?php echo $this->BcForm->error('MailField.separator') ?>
-				<div id="helpSeparator" class="helptext">
-					<ul>
-						<li><?php echo __d('baser', '空白の場合は自動で「＆nbsp;＆nbsp;」が挿入されます')?></li>
-						<li><?php echo __d('baser', '空にしたいときは半角スペースを入力してください。')?></li>
-					</ul>
-				</div>
 			</td>
 		</tr>
 		<tr id="RowDefault">


### PR DESCRIPTION
メールフォームラジオボタンなどの区切り文字を空白にしておくと、勝手に「＆nbsp;＆nbsp;」が入ってしまう。
（IEなどで公開側のインデントがおかしくなる）
区切り文字の欄に「半角スペース」を入れておくと、正しく空になるので、
その方法をhelpに表示させたい。