### PR TITLE
#1255 コンテンツ名「blog」を作成しない状態で http://{baserCMSの設置URL}/blog/ にアクセスすると内部…

### DIFF
--- a/lib/Baser/Plugin/Blog/Controller/BlogController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogController.php
@@ -123,6 +123,10 @@ class BlogController extends BlogAppController {
 			}
 		}
 
+		if (!$blogContentId) {
+			$this->notFound();
+		}
+
 		if(empty($this->request->params['Content'])) {
 			// ウィジェット系の際にコンテンツ管理上のURLでないので自動取得できない
 			$content = $this->BcContents->getContent($blogContentId);


### PR DESCRIPTION
…エラーが発生する

issue https://github.com/baserproject/basercms/issues/1255

メールプラグインの以下の対応を参考に修正しました。ご確認よろしくお願いします。
https://github.com/baserproject/basercamp/commit/a32a40e9f95d8ae1ef3011d501df1d43818f04d1