### PR TITLE
fix #1157 検索ワードが入力されていない際の表示文章を変更

### DIFF
--- a/lib/Baser/View/SearchIndices/search.php
+++ b/lib/Baser/View/SearchIndices/search.php
@@ -35,6 +35,10 @@
 			<p class="result-link"><small><?php $this->BcBaser->link(fullUrl(urldecode($data['SearchIndex']['url'])), $data['SearchIndex']['url']) ?></small></p>
 		</div>
 	<?php endforeach ?>
+<?php elseif (empty($this->request->query['q'])): ?>
+	<div class="section">
+		<p class="no-data"><?php echo __d('baser', '検索キーワードを入力してください。')?></p>
+	</div>
 <?php else: ?>
 	<div class="section">
 		<p class="no-data"><?php echo __d('baser', '該当する結果が存在しませんでした。')?></p>


### PR DESCRIPTION
以下のissueに対応しています。

> 無条件で検索したときに「 該当する結果が存在しませんでした。」となるのに違和感
> https://github.com/baserproject/basercms/issues/1157

`無条件であれば全ページ表示させる`かどうかの方針は決まっていないようですが、いったん違和感をなくす方向で改修を入れています。

ご確認お願いします。