### PR TITLE
fix #1208 MailPluginのファイルアップロードサイズvalidationメッセージ修正

### DIFF
--- a/lib/Baser/Plugin/Mail/Model/MailMessage.php
+++ b/lib/Baser/Plugin/Mail/Model/MailMessage.php
@@ -231,6 +231,7 @@ class MailMessage extends MailAppModel {
 						case 'VALID_MAX_FILE_SIZE':
 							if (!empty($options['maxFileSize']) && $this->data['MailMessage'][$mailField['field_name']]['error'] !== UPLOAD_ERR_NO_FILE) {
 								switch ($this->data['MailMessage'][$mailField['field_name']]['error']) {
+									case UPLOAD_ERR_OK:
 									case UPLOAD_ERR_INI_SIZE:
 									case UPLOAD_ERR_FORM_SIZE:
 										$errorMessage = __('ファイルサイズがオーバーしています。 %s MB以内のファイルをご利用ください。',


### PR DESCRIPTION
・ファイルアップロードフィールドを利用
・PHPの設定値においてアップロード可能
・メールプラグインのファイルアップロードサイズを制限 [maxFileSize]
・ブラウザがMAX_FILE_SIZEを無視

サーバ上にファイルがアップロードされるがMAX_FILE_SIZEのエラーを取得できないため、システムエラーと判別。

