### PR TITLE
BcAuthPrefixのuserModelにプラグインのモデルを設定している場合、クッキーを使用した自動ログイン機能が動作しな…

### DIFF
--- a/lib/Baser/Controller/Component/BcAuthConfigureComponent.php
+++ b/lib/Baser/Controller/Component/BcAuthConfigureComponent.php
@@ -165,14 +165,15 @@ class BcAuthConfigureComponent extends Component {
 				// ===================================================================================
 				if (!empty($cookie) && $cookie != 'deleted') {					
 					if(is_array($cookie)) {
-						if(!empty($Controller->request->data[$config['userModel']])) {
-							$requestData = $Controller->request->data[$config['userModel']];	
+						list($plugin, $userModel) = pluginSplit($config['userModel']);
+						if(!empty($Controller->request->data[$userModel])) {
+							$requestData = $Controller->request->data[$userModel];
 						}
-						$Controller->request->data[$config['userModel']] = $cookie;
+						$Controller->request->data[$userModel] = $cookie;
 						$loginResult = $BcAuth->login();
-						unset($Controller->request->data[$config['userModel']]);
+						unset($Controller->request->data[$userModel]);
 						if(!empty($requestData)) {
-							$Controller->request->data[$config['userModel']] = $requestData;
+							$Controller->request->data[$userModel] = $requestData;
 						}
 						if ($loginResult) {
 							return true;


### PR DESCRIPTION
…い問題を改善

以下のような設定を行っている場合に、クッキーによる自動ログイン機能が動作しない問題を修正しました。
ご確認よろしくお願いします。

```
$config['BcAuthPrefix'] = [
	'mypage' => [
		'loginRedirect' => '/mypage/',
		'userModel' => 'PluginName.ModelName',
		'loginAction' => '/login/',
		'username' => 'email',
		'toolbar' => false,
	],
];
```