### PR TITLE
admin-thirdテーマのcssを調整

### DIFF
--- a/app/webroot/theme/admin-third/css/admin/style.css
+++ b/app/webroot/theme/admin-third/css/admin/style.css
@@ -8767,8 +8767,6 @@ table.cake-sql-log tr td {
   margin-bottom: 10px; }
 
 .bca-file-list {
-  display: flex;
-  flex-wrap: wrap;
   background: #eeeeee;
   padding: 10px; }
   .bca-file-list__item {


### PR DESCRIPTION
以下のissueに対応しています。

■issue
[フォーラム]ブログの編集画面でアップローダーを開くと、画像が折り返されず、画面内に収まらない
https://github.com/baserproject/basercms/issues/1214

■問題
flex要素の親要素がtable要素だった場合にIEで起きる不都合のようです。
https://stackoverflow.com/questions/31022747/flexbox-ie11-flex-wrap-wrap-does-not-wrap-images-codepen-inside

■変更
display: flexの指定を解除しています。
ChromeとIE11で確認しましたが、特に表示の違いは発生しませんでした。