### PR TITLE
fix メールプラグインのメールフィールド 編集画面で、「注意書き」「説明文」の使い方がわかりにくい問題を解決

### DIFF
--- a/lib/Baser/Plugin/Mail/View/MailFields/admin/form.php
+++ b/lib/Baser/Plugin/Mail/View/MailFields/admin/form.php
@@ -96,11 +96,16 @@ $this->BcBaser->js('Mail.admin/mail_fields/form', false);
 				<?php echo $this->BcForm->error('MailField.valid') ?>
 			</td>
 		</tr>
-		<tr id="RowAttention">
-			<th class="col-head"><?php echo $this->BcForm->label('MailField.attention', __d('baser', '注意書き')) ?></th>
+		<tr id="RowDescription">
+			<th class="col-head">
+				<?php echo $this->BcForm->label('MailField.description', __d('baser', '説明文')) ?>
+				<br><small>※ 送信しない前見出し</small>
+				<?php echo $this->BcHtml->image('admin/icn_help.png', array('id' => 'helpDescription', 'class' => 'btn help', 'alt' => __d('baser', 'ヘルプ'))) ?>
+				<div id="helptextDescription" class="helptext"> <?php echo __d('baser', '姓・名などメール本文に入れない内容を入力してください。')?> </div>
+			</th>
 			<td class="col-input">
-				<?php echo $this->BcForm->input('MailField.attention', array('type' => 'textarea', 'cols' => 35, 'rows' => 3)) ?>
-				<?php echo $this->BcForm->error('MailField.attention') ?>
+				<?php echo $this->BcForm->input('MailField.description', array('type' => 'textarea', 'cols' => 35, 'rows' => 3)) ?>
+				<?php echo $this->BcForm->error('MailField.description') ?>
 			</td>
 		</tr>
 		<tr id="RowBeforeAttachment">
@@ -117,11 +122,16 @@ $this->BcBaser->js('Mail.admin/mail_fields/form', false);
 				<?php echo $this->BcForm->error('MailField.after_attachment') ?>
 			</td>
 		</tr>
-		<tr id="RowDescription">
-			<th class="col-head"><?php echo $this->BcForm->label('MailField.description', __d('baser', '説明文')) ?></th>
+		<tr id="RowAttention">
+			<th class="col-head">
+				<?php echo $this->BcForm->label('MailField.attention', __d('baser', '注意書き')) ?>
+				<br><small>※ 送信しない後見出し</small>
+				<?php echo $this->BcHtml->image('admin/icn_help.png', array('id' => 'helpAttention', 'class' => 'btn help', 'alt' => __d('baser', 'ヘルプ'))) ?>
+				<div id="helptextAttention" class="helptext"> <?php echo __d('baser', '「確認のためもう一度入力してください」などメール本文に入れない内容を入力してください。')?> </div>
+			</th>
 			<td class="col-input">
-				<?php echo $this->BcForm->input('MailField.description', array('type' => 'textarea', 'cols' => 35, 'rows' => 3)) ?>
-				<?php echo $this->BcForm->error('MailField.description') ?>
+				<?php echo $this->BcForm->input('MailField.attention', array('type' => 'textarea', 'cols' => 35, 'rows' => 3)) ?>
+				<?php echo $this->BcForm->error('MailField.attention') ?>
 			</td>
 		</tr>
 		<tr id="RowSource">


### PR DESCRIPTION
・後方互換も考慮し、入力画面のUIの調整のみで完結

View側の出力順と同じになるように、入力側の「説明文」「注意書き」の順番を入れ替え、
明示的に項目の目的を追記

> 説明文	
> ※ 送信しない前見出し

> 注意書き	
> ※ 送信しない後見出し

 

詳細については、helpを使用