### PR TITLE
fix #1282 ウィジェット内ブログタグ一覧で表示するタグのリンク先がNotFoundになるため

### DIFF
--- a/lib/Baser/Plugin/Blog/View/Elements/blog_tag_list.php
+++ b/lib/Baser/Plugin/Blog/View/Elements/blog_tag_list.php
@@ -14,6 +14,11 @@
  * @var \BcAppView $this
  * @var int $blogContentId
  */
+if (isset($blogContent)) {
+	$blogContentId = $blogContent['BlogContent']['id'];
+} else {
+	$blogContentId = $blog_content_id;
+}
 ?>
 
 


### PR DESCRIPTION
可能な際に取込検討お願いします。
