### PR TITLE
ログインフォームに文字を入力しても背景の文字が消えない問題を修正

### DIFF
--- a/lib/Baser/View/Users/admin/login.php
+++ b/lib/Baser/View/Users/admin/login.php
@@ -37,12 +37,10 @@ $this->BcBaser->js('admin/users/login', false);
 		<div id="AlertMessage" class="message" style="display:none"></div>
 		<?php echo $this->BcForm->create($userModel, ['url' => ['action' => 'login']]) ?>
 		<div class="float-left login-input">
-			<?php echo $this->BcForm->label($userModel . '.name', __d('baser', 'アカウント名')) ?>
-			<?php echo $this->BcForm->input($userModel . '.name', ['type' => 'text', 'size' => 16, 'tabindex' => 1, 'autofocus' => true]) ?>
+			<?php echo $this->BcForm->input($userModel . '.name', ['type' => 'text', 'size' => 16, 'tabindex' => 1, 'autofocus' => true, 'placeholder' => __d('baser', 'アカウント名')]) ?>
 		</div>
 		<div class="float-left login-input">
-			<?php echo $this->BcForm->label($userModel . '.password', __d('baser', 'パスワード')) ?>
-			<?php echo $this->BcForm->input($userModel . '.password', ['type' => 'password', 'size' => 16, 'tabindex' => 2]) ?>
+			<?php echo $this->BcForm->input($userModel . '.password', ['type' => 'password', 'size' => 16, 'tabindex' => 2, 'placeholder' => __d('baser', 'パスワード')]) ?>
 		</div>
 		<div class="float-left submit">
 			<?php echo $this->BcForm->submit(__d('baser', 'ログイン'), ['div' => false, 'class' => 'btn-red button', 'id' => 'BtnLogin', 'tabindex' => 4]) ?>

--- a/lib/Baser/webroot/css/admin/contents.css
+++ b/lib/Baser/webroot/css/admin/contents.css
@@ -1023,14 +1023,14 @@ background: #888;
 	margin-bottom: 5px;
 	margin-right:3px;
 }
-.login-input label {
-	position: absolute;
-	z-index: 1;
-	margin:2px;
-	padding:6px 10px;
-	color:#CCC;
-	font-size:16px;
-	cursor: text;
+.login-input input::placeholder {
+	color: #ccc;
+}
+.login-input input::-ms-input-placeholder {
+	color: #ccc;
+}
+.login-input input:-ms-input-placeholder {
+	color: #ccc;
 }
 #LoginInner .logo {
 	margin-bottom: 20px;

--- a/lib/Baser/webroot/js/admin/users/login.js
+++ b/lib/Baser/webroot/js/admin/users/login.js
@@ -7,14 +7,6 @@ $(function(){
 	changeNavi("#"+$("#UserModel").html()+"Name");
 	changeNavi("#"+$("#UserModel").html()+"Password");
 
-	$("#"+$("#UserModel").html()+"Name,#"+$("#UserModel").html()+"Password").bind('keyup', function(){
-		if($(this).val()) {
-			$(this).prev().hide();
-		} else {
-			$(this).prev().show();
-		}
-	});
-
 	$("#Login").click(function(){
 		changeView(false);
 	});


### PR DESCRIPTION
ログイン画面の「アカウント名」「パスワード」の部分に文字を入力しても背景の文字が消えないため修正しています。
今まで、login.js内の、キー入力時に背景の文字を消す処理が動いていましたが、ログイン画面のhtml構造の変更により、動作しない状態になっていました。

ただ、jsに処理を任せるよりもinput要素に対してplaceholder属性を設定したほうが処理が軽いのでそちらの処理に変更しています。
これにより、ブラウザによっては背景の文字が微妙に中央からずれる問題も解決しています。

ご確認をよろしくお願いします。
