### PR TITLE
fix #1289 メールフォームのテキストタイプフィールドにhtml改行タグを入力すると、通知メール内に改行が反映されるため調整

### DIFF
--- a/lib/Baser/Plugin/Mail/View/Helper/MaildataHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MaildataHelper.php
@@ -50,8 +50,9 @@ class MaildataHelper extends BcTextHelper {
 		switch ($type) {
 			case 'text':
 			case 'tel':
-			case 'textarea':
 			case 'email':
+				return str_replace(PHP_EOL, '', $value);
+			case 'textarea':
 			case 'hidden':
 			case 'check':
 			case 'radio':


### PR DESCRIPTION
ユーザーより1行テキスト内に改行が反映される、との指摘をいただいたので調整してみました。
可能な際に取込み検討お願いします。
