### PR TITLE
fix #1317 固定ページをエレメントとして読み込む際にページの存在判定をして正しいエラーを返したい問題を解決

### DIFF
--- a/lib/Baser/Test/Case/View/Helper/BcContentsHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcContentsHelperTest.php
@@ -481,6 +481,40 @@ class BcContentsHelperTest extends BaserTestCase {
 	}
 
 /**
+ * urlからコンテンツの情報を取得
+ * getContentByUrl
+ * 
+ * @param string $contentType コンテンツタイプ
+ * ('Page','MailContent','BlogContent','ContentFolder')
+ * @param string $url
+ * @param string $field 取得したい値
+ *  'name','url','title'など　初期値：Null 
+ *  省略した場合配列を取得
+ * @param string|bool $expect 期待値
+ * @dataProvider getContentByUrlDataProvider
+ */	
+	public function testgetContentByUrl($expect, $url, $contentType, $field) {
+		$result = $this->BcContents->getContentByUrl($url, $contentType, $field);
+		$this->assertEquals($expect, $result);                       
+	}
+	
+	public function getContentByUrlDataProvider() {
+		return [
+			// 存在するURL（0~2）を指定した場合
+			['1', '/news/', 'BlogContent', 'entity_id'],
+			['/contact/', '/contact/', 'MailContent', 'url'],
+			['1', '/index', 'Page', 'entity_id'],
+			['4', '/service/', 'ContentFolder', 'entity_id'],
+			['14', '/service/sub_service/sub_service_1', 'Page', 'entity_id'],
+			['サービス２', '/service/service2', 'Page', 'title'],
+			// 存在しないURLを指定した場合
+			[false, '/blog/', 'BlogContent', 'name'],
+			//指定がおかしい場合
+			[false, '/blog/', 'Blog', 'url'],
+		];
+	}
+
+/**
  * IDがコンテンツ自身の親のIDかを判定する
  * @param $id
  * @param $parentId

--- a/lib/Baser/View/Helper/BcBaserHelper.php
+++ b/lib/Baser/View/Helper/BcBaserHelper.php
@@ -1957,6 +1957,7 @@ END_FLASH;
  * todo loadHelpersが利用されていないのをなんとかする
  *	- `subDir` : テンプレートの配置場所についてプレフィックスに応じたサブフォルダを利用するかどうか（初期値 : true）
  *	- `recursive` : 固定ページ読み込みを再帰的に読み込むかどうか（初期値 : true）
+ *	- `existence` : 固定ページの存在判定をするかどうか（初期値 : true）
  * @return void
  */
 	public function page($url, $params = [], $options = []) {
@@ -1967,7 +1968,8 @@ END_FLASH;
 		$options = array_merge([
 			'loadHelpers' => false,
 			'subDir' => true,
-			'recursive' => true
+			'recursive' => true,
+			'existence' => true
 		], $options);
 
 		$subDir = $options['subDir'];
@@ -1981,6 +1983,15 @@ END_FLASH;
 		$title = $this->getContentsTitle();
 		if (!empty($this->_View->viewVars['editLink'])) {
 			$editLink = $this->_View->viewVars['editLink'];
+		}
+
+		// 該当URLページの存在確認
+		if ($options['existence']) {
+			$page = $this->BcContents->getContentByUrl($url, 'Page');
+			if(!$page) {
+				trigger_error('ページ「'. $url. '」が存在しません。', E_USER_NOTICE);
+				return ;
+			}
 		}
 
 		// urlを取得

--- a/lib/Baser/View/Helper/BcBaserHelper.php
+++ b/lib/Baser/View/Helper/BcBaserHelper.php
@@ -1957,7 +1957,7 @@ END_FLASH;
  * todo loadHelpersが利用されていないのをなんとかする
  *	- `subDir` : テンプレートの配置場所についてプレフィックスに応じたサブフォルダを利用するかどうか（初期値 : true）
  *	- `recursive` : 固定ページ読み込みを再帰的に読み込むかどうか（初期値 : true）
- *	- `existence` : 固定ページの存在判定をするかどうか（初期値 : true）
+ *	- `checkExists` : 固定ページの存在判定をするかどうか（初期値 : true）
  * @return void
  */
 	public function page($url, $params = [], $options = []) {
@@ -1969,7 +1969,7 @@ END_FLASH;
 			'loadHelpers' => false,
 			'subDir' => true,
 			'recursive' => true,
-			'existence' => true
+			'checkExists' => true
 		], $options);
 
 		$subDir = $options['subDir'];
@@ -1986,7 +1986,7 @@ END_FLASH;
 		}
 
 		// 該当URLページの存在確認
-		if ($options['existence']) {
+		if ($options['checkExists']) {
 			$page = $this->BcContents->getContentByUrl($url, 'Page');
 			if(!$page) {
 				trigger_error('ページ「'. $url. '」が存在しません。', E_USER_NOTICE);

--- a/lib/Baser/View/Helper/BcContentsHelper.php
+++ b/lib/Baser/View/Helper/BcContentsHelper.php
@@ -511,9 +511,9 @@ class BcContentsHelper extends AppHelper {
 /**
  * エンティティIDからコンテンツの情報を取得
  *
+ * @param int $id エンティティID
  * @param string $contentType コンテンツタイプ
  * ('Page','MailContent','BlogContent','ContentFolder')
- * @param int $id エンティティID
  * @param string $field 取得したい値
  *  'name','url','title'など　初期値：Null 
  *  省略した場合配列を取得
@@ -527,9 +527,9 @@ class BcContentsHelper extends AppHelper {
 /**
  * urlからコンテンツの情報を取得
  *
+ * @param string $url
  * @param string $contentType コンテンツタイプ
  * ('Page','MailContent','BlogContent','ContentFolder')
- * @param int $url
  * @param string $field 取得したい値
  *  'name','url','title'など　初期値：Null 
  *  省略した場合配列を取得
@@ -541,7 +541,7 @@ class BcContentsHelper extends AppHelper {
 	}
 
 	private function _getContent($conditions, $field) {
-			$content = $this->_Content->find('first', ['conditions' => $conditions, 'order' => ['Content.id'], 'cache' => false]);
+		$content = $this->_Content->find('first', ['conditions' => $conditions, 'order' => ['Content.id'], 'cache' => false]);
 		if(!empty($content)){
 			if($field){
 				return $content ['Content'][$field];
@@ -551,7 +551,6 @@ class BcContentsHelper extends AppHelper {
 		} else {
 			return false;
 		}
-
 	}
 
 

--- a/lib/Baser/View/Helper/BcContentsHelper.php
+++ b/lib/Baser/View/Helper/BcContentsHelper.php
@@ -519,9 +519,29 @@ class BcContentsHelper extends AppHelper {
  *  省略した場合配列を取得
  * @return array|string|bool
  */
-	public function getContentByEntityId($id, $contentType, $field = null){
+	public function getContentByEntityId($id, $contentType, $field = null) {
 		$conditions = array_merge($this->_Content->getConditionAllowPublish(), ['type' => $contentType, 'entity_id' => $id]);
-		$content = $this->_Content->find('first', ['conditions' => $conditions, 'order' => ['Content.id'], 'cache' => false]);
+		return $this->_getContent($conditions, $field);
+	}
+
+/**
+ * urlからコンテンツの情報を取得
+ *
+ * @param string $contentType コンテンツタイプ
+ * ('Page','MailContent','BlogContent','ContentFolder')
+ * @param int $url
+ * @param string $field 取得したい値
+ *  'name','url','title'など　初期値：Null 
+ *  省略した場合配列を取得
+ * @return array|string|bool
+ */
+	public function getContentByUrl($url, $contentType, $field = null) {
+		$conditions = array_merge($this->_Content->getConditionAllowPublish(), ['type' => $contentType, 'url' => $url]);
+		return $this->_getContent($conditions, $field);
+	}
+
+	private function _getContent($conditions, $field) {
+			$content = $this->_Content->find('first', ['conditions' => $conditions, 'order' => ['Content.id'], 'cache' => false]);
 		if(!empty($content)){
 			if($field){
 				return $content ['Content'][$field];
@@ -531,7 +551,9 @@ class BcContentsHelper extends AppHelper {
 		} else {
 			return false;
 		}
+
 	}
+
 
 /**
  * IDがコンテンツ自身の親のIDかを判定する


### PR DESCRIPTION
・[ BcContents] 存在判定をするヘルパーを用意　→　近いヘルパーと読み込み部分を共有
・[ BcBaser] 存在判定の結果のエラーを用意　→ findの発生回数を減らせるように、判定しないようにすることもできるようにした。