### PR TITLE
jQuery3系にした場合、blog_comments_scripts.jsでエラーが起き、画像認証が表示されない問題を修正

### DIFF
--- a/lib/Baser/Plugin/Blog/webroot/js/blog_comments_scripts.js
+++ b/lib/Baser/Plugin/Blog/webroot/js/blog_comments_scripts.js
@@ -112,7 +112,7 @@ function loadAuthCaptcha() {
 		var src = $("#BlogCommentCaptchaUrl").html() + '?' + captchaId;
 		$("#AuthCaptchaImage").hide();
 		$("#CaptchaLoader").show();
-		$("#AuthCaptchaImage").load(function() {
+		$("#AuthCaptchaImage").on('load',function() {
 			$("#CaptchaLoader").hide();
 			$("#AuthCaptchaImage").fadeIn(1000);
 		});


### PR DESCRIPTION
フォーラムから不都合報告を頂きました。
https://forum.basercms.net/t/topic/109

jquery3系を使用した場合に、ブログをコメントする際の画像認証が表示されない問題を修正しています。
ご確認をよろしくお願いします。

確認バージョン: 4.2.1-dev