### PR TITLE
修正: テーマ設定で画像のサムネイルの削除が出来ていなかった

### DIFF
--- a/lib/Baser/Model/ThemeConfig.php
+++ b/lib/Baser/Model/ThemeConfig.php
@@ -63,7 +63,7 @@ class ThemeConfig extends AppModel {
 			if (!empty($data['ThemeConfig'][$image]['tmp_name'])) {
 				@unlink($saveDir . $old[$image]);
 				$pathinfo = pathinfo($old[$image]);
-				@unlink($saveDir . $pathinfo['filename'] . $thumbSuffix . $pathinfo['extension']);
+				@unlink($saveDir . $pathinfo['filename'] . $thumbSuffix . '.' . $pathinfo['extension']);
 				$fileName = $data['ThemeConfig'][$image]['name'];
 				$ext = pathinfo($fileName, PATHINFO_EXTENSION);
 				$filePath = $saveDir . $image . '.' . $ext;
@@ -94,7 +94,7 @@ class ThemeConfig extends AppModel {
 			if (!empty($data['ThemeConfig'][$image . '_delete'])) {
 				@unlink($saveDir . $old[$image]);
 				$pathinfo = pathinfo($old[$image]);
-				@unlink($saveDir . $pathinfo['filename'] . $thumbSuffix . $pathinfo['extension']);
+				@unlink($saveDir . $pathinfo['filename'] . $thumbSuffix . '.' . $pathinfo['extension']);
 				$data['ThemeConfig'][$image] = '';
 			}
 		}


### PR DESCRIPTION
テーマ設定で画像を削除する際に、サムネイルの画像のファイル名指定に拡張子の前の . (ドット) が足りず実ファイルが削除できていなかったため修正しました。