### PR TITLE
docker-compose.ymlにwindows用の設定を追加

### DIFF
--- a/docker/docker-compose.yml.default
+++ b/docker/docker-compose.yml.default
@@ -1,6 +1,7 @@
 version: '3'
 
 # volumes:
+#  db-volume: # windowsの場合はコメントを外す
 #  sync-volume:
 #    external: true
     
@@ -10,6 +11,7 @@ services:
     image: mysql/mysql-server:5.7
     volumes:
       - ./volumes/mysql:/var/lib/mysql
+      # - db-volume:/var/lib/mysql # windowsの場合はコメントを外し、上の行をコメントアウトする
       - ./mysql/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
     ports:
       - 3306:3306


### PR DESCRIPTION
WindowsでDockerを動かす際の設定を追加していますのでご確認をお願いします。

Docker for windowsでmysqlを使用する場合、権限の問題で"/var/lib/mysql"のマッピングができないので、Docker Volumeを使用する必要があるみたいです。

□関連フォーラム
> Dockerで環境構築を行ったが、MySQLに接続できない 
https://forum.basercms.net/t/topic/186