### PR TITLE
fix #1015 タイトルにTabを含むコンテンツを作成すると、コンテンツ一覧に正しく表示されない

### DIFF
--- a/lib/Baser/Lib/BcUtil.php
+++ b/lib/Baser/Lib/BcUtil.php
@@ -294,7 +294,7 @@ class BcUtil extends CakeObject {
  */
 	public static function urlencode($value) {
 		$value = str_replace([
-			' ', '　', '\\', '\'','|', '`', '^', '"', ')', '(', '}', '{', ']', '[', ';',
+			' ', '　', '	', '\\', '\'','|', '`', '^', '"', ')', '(', '}', '{', ']', '[', ';',
 			'/', '?', ':', '@', '&', '=', '+', '$', ',', '%', '<', '>', '#', '!'
 		], '_', $value);
 		$value = preg_replace('/\_{2,}/', '_', $value);

--- a/lib/Baser/Model/Content.php
+++ b/lib/Baser/Model/Content.php
@@ -133,6 +133,7 @@ class Content extends AppModel {
 				['rule' => ['duplicateRelatedSiteContent'], 'message' => __d('baser', '連携しているサブサイトでスラッグが重複するコンテンツが存在します。重複するコンテンツのスラッグ名を先に変更してください。')]],
 			'title' => [
 				['rule' => ['bcUtileUrlencodeBlank'], 'message' => __d('baser', 'タイトルはスペース、全角スペース及び、指定の記号(\\\'|`^"(){}[];/?:@&=+$,%<>#!)だけの名前は付けられません。')],
+				['rule' => '/\A(?!.*(\t)).*\z/', 'message' => __d('baser', 'タイトルはタブを含む名前は付けられません。')],
 				['rule' => ['notBlank'], 'message' => __d('baser', 'タイトルを入力してください。')],
 				['rule' => ['maxLength', 230], 'message' => __d('baser', 'タイトルは230文字以内で入力してください。')]],
 			'self_publish_begin' => [


### PR DESCRIPTION
https://github.com/baserproject/basercms/issues/1015 の対応を行いました。

タイトルにタブを含むコンテンツを保存しようとすると、コンテンツ一覧の表示がおかしくなるので入力チェックを追加しています。

また、nameの方も同じく不都合が起きるので変換処理を入れています。

ご確認お願いします。