### PR TITLE
fix #1296 MailPluginのCSVダウンロードでメモリを消費する問題

### DIFF
--- a/lib/Baser/Test/Case/View/Helper/BcCsvHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcCsvHelperTest.php
@@ -214,7 +214,7 @@ class BcCsvHelperTest extends BaserTestCase {
  *
  * @param $fileName
  */
-	public function atestSave() {
+	public function testSave() {
 
 		// csvのデータを作成
 		$modelName = 'sample';

--- a/lib/Baser/Test/Case/View/Helper/BcCsvHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcCsvHelperTest.php
@@ -56,8 +56,13 @@ class BcCsvHelperTest extends BaserTestCase {
 
 		$this->BcCsv->addModelData($modelName, $data);
 		$this->assertEquals($expectedHead, $this->BcCsv->csvHead);
-		$this->assertEquals($expectedBody, $this->BcCsv->csvBody);
-
+		$body = '';
+		$fp = $this->BcCsv->getCsvTmpDataFp();
+		rewind($fp);
+		while($line = fgets($fp)) {
+			$body .= $line;
+		}
+		$this->assertEquals($expectedBody, $body);
 	}
 
 	public function addModelDataDataProvider() {
@@ -122,7 +127,13 @@ class BcCsvHelperTest extends BaserTestCase {
 		$datas = [$datas];
 		$this->BcCsv->addModelDatas($modelName, $datas);
 		$this->assertEquals($expectedHead, $this->BcCsv->csvHead);
-		$this->assertEquals($expectedBody, $this->BcCsv->csvBody);
+		$body = '';
+		$fp = $this->BcCsv->getCsvTmpDataFp();
+		rewind($fp);
+		while($line = fgets($fp)) {
+			$body .= $line;
+		}
+		$this->assertEquals($expectedBody, $body);
 	}
 
 	public function addModelDatasDataProvider() {
@@ -180,8 +191,8 @@ class BcCsvHelperTest extends BaserTestCase {
 			]
 		];
 		$this->BcCsv->addModelData($modelName, $data);
-		$result = $this->BcCsv->download($fileName, $debug);
-		$this->assertEquals($expected, $result);
+		// $result = $this->BcCsv->download($fileName, $debug);
+		// $this->assertEquals($expected, $result);
 	}
 
 	public function downloadDataProvider() {
@@ -203,7 +214,7 @@ class BcCsvHelperTest extends BaserTestCase {
  *
  * @param $fileName
  */
-	public function testSave() {
+	public function atestSave() {
 
 		// csvのデータを作成
 		$modelName = 'sample';

--- a/lib/Baser/Test/Case/View/Helper/BcCsvHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcCsvHelperTest.php
@@ -191,8 +191,8 @@ class BcCsvHelperTest extends BaserTestCase {
 			]
 		];
 		$this->BcCsv->addModelData($modelName, $data);
-		// $result = $this->BcCsv->download($fileName, $debug);
-		// $this->assertEquals($expected, $result);
+		$result = $this->BcCsv->download($fileName, $debug);
+		$this->assertEquals($expected, $result);
 	}
 
 	public function downloadDataProvider() {

--- a/lib/Baser/View/Helper/BcCsvHelper.php
+++ b/lib/Baser/View/Helper/BcCsvHelper.php
@@ -53,7 +53,15 @@ class BcCsvHelper extends AppHelper {
 			$this->_csvTmpDataFp = tmpfile();
 		}
 	}
-
+	
+/**
+ * 一時ファイルのポインタを取得
+ */
+	public function getCsvTmpDataFp() {
+		$this->_createTmpFp();
+		return $this->_csvTmpDataFp;
+	}
+	
 /**
  * データを追加する（単数）
  *

--- a/lib/Baser/View/Helper/BcCsvHelper.php
+++ b/lib/Baser/View/Helper/BcCsvHelper.php
@@ -25,13 +25,6 @@ class BcCsvHelper extends AppHelper {
 	public $csvHead = '';
 
 /**
- * CSVボディ
- *
- * @var string
- */
-	public $csvBody = '';
-
-/**
  * CSVヘッドの出力
  *
  * @var boolean
@@ -46,6 +39,22 @@ class BcCsvHelper extends AppHelper {
 	public $encoding = 'UTF-8';
 
 /**
+ * 出力データテンポラリファイルポインタ
+ * @private string
+ */
+	private $_csvTmpDataFp = null;
+
+
+/**
+ * テンポラリファイルを生成する
+ */
+	private function _createTmpFp() {
+		if ($this->_csvTmpDataFp === null) {
+			$this->_csvTmpDataFp = tmpfile();
+		}
+	}
+
+/**
  * データを追加する（単数）
  *
  * @param string $modelName
@@ -53,16 +62,20 @@ class BcCsvHelper extends AppHelper {
  * @return void
  */
 	public function addModelData($modelName, $data) {
-
-		if (!$modelName)
+		if (!$modelName) {
 			return false;
-		if (!isset($data[$modelName]))
+		}
+		if (!isset($data[$modelName])) {
 			return false;
+		}
+		$this->_createTmpFp();
 
 		if (!$this->csvHead) {
 			$this->csvHead = $this->_perseKey($data[$modelName]);
 		}
-		$this->csvBody .= $this->_perseValue($data[$modelName]);
+		fputs($this->_csvTmpDataFp, $this->_perseValue($data[$modelName]));
+
+		// echo memory_get_usage() / (1024 * 1024)."MB\n";
 		return true;
 	}
 
@@ -74,11 +87,12 @@ class BcCsvHelper extends AppHelper {
  * @return $csv
  */
 	public function addModelDatas($modelName, $datas) {
-
-		if (!$modelName)
+		if (!$modelName) {
 			return false;
-		if (!isset($datas[0][$modelName]))
+		}
+		if (!isset($datas[0][$modelName])) {
 			return false;
+		}
 
 		foreach ($datas as $data) {
 			$this->addModelData($modelName, $data);
@@ -146,21 +160,32 @@ class BcCsvHelper extends AppHelper {
  * @return void|string
  */
 	public function download($fileName, $debug = false) {
-
-
 		if (!$debug) {
+			for($i = 0; $i < ob_get_level(); $i++) {
+				ob_end_flush();
+			}
 			Header("Content-disposition: attachment; filename=" . $fileName . ".csv");
 			Header("Content-type: application/octet-stream; name=" . $fileName . ".csv");
 			if ($this->exportCsvHead) {
 				echo $this->csvHead;
 			}
-			echo $this->csvBody;
+			if ($this->_csvTmpDataFp !== null) {
+				rewind($this->_csvTmpDataFp);
+				while ($line = fgets($this->_csvTmpDataFp)) {
+					echo $line;
+				}
+			}
 			exit();
 		} else {
 			if ($this->exportCsvHead) {
 				echo $this->csvHead;
 			}
-			echo $this->csvBody;
+			if ($this->_csvTmpDataFp !== null) {
+				rewind($this->_csvTmpDataFp);
+				while ($line = fgets($this->_csvTmpDataFp)) {
+					echo $line;
+				}
+			}
 		}
 	}
 
@@ -171,15 +196,16 @@ class BcCsvHelper extends AppHelper {
  * @return void
  */
 	public function save($fileName) {
-
-		if ($this->exportCsvHead) {
-			$exportData = $this->csvHead . $this->csvBody;
-		} else {
-			$exportData = $this->csvBody;
-		}
-
 		$fp = fopen($fileName, "w");
-		fputs($fp, $exportData, 1024 * 1000 * 10);
+		if ($this->exportCsvHead) {
+			fputs($fp, $this->csvHead, 1024 * 1000 * 10);
+		}
+		if ($this->_csvTmpDataFp !== null) {
+			rewind($this->_csvTmpDataFp);
+			while ($line = fgets($this->_csvTmpDataFple)) {
+				fputs($fp, $line, 1024 * 1000 * 10);
+			}
+		}
 		fclose($fp);
 	}
 

--- a/lib/Baser/View/Helper/BcCsvHelper.php
+++ b/lib/Baser/View/Helper/BcCsvHelper.php
@@ -212,7 +212,7 @@ class BcCsvHelper extends AppHelper {
 		}
 		if ($this->_csvTmpDataFp !== null) {
 			rewind($this->_csvTmpDataFp);
-			while ($line = fgets($this->_csvTmpDataFple)) {
+			while ($line = fgets($this->_csvTmpDataFp)) {
 				fputs($fp, $line, 1024 * 1000 * 10);
 			}
 		}

--- a/lib/Baser/View/Helper/BcCsvHelper.php
+++ b/lib/Baser/View/Helper/BcCsvHelper.php
@@ -147,19 +147,20 @@ class BcCsvHelper extends AppHelper {
  */
 	public function download($fileName, $debug = false) {
 
-		if ($this->exportCsvHead) {
-			$exportData = $this->csvHead . $this->csvBody;
-		} else {
-			$exportData = $this->csvBody;
-		}
 
 		if (!$debug) {
 			Header("Content-disposition: attachment; filename=" . $fileName . ".csv");
 			Header("Content-type: application/octet-stream; name=" . $fileName . ".csv");
-			echo $exportData;
+			if ($this->exportCsvHead) {
+				echo $this->csvHead;
+			}
+			echo $this->csvBody;
 			exit();
 		} else {
-			return $exportData;
+			if ($this->exportCsvHead) {
+				echo $this->csvHead;
+			}
+			echo $this->csvBody;
 		}
 	}
 

--- a/lib/Baser/View/Helper/BcCsvHelper.php
+++ b/lib/Baser/View/Helper/BcCsvHelper.php
@@ -185,15 +185,17 @@ class BcCsvHelper extends AppHelper {
 			}
 			exit();
 		} else {
+			$output = '';
 			if ($this->exportCsvHead) {
-				echo $this->csvHead;
+				$output .= $this->csvHead;
 			}
 			if ($this->_csvTmpDataFp !== null) {
 				rewind($this->_csvTmpDataFp);
 				while ($line = fgets($this->_csvTmpDataFp)) {
-					echo $line;
+					$output .= $line;
 				}
 			}
+			return $output;
 		}
 	}
 


### PR DESCRIPTION
BcCsvHelper::download() を文字列結合せずにoutput