### PR TITLE
アップローダープラグインで、アップしたファイルがフォルダから消えない問題を修正

### DIFF
--- a/lib/Baser/Plugin/Uploader/Model/UploaderFile.php
+++ b/lib/Baser/Plugin/Uploader/Model/UploaderFile.php
@@ -230,7 +230,7 @@ class UploaderFile extends AppModel {
 		if(!empty($data['UploaderFile']['publish_begin']) || !empty($data['UploaderFile']['publish_end'])) {
 			$this->Behaviors->BcUpload->savePath['UploaderFile'] .= 'limited' . DS;
 		} else {
-			$this->Behaviors->BcUpload->savePath['UploaderFile'] = preg_replace('/' . preg_quote('limited' . DS, '/') . '$/', '', $this->Behaviors->BcUpload->savePath);
+			$this->Behaviors->BcUpload->savePath['UploaderFile'] = preg_replace('/' . preg_quote('limited' . DS, '/') . '$/', '', $this->Behaviors->BcUpload->savePath['UploaderFile']);
 		}
 		return parent::beforeDelete($cascade);
 	}


### PR DESCRIPTION
アップローダープラグインで、ファイル削除に失敗していたので修正しています。
公開期間を設定していない場合にのみ発生していました。

ご確認よろしくお願いします。

http://project.e-catchup.jp/issues/22756