### PR TITLE
ブログ編集画面でアイキャッチのファイルの選択と削除を同時に行おうとするとエラーが発生する問題を修正

### DIFF
--- a/lib/Baser/Model/Behavior/BcUploadBehavior.php
+++ b/lib/Baser/Model/Behavior/BcUploadBehavior.php
@@ -340,6 +340,13 @@ class BcUploadBehavior extends ModelBehavior {
 		$options = array_merge([
 			'deleteTmpFiles' => true
 		], $options);
+
+		if (empty($requestData[$Model->name][$fieldSetting['name']])
+			|| !is_array($requestData[$Model->name][$fieldSetting['name']])
+		) {
+			return $requestData;
+		}
+
 		if(!$this->tmpId && empty($fieldSetting['upload'])) {
 			if(!empty($requestData[$Model->name][$fieldSetting['name']]) && is_array($requestData[$Model->name][$fieldSetting['name']])) {
 				unset($requestData[$Model->name][$fieldSetting['name']]);


### PR DESCRIPTION
ブログ編集画面でアイキャッチのファイルの選択と削除を同時に行おうとするとエラーが発生するため、修正しています。

ご確認をよろしくお願いします。

エラー

```
Warning (2): Illegal string offset 'name' [CORE/Baser/Model/Behavior/BcUploadBehavior.php, line 351]
Notice (8): Uninitialized string offset: 0 [CORE/Baser/Model/Behavior/BcUploadBehavior.php, line 351]
Notice (8): Undefined index: extension [CORE/Baser/Model/Behavior/BcUploadBehavior.php, line 946]
Notice (8): Array to string conversion [CORE/Baser/Model/Datasource/DboSource.php, line 2233]
エラー: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'Array' in 'field list'
```