### PR TITLE
fix #1315 blogPostsで呼び出すテンプレートに変数を渡したい要望を解決

### DIFF
--- a/lib/Baser/Plugin/Blog/View/Helper/BlogBaserHelper.php
+++ b/lib/Baser/Plugin/Blog/View/Helper/BlogBaserHelper.php
@@ -71,6 +71,7 @@ class BlogBaserHelper extends AppHelper {
  *	- `page` : ページ数を指定（初期値 : null）
  *	- `sort` : 並び替えの基準となるフィールドを指定（初期値 : null）
  *	- `autoSetCurrentBlog` : $contentsName を指定していない場合、現在のコンテンツより自動でブログを指定する（初期値：true）
+ *	- `data` : エレメントに渡したい変数（初期値 : array）
  * @return void
  */
 	public function blogPosts($contentsName = [], $num = 5, $options = []) {

--- a/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
+++ b/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
@@ -1570,7 +1570,11 @@ class BlogHelper extends AppHelper {
 		if(!empty($this->request->params['Site']['device'])) {
 			$this->_View->subDir = $this->request->params['Site']['device'];
 		}
-		$data = array_merge(['posts' => $blogPosts], ['data' => $options['data']]);
+		if (is_array($options['data'])) {
+			$data =  array_merge(['posts' => $blogPosts], $options['data']);
+		} else {
+			$data = ['posts' => $blogPosts];
+		}
 		$this->BcBaser->element($template, $data, $params);
 	}
 

--- a/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
+++ b/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
@@ -1507,6 +1507,7 @@ class BlogHelper extends AppHelper {
  *	- `page` : ページ数を指定（初期値 : null）
  *	- `sort` : 並び替えの基準となるフィールドを指定（初期値 : null）
  *	- `autoSetCurrentBlog` : $contentsName を指定していない場合、現在のコンテンツより自動でブログを指定する（初期値：true）
+ *	- `data` : エレメントに渡したい変数（初期値 : array）
  * @return void
  */
 	public function posts($contentsName = [], $num = 5, $options = []) {
@@ -1532,6 +1533,7 @@ class BlogHelper extends AppHelper {
 			'page' => 1,
 			'sort' => 'posts_date',
 			'autoSetCurrentBlog' => true
+			'data' => [],
 		], $options);
 
 		if(!$contentsName && empty($options['contentsTemplate'])) {
@@ -1568,7 +1570,7 @@ class BlogHelper extends AppHelper {
 		if(!empty($this->request->params['Site']['device'])) {
 			$this->_View->subDir = $this->request->params['Site']['device'];
 		}
-		$this->BcBaser->element($template, ['posts' => $blogPosts], $params);
+		$this->BcBaser->element($template, ['posts' => $blogPosts, 'data' => $options['data']], $params);
 	}
 
 /**

--- a/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
+++ b/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
@@ -1570,7 +1570,8 @@ class BlogHelper extends AppHelper {
 		if(!empty($this->request->params['Site']['device'])) {
 			$this->_View->subDir = $this->request->params['Site']['device'];
 		}
-		$this->BcBaser->element($template, ['posts' => $blogPosts, 'data' => $options['data']], $params);
+		$data = array_merge(['posts' => $blogPosts], ['data' => $options['data']]);
+		$this->BcBaser->element($template, $data, $params);
 	}
 
 /**

--- a/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
+++ b/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
@@ -1532,7 +1532,7 @@ class BlogHelper extends AppHelper {
 			'direction' => 'DESC',
 			'page' => 1,
 			'sort' => 'posts_date',
-			'autoSetCurrentBlog' => true
+			'autoSetCurrentBlog' => true,
 			'data' => [],
 		], $options);
 


### PR DESCRIPTION
@ryuring 
blogPostsで記事一覧を呼び出すときに、
elementに変数を引き渡しできるようにヘルパーに少し手を入れました。

お手数ですが、こちらの機能をマージしていただくことは可能でしょうか？

