### PR TITLE
BlogPostの修正：カテゴリを複数指定して検索した場合に1つ目のカテゴリしか検索されない問題を改善。

### DIFF
--- a/lib/Baser/Plugin/Blog/Model/BlogPost.php
+++ b/lib/Baser/Plugin/Blog/Model/BlogPost.php
@@ -929,15 +929,20 @@ class BlogPost extends BlogAppModel {
 		} elseif(!$force) {
 			trigger_error(__d('baser', 'contentId を指定してください。'), E_USER_WARNING);
 		}
-		$categoryId = $this->BlogCategory->field('id', $categoryConditions);
-		if ($categoryId === false) {
+
+		$categoryData = $this->BlogCategory->find('all', array(
+			'conditions' => $categoryConditions,
+		));
+		$categoryIds = Hash::extract($categoryData, '{n}.BlogCategory.id');
+		if (!$categoryIds) {
 			$categoryIds = false;
 		} else {
-			$categoryIds = [$categoryId];
 			// 指定したカテゴリ名にぶら下がる子カテゴリを取得
-			$catChildren = $this->BlogCategory->children($categoryId);
-			if ($catChildren) {
-				$categoryIds = am($categoryIds, Hash::extract($catChildren, '{n}.BlogCategory.id'));
+			foreach ($categoryIds as $categoryId) {
+				$catChildren = $this->BlogCategory->children($categoryId);
+				if ($catChildren) {
+					$categoryIds = am($categoryIds, Hash::extract($catChildren, '{n}.BlogCategory.id'));
+				}
 			}
 		}
 		if($categoryIds === false) {

--- a/lib/Baser/Plugin/Blog/Test/Case/Model/BlogPostTest.php
+++ b/lib/Baser/Plugin/Blog/Test/Case/Model/BlogPostTest.php
@@ -526,7 +526,7 @@ public function testGetDefaultValue() {
 			['count', ['preview' => true], 8],							// 非公開も含めて全件取得
 			['count', ['contentId' => 1, 'category' => 'release'], 3],	// 親カテゴリ
 			['count', ['contentId' => 1, 'category' => 'child'], 2],	// 子カテゴリ
-			['count', ['category' => 'release', 'force' => true], 3],	// 親カテゴリ contentId指定なし、強制取得（カテゴリ名に最初にマッチしたカテゴリIDに紐づくデータを取得）
+			['count', ['category' => 'release', 'force' => true], 4],	// 親カテゴリ contentId指定なし、強制取得（カテゴリ名にマッチしたカテゴリIDに紐づくデータを取得）
 			['count', ['category' => 'hoge'], 0],						// 存在しないカテゴリ
 			['count', ['num' => 2], 2],									// 件数指定
 			['count', ['listCount' => 3], 3],							// 件数指定（非推奨）


### PR DESCRIPTION
BlogHelper::getPosts() 等でカテゴリ指定の条件を複数指定した際に、
指定した1つ目のカテゴリしか検索されない問題を改善しました。

BlogHelper::getPosts()から
BlogPost::_findCustomParams()経由で呼び出している
BlogPost::createCategoryCondition()内にて
Model::field()でカテゴリのIDを取得していますが、
field()ではfindによる検索結果の一番最初の行の値しか渡されないため、
カテゴリを複数指定しても、1つ目のカテゴリのみ指定している状態となります。

今回、find()で検索しHashでBlogCategory.idを取得という形に変更しております。
```
$this->Blog->getPosts('news', 3, array('category' => array('news', 'event')))
```
のような形式に対応できるようになりました。