### PR TITLE
fix #1274 「すべてのリンクをサブサイト用に変換する」指定している場合、全てのリンクに対して強制的にプレフィックスを備えるため、除…

### DIFF
--- a/lib/Baser/Config/setting.php
+++ b/lib/Baser/Config/setting.php
@@ -460,3 +460,16 @@ $config['BcShortCode']['Core'] = [
 $config['BcSecurity'] = [
 	'csrfExpires' => '+4 hours'
 ];
+
+/**
+ * オートプレフィックス除外設定
+ */
+$config['Baser'] = [
+	// 「すべてのリンクをサブサイト用に変換する」指定時、全てのリンクに対してプレフィックスを備える箇所に除外指定できる
+	// 指定した絶対URLを記載しているリンクは変換しない
+	// 例: 'https://basercms.net/'と記載 → https://basercms.net/s/ は s が付かなくなる
+	'excludeAbsoluteUrlAddPrefix' => [],
+	// 指定したディレクトリURLを記載しているリンクは変換しない
+	// 例: 'test/' と記載 → https://basercms.net/s/test/ は s が付かなくなる
+	'excludeListAddPrefix' => [],
+];

--- a/lib/Baser/View/Helper/BcSmartphoneHelper.php
+++ b/lib/Baser/View/Helper/BcSmartphoneHelper.php
@@ -128,6 +128,25 @@ class BcSmartphoneHelper extends Helper {
 		if (strpos($url, 'smartphone=off') !== false) {
 			return 'a' . $etc . 'href="' . $baseUrl . $url . '"';
 		} else {
+			// 指定した絶対URLを記載しているリンクは変換しない
+			$excludeList = Configure::read('Baser.excludeAbsoluteUrlAddPrefix');
+			if ($excludeList) {
+				foreach ($excludeList as $exclude) {
+					if (strpos($baseUrl, $exclude) !== false) {
+						return 'a' . $etc . 'href="' . $baseUrl . $url . '"';
+					}
+				}
+			}
+			// 指定したディレクトリURLを記載しているリンクは変換しない
+			$excludeList = Configure::read('Baser.excludeListAddPrefix');
+			if ($excludeList) {
+				foreach ($excludeList as $exclude) {
+					if (strpos($url, $exclude) !== false) {
+						return 'a' . $etc . 'href="' . $baseUrl . $url . '"';
+					}
+				}
+			}
+
 			return 'a' . $etc . 'href="' . $baseUrl . $currentAlias . '/' . $url . '"';
 		}
 	}


### PR DESCRIPTION
必要な場面が出て調整入れました。可能な際に取込検討いただけると幸いです。

- 設定ファイルで指定した絶対URLの場合はプレフィックスを備えない
- 設定ファイルで指定したディレクトリ配下の場合はプレフィックスを備えない
