### PR TITLE
fix #1080 ブログのコメント表示時に二重にエスケープされた状態で表示される問題を改善

### DIFF
--- a/lib/Baser/Plugin/Blog/Model/BlogComment.php
+++ b/lib/Baser/Plugin/Blog/Model/BlogComment.php
@@ -88,11 +88,6 @@ class BlogComment extends BlogAppModel {
 			$data = $data['BlogComment'];
 		}
 
-		// サニタイズ
-		foreach ($data as $key => $value) {
-			$data[$key] = Sanitize::html($value);
-		}
-
 		// Modelのバリデートに引っかからない為の対処
 		$data['url'] = str_replace('&#45;', '-', $data['url']);
 		$data['email'] = str_replace('&#45;', '-', $data['email']);

--- a/lib/Baser/Plugin/Blog/Test/Case/Model/BlogCommentTest.php
+++ b/lib/Baser/Plugin/Blog/Test/Case/Model/BlogCommentTest.php
@@ -124,10 +124,10 @@ class BlogCommentTest extends BaserTestCase {
 		]);
 
 		$message = 'コメントを正しく追加できません';
-		$this->assertEquals($result['BlogComment']['name'], 'test_name&lt;', $message);
+		$this->assertEquals($result['BlogComment']['name'], 'test_name<', $message);
 		$this->assertEquals($result['BlogComment']['email'], '-@example.com', $message);
 		$this->assertEquals($result['BlogComment']['url'], 'http://example.com/-', $message);
-		$this->assertEquals($result['BlogComment']['message'], 'test_message&lt;', $message);
+		$this->assertEquals($result['BlogComment']['message'], 'test_message<', $message);
 		$this->assertEquals($result['BlogComment']['no'], 2, $message);
 		$this->assertEquals($result['BlogComment']['status'], 1, $message);
 


### PR DESCRIPTION
以下のissueの対応を行いました。

ブログのコメント表示時のエスケープについ https://github.com/baserproject/basercms/issues/1080

ブログのコメントに対して、入力時と出力時両方にエスケープが行われていたので、入力時のエスケープを削除しています。

ご確認お願いします。
