### PR TITLE
ログイン時はキャッシュしないようにHTTPヘッダを挿入する

### DIFF
--- a/lib/Baser/Controller/BcAppController.php
+++ b/lib/Baser/Controller/BcAppController.php
@@ -341,14 +341,6 @@ class BcAppController extends Controller {
 			return;
 		}
 
-		// Ajax ヘッダー
-		if ($this->request->is('ajax')) {
-			// キャッシュ対策
-			header("Cache-Control: no-cache, must-revalidate");
-			header("Cache-Control: post-check=0, pre-check=0", false);
-			header("Pragma: no-cache");
-		}
-
 		// テーマ内プラグインのテンプレートをテーマに梱包できるようにプラグインパスにテーマのパスを追加
 		// ===============================================================================
 		// 実際には、プラグインの場合も下記パスがテンプレートの検索対象となっている為不要だが、
@@ -425,14 +417,14 @@ class BcAppController extends Controller {
 					}
 				}
 			}
+		}
 
-			// ログイン時のキャッシュ対策
-			if ($user) {
-				$this->response->header([
-					'Cache-Control' => 'no-cache, must-revalidate, post-check=0, pre-check=0',
-					'Pragma'        => 'no-cache',
-				]);
-			}
+		if ($this->request->is('ajax') || isset($this->BcAuth) && $this->BcAuth->user()) {
+			// キャッシュ対策
+			$this->response->header([
+				'Cache-Control' => 'no-cache, must-revalidate, post-check=0, pre-check=0',
+				'Pragma'        => 'no-cache',
+			]);
 		}
 
 		if($isRequestView) {

--- a/lib/Baser/Controller/BcAppController.php
+++ b/lib/Baser/Controller/BcAppController.php
@@ -425,6 +425,14 @@ class BcAppController extends Controller {
 					}
 				}
 			}
+
+			// ログイン時のキャッシュ対策
+			if ($user) {
+				$this->response->header([
+					'Cache-Control' => 'no-cache, must-revalidate, post-check=0, pre-check=0',
+					'Pragma'        => 'no-cache',
+				]);
+			}
 		}
 
 		if($isRequestView) {


### PR DESCRIPTION
### 本Pull-reqについて
この Pull-req では、BaserCMS の前段に Nginx のリバースプロキシを経由させる構成で、[ngx_http_proxy_module](http://nginx.org/en/docs/http/ngx_http_proxy_module.html]) を使ったキャッシュを実装した場合の、ログイン状態の時のキャッシュコントロールを実装します。

BaserCMS の管理画面は `/admin` から始まるため、URIベースの判定でキャッシュのコントロールが可能です。しかし、ログイン後のトップページや記事の参照時は、プロキシのレイヤでは未ログイン状態との判別が付かず Nginx の設定ベースによるキャッシュのコントロールができませんでした。

これによって、ログインしていない第三者がトップページ等を閲覧した際に、ログイン時に表示されるツールバーが表示されてしまいます。

そのため、ログイン状態では `Cache-Control` 等のHTTPヘッダを挿入することでこの課題を解決いたします。

HTTPヘッダの挿入内容については、  [`ajax` 時のキャッシュコントロール](https://github.com/baserproject/basercms/blob/dev-4/lib/Baser/Controller/BcAppController.php#L344-L350) と合わせています。

### 動作確認内容

ログイン時は以下のように、HTTPヘッダが挿入されます。

![image](https://user-images.githubusercontent.com/10905048/58535642-72096880-8229-11e9-959d-d9901efbb43e.png)

未ログイン時は、通常動作と変更ありません。

ご確認のほど、よろしくお願いいたします。
