### PR TITLE
sendMail()のデフォルト文字コードをUTF-8に変更

### DIFF
--- a/lib/Baser/Controller/BcAppController.php
+++ b/lib/Baser/Controller/BcAppController.php
@@ -881,7 +881,7 @@ class BcAppController extends Controller {
 		if (!empty($this->siteConfigs['mail_encode'])) {
 			$encode = $this->siteConfigs['mail_encode'];
 		} else {
-			$encode = 'ISO-2022-JP';
+			$encode = 'UTF-8';
 		}
 
 		// ISO-2022-JPの場合半角カナが文字化けしてしまうので全角に変換する


### PR DESCRIPTION
BcAppControllerのsendMail()をシェル等から呼んだ時に$this->siteConfigが読めずに文字コードがISOになってしまい、送信したメールが文字化けしていました。
なので、文字コードのデフォルトをUTF-8に変更しています。
レビューよろしくお願いします。