### PR TITLE
サイト基本設定・サブサイト設定のヘルプメッセージを調整

### DIFF
--- a/app/webroot/theme/admin-third/Elements/admin/sites/form.php
+++ b/app/webroot/theme/admin-third/Elements/admin/sites/form.php
@@ -79,7 +79,7 @@ $useSiteLangSetting = @$this->get('siteConfig')['use_site_lang_setting'];
 		<th class="bca-form-table__label"><?php echo $this->BcForm->label('Site.keyword', __d('baser', 'サイト基本キーワード')) ?></th>
 		<td class="bca-form-table__input"><?php echo $this->BcForm->input('Site.keyword', ['type' => 'text', 'size' => 55, 'maxlength' => 255, 'counter' => true, 'class' => 'bca-textbox__input full-width']) ?>
 			<i class="bca-icon--question-circle btn help bca-help"></i>
-			<div id="helptextKeyword" class="helptext"><?php echo __d('baser', 'テンプレートで利用する場合は、<br>&lt;?php $this->BcBaser->keywords() ?&gt; で出力します。')?></div>
+			<div id="helptextKeyword" class="helptext"><?php echo __d('baser', 'テンプレートで利用する場合は、<br>&lt;?php $this->BcBaser->metaKeywords() ?&gt; で出力します。')?></div>
 			<?php echo $this->BcForm->error('Site.keyword') ?>
 		</td>
 	</tr>
@@ -87,7 +87,7 @@ $useSiteLangSetting = @$this->get('siteConfig')['use_site_lang_setting'];
 		<th class="bca-form-table__label"><?php echo $this->BcForm->label('Site.description', __d('baser', 'サイト基本説明文')) ?></th>
 		<td class="bca-form-table__input"><?php echo $this->BcForm->input('Site.description', ['type' => 'textarea', 'cols' => 20, 'rows' => 6, 'maxlength' => 255, 'counter' => true]) ?>
 			<i class="bca-icon--question-circle btn help bca-help"></i>
-			<div id="helptextDescription" class="helptext"><?php echo __d('baser', 'テンプレートで利用する場合は、<br>&lt;?php $this->BcBaser->description() ?&gt; で出力します。')?></div>
+			<div id="helptextDescription" class="helptext"><?php echo __d('baser', 'テンプレートで利用する場合は、<br>&lt;?php $this->BcBaser->metaDescription() ?&gt; で出力します。')?></div>
 			<?php echo $this->BcForm->error('Site.description') ?>
 		</td>
 	</tr>

--- a/app/webroot/theme/admin-third/SiteConfigs/admin/form.php
+++ b/app/webroot/theme/admin-third/SiteConfigs/admin/form.php
@@ -71,7 +71,7 @@ $this->BcBaser->js('admin/site_configs/form', false, ['id' => 'AdminSiteConfigsF
       <td class="col-input bca-form-table__input"><?php echo $this->BcForm->input('SiteConfig.keyword', ['type' => 'text', 'size' => 55, 'maxlength' => 255, 'counter' => true]) ?>
         <i class="bca-icon--question-circle btn help bca-help"></i>
         <?php echo $this->BcForm->error('SiteConfig.keyword') ?>
-        <div id="helptextKeyword" class="helptext"><?php echo __d('baser', 'テンプレートで利用する場合は、<br />&lt;?php $this->BcBaser->keywords() ?&gt; で出力します。')?></div>
+        <div id="helptextKeyword" class="helptext"><?php echo __d('baser', 'テンプレートで利用する場合は、<br />&lt;?php $this->BcBaser->metaKeywords() ?&gt; で出力します。')?></div>
       </td>
     </tr>
     <tr>
@@ -79,7 +79,7 @@ $this->BcBaser->js('admin/site_configs/form', false, ['id' => 'AdminSiteConfigsF
       <td class="col-input bca-form-table__input"><?php echo $this->BcForm->input('SiteConfig.description', ['type' => 'textarea', 'cols' => 36, 'rows' => 5, 'counter' => true, 'data-input-text-size' => 'full-counter']) ?>
         <i class="bca-icon--question-circle btn help bca-help"></i>
         <?php echo $this->BcForm->error('SiteConfig.description') ?>
-        <div id="helptextDescription" class="helptext"><?php echo __d('baser', 'テンプレートで利用する場合は、<br />&lt;?php $this->BcBaser->description() ?&gt; で出力します')?></div>
+        <div id="helptextDescription" class="helptext"><?php echo __d('baser', 'テンプレートで利用する場合は、<br />&lt;?php $this->BcBaser->metaDescription() ?&gt; で出力します')?></div>
       </td>
     </tr>
     <tr>

--- a/lib/Baser/View/Elements/admin/sites/form.php
+++ b/lib/Baser/View/Elements/admin/sites/form.php
@@ -76,7 +76,7 @@ $useSiteLangSetting = @$this->get('siteConfig')['use_site_lang_setting'];
 		<td class="col-input"><?php echo $this->BcForm->input('Site.keyword', array('type' => 'text', 'size' => 55, 'maxlength' => 255, 'counter' => true, 'class' => 'full-width')) ?>
 			<?php echo $this->Html->image('admin/icn_help.png', array('id' => 'helpKeyword', 'class' => 'btn help', 'alt' => __d('baser', 'ヘルプ'))) ?>
 			<?php echo $this->BcForm->error('Site.keyword') ?>
-			<div id="helptextKeyword" class="helptext"><?php echo __d('baser', 'テンプレートで利用する場合は、<br />&lt;?php $this->BcBaser->keywords() ?&gt; で出力します。')?></div>
+			<div id="helptextKeyword" class="helptext"><?php echo __d('baser', 'テンプレートで利用する場合は、<br />&lt;?php $this->BcBaser->metaKeywords() ?&gt; で出力します。')?></div>
 		</td>
 	</tr>
 	<tr>
@@ -84,7 +84,7 @@ $useSiteLangSetting = @$this->get('siteConfig')['use_site_lang_setting'];
 		<td class="col-input"><?php echo $this->BcForm->input('Site.description', array('type' => 'textarea', 'cols' => 36, 'rows' => 5, 'counter' => true)) ?>
 			<?php echo $this->Html->image('admin/icn_help.png', array('id' => 'helpDescription', 'class' => 'btn help', 'alt' => __d('baser', 'ヘルプ'))) ?>
 			<?php echo $this->BcForm->error('Site.description') ?>
-			<div id="helptextDescription" class="helptext"><?php echo __d('baser', 'テンプレートで利用する場合は、<br />&lt;?php $this->BcBaser->description() ?&gt; で出力します。')?></div>
+			<div id="helptextDescription" class="helptext"><?php echo __d('baser', 'テンプレートで利用する場合は、<br />&lt;?php $this->BcBaser->metaDescription() ?&gt; で出力します。')?></div>
 		</td>
 	</tr>
 	<tr>

--- a/lib/Baser/View/SiteConfigs/admin/form.php
+++ b/lib/Baser/View/SiteConfigs/admin/form.php
@@ -73,7 +73,7 @@ $this->BcBaser->js('admin/site_configs/form', false, ['id' => 'AdminSiteConfigsF
 		<td class="col-input"><?php echo $this->BcForm->input('SiteConfig.keyword', ['type' => 'text', 'size' => 55, 'maxlength' => 255, 'counter' => true, 'class' => 'full-width']) ?>
 			<?php echo $this->Html->image('admin/icn_help.png', ['id' => 'helpKeyword', 'class' => 'btn help', 'alt' => __d('baser', 'ヘルプ')]) ?>
 			<?php echo $this->BcForm->error('SiteConfig.keyword') ?>
-			<div id="helptextKeyword" class="helptext"><?php echo __d('baser', 'テンプレートで利用する場合は、<br />&lt;?php $this->BcBaser->keywords() ?&gt; で出力します。')?></div>
+			<div id="helptextKeyword" class="helptext"><?php echo __d('baser', 'テンプレートで利用する場合は、<br />&lt;?php $this->BcBaser->metaKeywords() ?&gt; で出力します。')?></div>
 		</td>
 	</tr>
 	<tr>
@@ -81,7 +81,7 @@ $this->BcBaser->js('admin/site_configs/form', false, ['id' => 'AdminSiteConfigsF
 		<td class="col-input"><?php echo $this->BcForm->input('SiteConfig.description', ['type' => 'textarea', 'cols' => 36, 'rows' => 5, 'counter' => true]) ?>
 			<?php echo $this->Html->image('admin/icn_help.png', ['id' => 'helpDescription', 'class' => 'btn help', 'alt' => __d('baser', 'ヘルプ')]) ?>
 			<?php echo $this->BcForm->error('SiteConfig.description') ?>
-			<div id="helptextDescription" class="helptext"><?php echo __d('baser', 'テンプレートで利用する場合は、<br />&lt;?php $this->BcBaser->description() ?&gt; で出力します')?></div>
+			<div id="helptextDescription" class="helptext"><?php echo __d('baser', 'テンプレートで利用する場合は、<br />&lt;?php $this->BcBaser->metaDescription() ?&gt; で出力します')?></div>
 		</td>
 	</tr>
 	<tr>


### PR DESCRIPTION
管理画面のサイト基本設定・サブサイト設定の、「サイト基本キーワード」と「サイト基本キーワード」のヘルプメッセージが古かったため、更新しています。
ご確認をお願いします。

フォーラムから指摘がありました。
https://forum.basercms.net/t/topic/145

