### PR TITLE
fix #22754

### DIFF
--- a/lib/Baser/Plugin/Blog/Controller/BlogPostsController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogPostsController.php
@@ -343,6 +343,7 @@ class BlogPostsController extends BlogAppController {
 		}
 		$this->crumbs[] = ['name' => sprintf(__d('baser', '%s 記事一覧'), $this->request->params['Content']['title']), 'url' => ['controller' => 'blog_posts', 'action' => 'index', $blogContentId]];
 		$this->set('hasNewCategoryAddablePermission', $this->BlogPost->BlogCategory->hasNewCategoryAddablePermission($user['user_group_id'], $blogContentId));
+		$this->set('hasNewTagAddablePermission', $this->BlogPost->BlogTag->hasNewTagAddablePermission($user['user_group_id'], $blogContentId));
 		$this->set('editable', true);
 		$this->set('categories', $categories);
 		$this->set('previewId', 'add_' . mt_rand(0, 99999999));
@@ -439,6 +440,7 @@ class BlogPostsController extends BlogAppController {
 
 		$this->crumbs[] = ['name' => sprintf(__d('baser', '%s 記事一覧'), $this->request->params['Content']['title']), 'url' => ['controller' => 'blog_posts', 'action' => 'index', $blogContentId]];
 		$this->set('hasNewCategoryAddablePermission', $this->BlogPost->BlogCategory->hasNewCategoryAddablePermission($user['user_group_id'], $blogContentId));
+		$this->set('hasNewTagAddablePermission', $this->BlogPost->BlogTag->hasNewTagAddablePermission($user['user_group_id'], $blogContentId));
 		$this->set('categories', $categories);
 		$this->set('previewId', $this->request->data['BlogPost']['id']);
 		$this->set('users', $this->BlogPost->User->getUserList());

--- a/lib/Baser/Plugin/Blog/Model/BlogTag.php
+++ b/lib/Baser/Plugin/Blog/Model/BlogTag.php
@@ -163,4 +163,21 @@ class BlogTag extends BlogAppModel {
 		return $results;
 	}
 
+/**
+ * アクセス制限としてブログの新規追加ができるか確認する
+ * 
+ * Ajaxを利用する箇所にて BcBaserHelper::link() が利用できない場合に利用
+ * 
+ * @param int $userGroupId ユーザーグループID
+ * @param int $blogContentId ブログコンテンツID
+ */
+	public function hasNewTagAddablePermission($userGroupId, $blogContentId) {
+		if (ClassRegistry::isKeySet('Permission')) {
+			$Permission = ClassRegistry::getObject('Permission');
+		} else {
+			$Permission = ClassRegistry::init('Permission');
+		}
+		$ajaxAddUrl = preg_replace('|^/index.php|', '', Router::url(['plugin' => 'blog', 'controller' => 'blog_tags', 'action' => 'ajax_add', $blogContentId]));
+		return $Permission->check($ajaxAddUrl, $userGroupId);
+	}
 }

--- a/lib/Baser/Plugin/Blog/Model/BlogTag.php
+++ b/lib/Baser/Plugin/Blog/Model/BlogTag.php
@@ -164,7 +164,7 @@ class BlogTag extends BlogAppModel {
 	}
 
 /**
- * アクセス制限としてブログの新規追加ができるか確認する
+ * アクセス制限としてブログタグの新規追加ができるか確認する
  * 
  * Ajaxを利用する箇所にて BcBaserHelper::link() が利用できない場合に利用
  * 

--- a/lib/Baser/Plugin/Blog/View/BlogPosts/admin/form.php
+++ b/lib/Baser/Plugin/Blog/View/BlogPosts/admin/form.php
@@ -142,9 +142,11 @@ $this->BcBaser->js('Blog.admin/blog_posts/form', false, [
 					<?php echo $this->BcForm->input('BlogTag.BlogTag', ['type' => 'select', 'multiple' => 'checkbox', 'options' => $this->BcForm->getControlSource('BlogPost.blog_tag_id')]); ?>
 				</div>
 				<?php echo $this->BcForm->error('BlogTag.BlogTag') ?>
-				<?php echo $this->BcForm->input('BlogTag.name', ['type' => 'text']) ?>
-				<?php echo $this->BcForm->button(__d('baser', '新しいタグを追加'), ['id' => 'BtnAddBlogTag']) ?>
-				<?php $this->BcBaser->img('admin/ajax-loader-s.gif', ['style' => 'vertical-align:middle;display:none', 'id' => 'TagLoader', 'class' => 'loader']) ?>
+				<?php if($hasNewTagAddablePermission): ?>
+					<?php echo $this->BcForm->input('BlogTag.name', ['type' => 'text']) ?>
+					<?php echo $this->BcForm->button(__d('baser', '新しいタグを追加'), ['id' => 'BtnAddBlogTag']) ?>
+					<?php $this->BcBaser->img('admin/ajax-loader-s.gif', ['style' => 'vertical-align:middle;display:none', 'id' => 'TagLoader', 'class' => 'loader']) ?>
+				<?php endif; ?>
 			</td>
 		</tr>
 		<?php endif ?>


### PR DESCRIPTION
ブログタグの追加が許可されてない場合でも記事編集画面にタグ追加ボタンが表示される不具合修正
こちらご確認いただけますと幸いです。
http://project.e-catchup.jp/issues/22754