### PR TITLE
Fix #1203 :  BcBaserHelper::getDescription() がトップページでサイト基本説明文を取得できない問題を修正

### DIFF
--- a/lib/Baser/View/Helper/BcBaserHelper.php
+++ b/lib/Baser/View/Helper/BcBaserHelper.php
@@ -223,7 +223,7 @@ class BcBaserHelper extends AppHelper {
 			return $description;
 		}
 
-		if (!empty($this->request->params['Content']['site_root'])) {
+		if ($this->isHome()) {
 
 			if (!empty($this->request->params['Site']['description'])) {
 				return $this->request->params['Site']['description'];


### PR DESCRIPTION
fixes #1203

BcBaserHelper::getDescription() がトップページでサイト基本説明文を取得できない問題を修正しました。

`$this->request->params['Content']['site_root']` ではなく `isHome()` を利用してトップページかどうか判定するように変更しました。

ご確認よろしくお願いします。