### PR TITLE
ページ名を変更した際、メッセージに以前のURLが表示される問題を改善

### DIFF
--- a/lib/Baser/Controller/PagesController.php
+++ b/lib/Baser/Controller/PagesController.php
@@ -150,7 +150,7 @@ class PagesController extends AppController {
 				}
 
 				// 完了メッセージ
-				$this->setMessage(sprintf(__d('baser', "固定ページ「%s」を更新しました。\n%s"), $this->request->data['Content']['name'], urldecode($this->request->data['Content']['url'])), false, true);
+				$this->setMessage(sprintf(__d('baser', "固定ページ「%s」を更新しました。\n%s"), $data['Content']['name'], urldecode($data['Content']['url'])), false, true);
 
 				// EVENT Pages.afterEdit
 				$this->dispatchEvent('afterEdit', [


### PR DESCRIPTION
固定ページ編集画面でnameを変更した際、メッセージに変更前のnameをもとにしたURLが表示されるので修正しました。

ご確認よろしくお願いします。