### PR TITLE
fix #1095 メールプラグインのメールフィールド編集にパスワードタイプ追加

### DIFF
--- a/lib/Baser/Plugin/Mail/Model/MailField.php
+++ b/lib/Baser/Plugin/Mail/Model/MailField.php
@@ -93,6 +93,7 @@ class MailField extends MailAppModel {
 			'date_time_wareki'	=> __d('baser', '和暦日付'),
 			'date_time_calender'=> __d('baser', 'カレンダー'),
 			'tel'				=> __d('baser', '電話番号'),
+			'password'			=> __d('baser', 'パスワード'),
 			'hidden'			=> __d('baser', '隠しフィールド')
 		];
 		$source['valid'] = [

--- a/lib/Baser/Plugin/Mail/Model/MailMessage.php
+++ b/lib/Baser/Plugin/Mail/Model/MailMessage.php
@@ -504,9 +504,9 @@ class MailMessage extends MailAppModel {
  * @return array $dbDatas
  */
 	public function convertToDb($dbData) {
-		// マルチチェックのデータを｜区切りに変換
 		foreach ($this->mailFields as $mailField) {
 			$mailField = $mailField['MailField'];
+			// マルチチェックのデータを｜区切りに変換
 			if ($mailField['type'] == 'multi_check' && $mailField['use_field']) {
 				if (!empty($dbData['MailMessage'][$mailField['field_name']])) {
 					if (is_array($dbData['MailMessage'][$mailField['field_name']])) {
@@ -514,6 +514,13 @@ class MailMessage extends MailAppModel {
 					} else {
 						$dbData['MailMessage'][$mailField['field_name']] = $dbData['MailMessage'][$mailField['field_name']];
 					}
+				}
+			}
+			// パスワードのデータをハッシュ化
+			if ($mailField['type'] == 'password') {
+				if (!empty($dbData['MailMessage'][$mailField['field_name']])) {
+					App::uses('AuthComponent', 'Controller/Component');
+					$dbData['MailMessage'][$mailField['field_name']] = AuthComponent::password($dbData['MailMessage'][$mailField['field_name']]);
 				}
 			}
 		}

--- a/lib/Baser/Plugin/Mail/View/Helper/MailformHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MailformHelper.php
@@ -214,7 +214,14 @@ class MailformHelper extends BcFreezeHelper {
 				$attributes['type'] = 'tel';
 				$out = $this->tel($fieldName, $attributes);
 				break;
-				
+
+			case 'password':
+				unset($attributes['separator']);
+				unset($attributes['rows']);
+				unset($attributes['empty']);
+				$out = $this->password($fieldName, $attributes);
+				break;
+
 			case 'hidden':
 				unset($attributes['separator']);
 				unset($attributes['rows']);

--- a/lib/Baser/View/Helper/BcFreezeHelper.php
+++ b/lib/Baser/View/Helper/BcFreezeHelper.php
@@ -470,6 +470,36 @@ class BcFreezeHelper extends BcFormHelper {
 	}
 
 /**
+ * パスワードボックスを表示する
+ * 
+ * @param string $fieldName フィールド文字列
+ * @param array $attributes html属性
+ * - 凍結時に、valueはマスクして表示する。
+ * @return	string	htmlタグ
+ * @access	public
+ */
+	public function password($fieldName, $attributes = []) {
+
+		if ($this->freezed) {
+			list($model, $field) = explode('.', $fieldName);
+			if (isset($attributes)) {
+				$attributes = $attributes + ['type' => 'hidden'];
+			} else {
+				$attributes = ['type' => 'hidden'];
+			}
+			if (isset($attributes["value"])) {
+				$value = $attributes["value"];
+			} else {
+				$value = $this->request->data[$model][$field];
+			}
+			$value = preg_replace('/./', '*', $value);
+			return parent::password($fieldName, $attributes) . h($value);
+		} else {
+			return parent::password($fieldName, $attributes);
+		}
+	}
+
+/**
  * JsonList
  * TODO 確認画面用の実装は全くしてない
  * 


### PR DESCRIPTION
下記の処理を追加いたしました。

1. 管理画面メールフィールド編集のタイプ項目にパスワード追加
2. フォーム凍結時にパスワードタイプのvalueをマスク表示
3. `convertToDb()` にてデータベース用のパスワードタイプのデータをハッシュ化
4. `_sendMail()` にてメール送信用のパスワードタイプのデータをマスク表示

ご確認よろしくお願いいたします！