### PR TITLE
baserの実際のバージョンとDBのバージョン値が異なる場合にログを記録する

### DIFF
--- a/lib/Baser/Config/bootstrap.php
+++ b/lib/Baser/Config/bootstrap.php
@@ -287,6 +287,7 @@ if (BC_INSTALLED) {
 		$isUpdater = true;
 	} elseif (BC_INSTALLED && !$isMaintenance && (!empty($bcSite['version']) && (getVersion() > $bcSite['version']))) {
 		if(!isConsole()) {
+			CakeLog::write(LOG_ERR, 'プログラムとデータベースのバージョンが異なります。');
 			header('Location: ' . topLevelUrl(false) . baseUrl() . 'maintenance/index');
 			exit();
 		} else {


### PR DESCRIPTION
現在、baserの実際のバージョンとDBのバージョン値が異なる場合に、メンテナンス画面が表示されます。

その際、メンテナンス画面が表示された原因がどこにも記録されないので、エラーメッセージをログに出力するよう変更しています。

取り込んでいただけるとデバッグ時に大変助かりますのでよろしくお願いします。