### PR TITLE
fix #22722 管理画面を別のドメインで利用できるように調整

### DIFF
--- a/lib/Baser/Controller/BcAppController.php
+++ b/lib/Baser/Controller/BcAppController.php
@@ -268,7 +268,10 @@ class BcAppController extends Controller {
 
 		// 設定されたサイトURLとリクエストされたサイトURLが違う場合は設定されたサイトにリダイレクト
 		if($isAdmin) {
-			if($this->request->is('ssl')) {
+			$cmsUrl = Configure::read('BcEnv.cmsUrl');
+			if($cmsUrl) {
+				$siteUrl = Configure::read('BcEnv.cmsUrl');
+			} elseif($this->request->is('ssl')) {
 				$siteUrl = Configure::read('BcEnv.sslUrl');
 			} else {
 				$siteUrl = Configure::read('BcEnv.siteUrl');				


### PR DESCRIPTION
install.php にて、設定を追加する
Configure::write('BcEnv.cmsUrl', 'https://cms.xxx.xxx/');
フロントエンドでツールバーを有効にするには複数ドメイン間のセッションを共有するためcookie_domain
の設定も追加する
ただし、他のサイトが動いていないか、影響がないかを確認する事
ini_set('session.cookie_domain', '.xxx.xxx');