### PR TITLE
fix #1327 インストール完了後のメールの管理画面urlにサブディレクトリを考慮するようにした

### DIFF
--- a/lib/Baser/View/Emails/text/installed.php
+++ b/lib/Baser/View/Emails/text/installed.php
@@ -29,7 +29,7 @@ $adminPrefix = BcUtil::getAdminPrefix();
 ━━━━◇◆━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 　◆ <?php echo __d('baser', 'ログイン情報')?>　
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━◆◇━━━━
-<?php echo __d('baser', '管理ページ')?>： <?php echo topLevelUrl(false) . Configure::read('App.baseUrl').'/' . $adminPrefix . '/users/login' ?>　
+<?php echo __d('baser', '管理ページ')?>： <?php echo $siteUrl . $adminPrefix . '/users/login' ?>　
 <?php echo __d('baser', 'アカウント')?>： <?php echo $name ?>　
 <?php echo __d('baser', 'パスワード')?>： <?php echo $password ?>　
 ※ <?php echo __d('baser', 'パスワードはユーザー管理より変更する事ができます。')?>　


### PR DESCRIPTION
`Config::read('App.baseUrl')`がデフォルトで設定されていませんでしたので、使用しないようにしました。
また、urlを`topLevelUrl(false)`ではなく`$siteUrl`から取得するようにしました。
マージお願いします。