### PR TITLE
fix #22732 検索機能で特定のブログ内の記事に絞って検索できない問題を解決

### DIFF
--- a/lib/Baser/Controller/SearchIndicesController.php
+++ b/lib/Baser/Controller/SearchIndicesController.php
@@ -183,8 +183,8 @@ class SearchIndicesController extends AppController {
 		}
 		if (!empty($data['SearchIndex']['f'])) {
 			$content = $this->Content->find('first', ['fields' => ['lft', 'rght'], 'conditions' => ['Content.id' => $data['SearchIndex']['f']], 'recursive' => -1]);
-			$conditions['SearchIndex.rght <'] = $content['Content']['rght'];
-			$conditions['SearchIndex.lft >'] = $content['Content']['lft'];
+			$conditions['SearchIndex.rght <='] = $content['Content']['rght'];
+			$conditions['SearchIndex.lft >='] = $content['Content']['lft'];
 		}
 		if ($query) {
 			$query = $this->_parseQuery($query);


### PR DESCRIPTION
案件で発生
検索機能で、特定のブログの記事を検索する際に、
ブログのカテゴリで絞り込む機能はあるが、
ブログコンテンツで絞り込む機能が無いので追加したい。

lib/Baser/Controller/SearchIndicesController.php
185〜186行目付近　$data['SearchIndex']['f']　でコンテンツIDを指定して検索する箇所

```
$conditions['SearchIndex.rght <'] = $content['Content']['rght'];
$conditions['SearchIndex.lft >'] = $content['Content']['lft'];

```
こちらだと、該当するコンテンツの内容は検索結果に含まれないため
```
$conditions['SearchIndex.rght <='] = $content['Content']['rght'];
$conditions['SearchIndex.lft >='] = $content['Content']['lft'];

```
こうすることで、該当するコンテンツの内容も検索結果に含める。
※現時点で、コンテンツフォルダは検索結果に含まれないため、既存のコンテンツフォルダ内のページ検索結果は変わらない。