### PR TITLE
fix #22777 BlogHelper getPostImg()にもURLを出力する機能を追加したい問題を解決

### DIFF
--- a/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
+++ b/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
@@ -803,6 +803,7 @@ class BlogHelper extends AppHelper {
  *	- `num` : 何枚目の画像か順番を指定（初期値 : 1）
  *	- `link` : 詳細ページへのリンクをつけるかどうか（初期値 : true）
  *	- `alt` : ALT属性（初期値 : ブログ記事のタイトル）
+ *	- `output` : 出力形式 tag, url のを指定できる（初期値 : ''）
  * @return string
  */
 	public function getPostImg($post, $options = []) {
@@ -810,12 +811,15 @@ class BlogHelper extends AppHelper {
 		$options = array_merge($_options = [
 			'num' => 1,
 			'link' => true,
-			'alt' => $post['BlogPost']['name']
+			'alt' => $post['BlogPost']['name'],
+			'output' => '', // 出力形式 tag or url
 			], $options);
 		$num = $options['num'];
 		$link = $options['link'];
+		$output = $options['output'];
 		unset($options['num']);
 		unset($options['link']);
+		unset($options['output']);
 
 		$contents = $post['BlogPost']['content'] . $post['BlogPost']['detail'];
 		$pattern = '/<img.*?src="([^"]+)"[^>]*>/is';
@@ -826,6 +830,9 @@ class BlogHelper extends AppHelper {
 		if (isset($matches[1][$num - 1])) {
 			$url = $matches[1][$num - 1];
 			$url = preg_replace('/^' . preg_quote($this->base, '/') . '/', '', $url);
+			if ($output == 'url') {
+				return $url; // 出力形式 が urlなら、URLを返す
+			}
 			$img = $this->BcBaser->getImg($url, $options);
 			if ($link) {
 				return $this->BcBaser->getLink($img, $this->request->params['Content']['url'] . 'archives/' . $post['BlogPost']['no']);


### PR DESCRIPTION
既に取得しているURLをgetImg()の前にリターンさせるようにしています。
linkがtrueの場合でも、outputにURLを指定すれば、outputが優先されます。