### PR TITLE
htmlメールテンプレートのデフォルトを追加

### DIFF
--- a/lib/Baser/View/Emails/html/default.php
+++ b/lib/Baser/View/Emails/html/default.php
@@ -11,6 +11,8 @@
  */
 
 /**
- * [EMAIL] 空レイアウト (text)
+ * [EMAIL] 送信メール(html)
  */
-echo $content_for_layout;
+?>
+<p style="text-align:right"><?php echo date('Y-m-d H:i:s') ?></p>  
+<?php echo $body ?>

--- a/lib/Baser/View/Layouts/Emails/html/default.php
+++ b/lib/Baser/View/Layouts/Emails/html/default.php
@@ -11,6 +11,15 @@
  */
 
 /**
- * [EMAIL] 空レイアウト (text)
+ * [EMAIL] 空レイアウト (html)
  */
-echo $content_for_layout;
+?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN">
+<html>
+	<head>
+		<title><?php echo $this->fetch('title'); ?></title>
+	</head>
+<body>
+	<?php echo $this->fetch('content'); ?>
+</body>
+</html>


### PR DESCRIPTION
現在、basercmsには有効なhtmlメールのテンプレートがなく、
```
//in Controller extends BcAppController
$this->sendMail($to,$subject,$viewVars,[
     'format' => 'html'
]);
```
とするとcakeのデフォルトレイアウトが呼ばれてしまい、メールの末尾に`This email was sent using the CakePHP Framework, http://cakephp.org.`と挿入されてしまいます。
これはバグではなく、レイアウトも自作して指定すればcakeのシグネチャは出てきません。
必要性も含めてレビューのほどよろしくお願いします。