### PR TITLE
docker-syncの設定にnocopyオプションを追加

### DIFF
--- a/docker/docker-compose.yml.default
+++ b/docker/docker-compose.yml.default
@@ -24,7 +24,7 @@ services:
     image: baserproject/basercms:4.2-php7.3
     volumes:
       - ../:/var/www/html:cached
-#      - sync-volume:/var/www/html
+#      - sync-volume:/var/www/html:nocopy
     environment:
       PHP_IDE_CONFIG: "serverName=localhost"
       COMPOSER_ALLOW_SUPERUSER: 1


### PR DESCRIPTION
sync_volumeの設定にnocopyオプションがありませんでしたので追加しました。
ご確認よろしくお願いします。

参考:https://docker-sync.readthedocs.io/en/latest/getting-started/configuration.html