### PR TITLE
fix #1268 メールプラグインのメール本文がエスケープされていない問題を解決

### DIFF
--- a/lib/Baser/Plugin/Mail/View/Helper/MaildataHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MaildataHelper.php
@@ -30,10 +30,12 @@ class MaildataHelper extends BcTextHelper {
  * @param string $type コントロールタイプ
  * @param mixed $value 変換前の値
  * @param array|string $options コントロールソース
+ * @param bool $escape エスケープ処理を行うかどうか （初期値 : true）
  * @return string メール用データ
  */
-	public function control($type, $value, $options = "") {
-		return ' ' . $this->toDisplayString($type, $value, $options);
+	public function control($type, $value, $options = "", $escape = true) {
+		$toDisplayString = $this->toDisplayString($type, $value, $options));
+		return $escape ? ' ' . h($toDisplayString) : ' ' . $toDisplayString;
 	}
 
 /**

--- a/lib/Baser/Plugin/Mail/View/Helper/MaildataHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MaildataHelper.php
@@ -34,7 +34,7 @@ class MaildataHelper extends BcTextHelper {
  * @return string メール用データ
  */
 	public function control($type, $value, $options = "", $escape = true) {
-		$toDisplayString = $this->toDisplayString($type, $value, $options));
+		$toDisplayString = $this->toDisplayString($type, $value, $options);
 		return $escape ? ' ' . h($toDisplayString) : ' ' . $toDisplayString;
 	}
 


### PR DESCRIPTION
後方互換を考慮して、view側のヘルパー内で処理を完了しています。
どうしてもエスケープしたくない場合は、引数の$escape をfalse にしてください。