### PR TITLE
新元号の合字に対応

### DIFF
--- a/lib/Baser/Model/BcAppModel.php
+++ b/lib/Baser/Model/BcAppModel.php
@@ -255,6 +255,7 @@ class BcAppModel extends Model {
 			"\xE3\x8F\x8D" => "K.K.",
 			"\xE2\x84\xA1" => "TEL",
 			"\xE2\x84\x96" => "No.",
+			"\xE3\x8B\xBF" => "令和",
 			"\xE3\x8D\xBB" => "平成",
 			"\xE3\x8D\xBC" => "昭和",
 			"\xE3\x8D\xBD" => "大正",

--- a/lib/Baser/Plugin/Mail/Model/MailMessage.php
+++ b/lib/Baser/Plugin/Mail/Model/MailMessage.php
@@ -593,6 +593,7 @@ class MailMessage extends MailAppModel {
 			"\xE3\x8F\x8D" => "K.K.",
 			"\xE2\x84\xA1" => "TEL",
 			"\xE2\x84\x96" => "No.",
+			"\xE3\x8B\xBF" => "令和",
 			"\xE3\x8D\xBB" => "平成",
 			"\xE3\x8D\xBC" => "昭和",
 			"\xE3\x8D\xBD" => "大正",


### PR DESCRIPTION
機種依存文字の変換テーブルに「令和」を追加しました。レビューお願いいたします。

関連ドキュメント
[The Unicode Blog: New Japanese Era](http://blog.unicode.org/2018/09/new-japanese-era.html)