### PR TITLE
管理画面自動ログイン用のCookieにhttpOnly属性を設定

### DIFF
--- a/lib/Baser/Controller/UsersController.php
+++ b/lib/Baser/Controller/UsersController.php
@@ -229,6 +229,7 @@ class UsersController extends AppController {
 				$cookie[$key] = $val;
 			}
 		}
+		$this->Cookie->httpOnly = true;
 		$this->Cookie->write(Inflector::camelize(str_replace('.', '', BcAuthComponent::$sessionKey)), $cookie, true, '+2 weeks');	// 3つめの'true'で暗号化
 	}
 


### PR DESCRIPTION
管理画面自動ログイン用のCookieにhttpOnly属性を設定しています。

JSから該当cookieにアクセス出来なくなるため、セキュリティが向上します。

ご確認よろしくお願いします。