### PR TITLE
fix #1294 メールプラグイン選択リストで特定の文字で終わると文字化けを起こす問題を解決

### DIFF
--- a/lib/Baser/Plugin/Mail/Model/MailField.php
+++ b/lib/Baser/Plugin/Mail/Model/MailField.php
@@ -256,7 +256,7 @@ class MailField extends MailAppModel {
 		$sourceList = [];
 		$values = explode('|', $source);
 		foreach ($values as $value) {
-			$sourceList[] = preg_replace("/(^\s+|\r|\n|\s+$)/", '', $value);
+			$sourceList[] = preg_replace("/(^\s+|\||\r|\n|\s+$)/u", '', $value);
 		}
 		return implode('|', $sourceList);
 	}


### PR DESCRIPTION
正規表現の部分で
「|」をエスケープし、文字コードの指定を追加