### PR TITLE
fix #1043 受信メールで１行の文字数が多い時、文字化けが発生の改善

### DIFF
--- a/lib/Cake/Network/Email/CakeEmail.php
+++ b/lib/Cake/Network/Email/CakeEmail.php
@@ -1393,10 +1393,18 @@ class CakeEmail {
 				continue;
 			}
 			if (!preg_match('/<[a-z]+.*>/i', $line)) {
+				// >>> CUSTOMIZE MODIFY 2019/09/26 gondoh
+				// マルチバイトの改行が文字化けする問題の改善
+				// $formatted = array_merge(
+				// 	$formatted,
+				// 	explode("\n", wordwrap($line, $wrapLength, "\n", $cut))
+				// );
+				// ---
 				$formatted = array_merge(
 					$formatted,
-					explode("\n", wordwrap($line, $wrapLength, "\n", $cut))
+					explode("\n", CakeText::wordwrap($line, $wrapLength, "\n", $cut))
 				);
+				// <<<
 				continue;
 			}
 
@@ -1414,10 +1422,17 @@ class CakeEmail {
 							$tmpLineLength += $tagLength;
 						} else {
 							if ($tmpLineLength > 0) {
+								// >>> CUSTOMIZE MODIFY 2019/09/26 gondoh
+								// $formatted = array_merge(
+								// 	$formatted,
+								// 	explode("\n", wordwrap(trim($tmpLine), $wrapLength, "\n", $cut))
+								// );
+								// ---
 								$formatted = array_merge(
 									$formatted,
-									explode("\n", wordwrap(trim($tmpLine), $wrapLength, "\n", $cut))
+									explode("\n", CakeText::wordwrap(trim($tmpLine), $wrapLength, "\n", $cut))
 								);
+								// <<<
 								$tmpLine = '';
 								$tmpLineLength = 0;
 							}


### PR DESCRIPTION
CakePHP3系では対応済み
https://github.com/cakephp/cakephp/commit/8099090c919e77bd6fc80958f4d2e765f7c41e69

よろしくおねがいします。