### PR TITLE
bc_sampleのmetaを追加

### DIFF
--- a/lib/Baser/Config/theme/bc_sample/Layouts/default.php
+++ b/lib/Baser/Config/theme/bc_sample/Layouts/default.php
@@ -9,6 +9,9 @@
 <head>
 	<?php $this->BcBaser->charset() ?>
 	<?php $this->BcBaser->title() ?>
+	<?php $this->BcBaser->metaDescription() ?>
+	<?php $this->BcBaser->metaKeywords() ?>
+	<?php $this->BcBaser->icon() ?>
 	<?php $this->BcBaser->css(array(
 		'style',
 		'jquery-ui/jquery-ui-1.11.4',


### PR DESCRIPTION
フォーラムからの要望です。
https://forum.basercms.net/t/topic/145/3

bc_sampleテーマに、metaのキーワードとページ説明文が出力されると、サンプルテーマとして便利でないかとのご意見です。

見てみるとスマホ版だと出力されていましたが、PC版には出力されていませんでしたので追加しています。

ご確認よろしくお願いします。