### PR TITLE
メールフォームのテキストタイプフィールドにhtml改行タグを入力すると、通知メール内に改行が反映されるため調整

### DIFF
--- a/lib/Baser/Config/theme/bc_sample/Emails/text/mail_data.php
+++ b/lib/Baser/Config/theme/bc_sample/Emails/text/mail_data.php
@@ -19,7 +19,7 @@ foreach ($mailFields as $field) {
 	}
 	if (isset($message[$field['field_name']]) && !$field['no_send'] && $field['use_field']) {
 		if($field['type'] != 'file') {
-			echo $this->Maildata->control($field['type'], $message[$field['field_name']], $this->Mailfield->getOptions($field));
+			echo $this->Maildata->control($field['type'], $message[$field['field_name']]);
 		} else {
 			if($message[$field['field_name']]) {
 				echo '添付あり';

--- a/lib/Baser/Config/theme/bc_sample/Emails/text/smartphone/mail_data.php
+++ b/lib/Baser/Config/theme/bc_sample/Emails/text/smartphone/mail_data.php
@@ -30,7 +30,7 @@
 	<?php endif; ?>
 	<?php if (!empty($message[$fields['MailField']['field_name']]) && !$fields['MailField']['no_send']): ?>
 		<?php if ($field['type'] != 'file'): ?>
-		<?php echo $this->Maildata->control($fields['MailField']['type'], $message[$fields['MailField']['field_name']], $this->Mailfield->getOptions($fields)); ?>
+		<?php echo $this->Maildata->control($fields['MailField']['type'], $message[$fields['MailField']['field_name']]); ?>
 		<?php else: ?>
 			<?php if($message[$field['field_name']]): ?>
 		<?php echo '添付あり' ?>

--- a/lib/Baser/Plugin/Mail/Model/MailMessage.php
+++ b/lib/Baser/Plugin/Mail/Model/MailMessage.php
@@ -660,10 +660,6 @@ class MailMessage extends MailAppModel {
 			if($mailField['no_send']) {
 				unset($dbData['message'][$mailField['field_name']]);
 			}
-			if (!empty($dbData['message'][$mailField['field_name']])) {
-				$dbData['message'][$mailField['field_name']] = str_replace(array("<br />", "<br>"), "\n", $dbData['message'][$mailField['field_name']]);
-				//$dbData['message'][$mailField['field_name']] = mb_convert_kana($dbData['message'][$mailField['field_name']], "K", "UTF-8");
-			}
 			if ($mailField['type'] == 'multi_check') {
 				if (!empty($dbData['message'][$mailField['field_name']]) && !is_array($dbData['message'][$mailField['field_name']])) {
 					$dbData['message'][$mailField['field_name']] = explode("|", $dbData['message'][$mailField['field_name']]);

--- a/lib/Baser/Plugin/Mail/Test/Case/Model/MailMessageTest.php
+++ b/lib/Baser/Plugin/Mail/Test/Case/Model/MailMessageTest.php
@@ -340,7 +340,7 @@ class MailMessageTest extends BaserTestCase {
 				);
 				$this->assertEquals($expectedMailField, $result['mailFields']['key1']['MailField'], 'mailFieldsに正しい値を格納できていません');
 
-				$expectedMessage = "\n\nhoge";
+				$expectedMessage = "<br><br />hoge";
 				$this->assertEquals($expectedMessage, $result['message']['value']);
 
 			} else {
@@ -348,7 +348,7 @@ class MailMessageTest extends BaserTestCase {
 			}
 
 		} else if ($type == 'multi_check') {
-			$expectedMessage = "\n\nhoge";
+			$expectedMessage = "<br><br />hoge";
 			$this->assertEquals($expectedMessage, $result['message']['value'][0]);
 
 		} else if ($type == 'file') {

--- a/lib/Baser/Plugin/Mail/View/Emails/text/mail_data.php
+++ b/lib/Baser/Plugin/Mail/View/Emails/text/mail_data.php
@@ -29,7 +29,7 @@ foreach ($mailFields as $field) {
 	}
 	if (isset($message[$field['field_name']]) && !$field['no_send'] && $field['use_field']) {
 		if($field['type'] != 'file') {
-			echo $this->Maildata->control($field['type'], $message[$field['field_name']], $this->Mailfield->getOptions($field));
+			echo $this->Maildata->control($field['type'], $message[$field['field_name']]);
 		} else {
 			if($message[$field['field_name']]) {
 				echo '添付あり';

--- a/lib/Baser/Plugin/Mail/View/Emails/text/mobile/mail_data.php
+++ b/lib/Baser/Plugin/Mail/View/Emails/text/mobile/mail_data.php
@@ -27,7 +27,7 @@
 <?php endif; ?>
 <?php if (!empty($message[$fields['MailField']['field_name']]) && !$fields['MailField']['no_send']): ?>
 <?php if ($field['type'] != 'file'): ?>
-<?php echo $this->Maildata->control($fields['MailField']['type'], $message[$fields['MailField']['field_name']], $this->Mailfield->getOptions($fields)); ?>
+<?php echo $this->Maildata->control($fields['MailField']['type'], $message[$fields['MailField']['field_name']]); ?>
 <?php else: ?>
 <?php if($message[$field['field_name']]): ?>
 <?php echo '添付あり' ?>


### PR DESCRIPTION
@gondoh @ryuring ご指摘、アドバイスありがとうございました。
https://github.com/baserproject/basercms/pull/1290#issuecomment-563830556

指摘内容を元に調整してきたので、可能な際に取込み検討よろしくお願いします。
