### PR TITLE
fix #22661 「ファイル」メールフィールドのファイルアップロードサイズ制限のバリデーションが誤っている

### DIFF
--- a/lib/Baser/Plugin/Mail/Model/MailMessage.php
+++ b/lib/Baser/Plugin/Mail/Model/MailMessage.php
@@ -226,11 +226,15 @@ class MailMessage extends MailAppModel {
 					$options = call_user_func_array('aa', $options);
 					switch ($valid) {
 						case 'VALID_MAX_FILE_SIZE':
-							if(!empty($options['maxFileSize'])) {
-								if(!in_array($this->data['MailMessage'][$mailField['field_name']]['error'], [1, 2])) {
-									$errorMessage = __('ファイルサイズがオーバーしています。 %s MB以内のファイルをご利用ください。', $options['maxFileSize']);
-								} else {
-									$errorMessage = __('何らかの原因でファイルをアップロードできませんでした。Webサイトの管理者に連絡してください。');
+							if (!empty($options['maxFileSize']) && $this->data['MailMessage'][$mailField['field_name']]['error'] !== UPLOAD_ERR_NO_FILE) {
+								switch ($this->data['MailMessage'][$mailField['field_name']]['error']) {
+									case UPLOAD_ERR_INI_SIZE:
+									case UPLOAD_ERR_FORM_SIZE:
+										$errorMessage = __('ファイルサイズがオーバーしています。 %s MB以内のファイルをご利用ください。',
+											$options['maxFileSize']);
+										break;
+									default:
+										$errorMessage = __('何らかの原因でファイルをアップロードできませんでした。Webサイトの管理者に連絡してください。');
 								}
 								$this->validate[$mailField['field_name']]['fileCheck'] = [
 									'rule' => ['fileCheck', $options['maxFileSize'] * 1000 * 1000],


### PR DESCRIPTION
ファイルを選択しなかった場合もファイルサイズオーバーのメッセージが表示される問題を修正しています。
また、エラーの判別に定数を利用するよう変更しています。

ご確認よろしくお願いします。