### PR TITLE
fix #1331 ブログコンテンツ設定の一覧表示件数で、100より大きい件数を指定しても100件迄しか記事が取得できないため

### DIFF
--- a/lib/Baser/Plugin/Blog/Controller/BlogController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogController.php
@@ -542,6 +542,11 @@ class BlogController extends BlogAppController {
 		}
 		if($options['num']) {
 			$options['limit'] = $options['num'];
+			// Cakeコア側で、maxLimit で 100の制限があるため
+			// https://book.cakephp.org/2.0/ja/core-libraries/components/pagination.html#id5
+			if (100 < intval($options['limit'])) {
+				$options['maxLimit'] = $options['limit'];
+			}
 		}
 		unset($options['listCount'], $options['num']);
 


### PR DESCRIPTION
可能な際に取込み検討お願いします。
