### PR TITLE
validation用のBcAppModel::fileCheckをアップロードされたか否かを除外

### DIFF
--- a/lib/Baser/Model/BcAppModel.php
+++ b/lib/Baser/Model/BcAppModel.php
@@ -805,44 +805,46 @@ class BcAppModel extends Model {
 			return true;
 		}
 
-
 		$fileErrorCode = Hash::get($file, 'error');
 		if ($fileErrorCode) {
 			// ファイルアップロード時のエラーメッセージを取得する
 			switch ($fileErrorCode) {
+				// アップロード成功
+				case 0:
+					// UPLOAD_ERR_OK
+					break;
 				case 1:
 					// UPLOAD_ERR_INI_SIZE
 					$this->log('CODE: ' . $fileErrorCode . ' アップロードされたファイルは、php.ini の upload_max_filesize ディレクティブの値を超えています。');
-					break;
+					return false;
 				case 2:
 					// UPLOAD_ERR_FORM_SIZE
 					$this->log('CODE: ' . $fileErrorCode . ' アップロードされたファイルは、HTMLで指定された MAX_FILE_SIZE を超えています。');
-					break;
+					return false;
 				case 3:
 					// UPLOAD_ERR_PARTIAL
 					$this->log('CODE: ' . $fileErrorCode . ' アップロードされたファイルが不完全です。');
-					break;
+					return false;
 				// アップロードされなかった場合の検証は必須チェックを仕様すること
-				// case 4:
-				// 	// UPLOAD_ERR_NO_FILE
-				// 	$this->log('CODE: ' . $fileErrorCode . ' ファイルがアップロードされませんでした。');
-				// 	break;
+				case 4:
+					// UPLOAD_ERR_NO_FILE
+					// 	$this->log('CODE: ' . $fileErrorCode . ' ファイルがアップロードされませんでした。');
+					break;
 				case 6:
 					// UPLOAD_ERR_NO_TMP_DIR
 					$this->log('CODE: ' . $fileErrorCode . ' 一時書込み用のフォルダがありません。テンポラリフォルダの書込み権限を見直してください。');
-					break;
+					return false;
 				case 7:
 					// UPLOAD_ERR_CANT_WRITE
 					$this->log('CODE: ' . $fileErrorCode . ' ディスクへの書き込みに失敗しました。');
-					break;
+					return false;
 				case 8:
 					// UPLOAD_ERR_EXTENSION
 					$this->log('CODE: ' . $fileErrorCode . ' PHPの拡張モジュールがファイルのアップロードを中止しました。');
-					break;
+					return false;
 				default:
 					break;
 			}
-			return false;
 		}
 
 		if (!empty($file['name'])) {

--- a/lib/Baser/Plugin/Mail/Model/MailMessage.php
+++ b/lib/Baser/Plugin/Mail/Model/MailMessage.php
@@ -229,7 +229,9 @@ class MailMessage extends MailAppModel {
 					$options = call_user_func_array('aa', $options);
 					switch ($valid) {
 						case 'VALID_MAX_FILE_SIZE':
-							if (!empty($options['maxFileSize']) && $this->data['MailMessage'][$mailField['field_name']]['error'] !== UPLOAD_ERR_NO_FILE) {
+							if (!empty($options['maxFileSize']) &&
+								(isset($this->data['MailMessage'][$mailField['field_name']]['error']) &&
+								$this->data['MailMessage'][$mailField['field_name']]['error'] !== UPLOAD_ERR_NO_FILE)) {
 								switch ($this->data['MailMessage'][$mailField['field_name']]['error']) {
 									case UPLOAD_ERR_OK:
 									case UPLOAD_ERR_INI_SIZE:

--- a/lib/Baser/Test/Case/Model/BcAppTest.php
+++ b/lib/Baser/Test/Case/Model/BcAppTest.php
@@ -533,24 +533,28 @@ class BcAppTest extends BaserTestCase {
  * @param boolean $expect
  * @dataProvider fileCheckDataProvider
  */
-	public function testFileCheck($fileName, $fileSize, $expect) {
+	public function testFileCheck($fileName, $fileSize, $errorCode, $expect) {
 		$check = [[
 				"name" => $fileName,
 				"size" => $fileSize,
+				"error" => $errorCode,
 			]
 		];
 		$size = 1000;
 
+		$_POST = ['fileCheck require $_POST' => true];
 		$result = $this->BcApp->fileCheck($check, $size);
 		$this->assertEquals($expect, $result);		
 	}
 
 	public function fileCheckDataProvider() {
 		return [
-			["test.jpg", 1000, true],
-			["test.jpg", 1001, false],
-			["", 1000, true],
-			["test.jpg", null, false],
+			["test.jpg", 1000, 0, true],
+			["test.jpg", 1001, 0, false], // filecheck制限オーバー
+			["", 1000, 0, true], // ファイル名なし
+			[null, null, 1, false], // upload_max_filesizeオーバー
+			["test.jpg", null, 2, false], // HTMLのMAX_FILE_SIZEオーバー
+			[null, null, 4, true], // ファイルアップロードなし
 		];
 	}
 


### PR DESCRIPTION
・必須チェックで検証することとファイルサイズは個別にと判断して変更しています。
・フォームのinput[type=file]をjQueryで$(target).val("")してクリアするとIE11にて検証自体が落ちる問題の修正になります。
・post_max_sizeの検証を追加しています。