### PR TITLE
fix #22721 JPEG画像をアップロードすると元画像より容量が大きくなる件の改善

### DIFF
--- a/lib/Baser/Vendor/Imageresizer.php
+++ b/lib/Baser/Vendor/Imageresizer.php
@@ -14,9 +14,16 @@ class Imageresizer {
  * @param 	string 	保存先のパス
  * @param 	int 	幅
  * @param 	int		高さ
+ * @param 	array	圧縮レベル (JPEG: 100 (0-100), PNG: 6 (0-9))
  * @return 	boolean
  */
-	function resize($imgPath, $savePath = null, $newWidth=null, $newHeight=null, $trimming = false) {
+	function resize($imgPath, $savePath = null, $newWidth=null, $newHeight=null, $trimming = false, $quality = array()) {
+
+		// 画像種類別の圧縮レベルのデフォルト値
+		$quality = $quality + array(
+			IMAGETYPE_JPEG => 100,	//  0 - 100
+			IMAGETYPE_PNG => 6,		// 	0 - 9
+		);
 
 		// 元画像のサイズを取得
 		$imginfo = getimagesize($imgPath);
@@ -129,12 +136,12 @@ class Imageresizer {
 				break;
 
 			case IMAGETYPE_JPEG:
-				imagejpeg($newImage,$savePath,100);
+				imagejpeg($newImage, $savePath, $quality[IMAGETYPE_JPEG]);
 				break;
 
 			case IMAGETYPE_PNG:
 				if($savePath) {
-					imagepng($newImage,$savePath);
+					imagepng($newImage, $savePath, $quality[IMAGETYPE_PNG]);
 				}else {
 					imagepng($newImage);
 				}

--- a/lib/Baser/Vendor/Imageresizer.php
+++ b/lib/Baser/Vendor/Imageresizer.php
@@ -17,13 +17,13 @@ class Imageresizer {
  * @param 	array	圧縮レベル (JPEG: 100 (0-100), PNG: 6 (0-9))
  * @return 	boolean
  */
-	function resize($imgPath, $savePath = null, $newWidth=null, $newHeight=null, $trimming = false, $quality = array()) {
+	function resize($imgPath, $savePath = null, $newWidth=null, $newHeight=null, $trimming = false, $quality = []) {
 
 		// 画像種類別の圧縮レベルのデフォルト値
-		$quality = $quality + array(
+		$quality = $quality + [
 			IMAGETYPE_JPEG => 100,	//  0 - 100
 			IMAGETYPE_PNG => 6,		// 	0 - 9
-		);
+		];
 
 		// 元画像のサイズを取得
 		$imginfo = getimagesize($imgPath);


### PR DESCRIPTION
lib/Baser/Vendor/Imageresizer.php の 圧縮レベル（quality）パラメータを指定できるようにしてみました。
（ https://d-project.backlog.jp/view/BGR-239 関連です ）

よろしくお願いいたします。
