### PR TITLE
fix #1312 ブログタグアーカイブページでタグが存在しない場合404に遷移

### DIFF
--- a/lib/Baser/Plugin/Blog/Controller/BlogController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogController.php
@@ -305,15 +305,22 @@ class BlogController extends BlogAppController {
 
 				break;
 
+			/* 投稿者別記事一覧 */
 			case 'author':
+
 				$author = h($pass[count($pass) - 1]);
+				if (empty($author) || empty($this->User->hasAny(['name' => $author]))) {
+					$this->notFound();
+				}
 				$posts = $this->_getBlogPosts(['author' => $author]);
 				$data = $this->BlogPost->User->find('first', ['fields' => ['real_name_1', 'real_name_2', 'nickname'], 'conditions' => ['User.name' => $author]]);
 				App::uses('BcBaserHelper', 'View/Helper');
 				$BcBaser = new BcBaserHelper(new View());
 				$this->pageTitle = $BcBaser->getUserName($data);
 				$template = $this->blogContent['BlogContent']['template'] . DS . 'archives';
+
 				$this->set('blogArchiveType', $type);
+
 				break;
 
 			/* タグ別記事一覧 */

--- a/lib/Baser/Plugin/Blog/Controller/BlogController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogController.php
@@ -39,7 +39,7 @@ class BlogController extends BlogAppController {
  *
  * @var array
  */
-	public $uses = ['Blog.BlogCategory', 'Blog.BlogPost', 'Blog.BlogContent'];
+	public $uses = ['Blog.BlogCategory', 'Blog.BlogPost', 'Blog.BlogContent', 'Blog.BlogTag'];
 
 /**
  * ヘルパー
@@ -320,7 +320,7 @@ class BlogController extends BlogAppController {
 			case 'tag':
 
 				$tag = h($pass[count($pass) - 1]);
-				if (empty($this->blogContent['BlogContent']['tag_use']) || empty($tag)) {
+				if (empty($this->blogContent['BlogContent']['tag_use']) || empty($tag) || empty($this->BlogTag->hasAny(['name' => urldecode($tag)]))) {
 					$this->notFound();
 				}
 				$posts = $this->_getBlogPosts(['tag' => $tag]);

--- a/lib/Baser/Plugin/Blog/Controller/BlogController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogController.php
@@ -309,7 +309,8 @@ class BlogController extends BlogAppController {
 			case 'author':
 
 				$author = h($pass[count($pass) - 1]);
-				if (empty($author) || empty($this->User->hasAny(['name' => $author]))) {
+				$existsAuthor = $this->User->hasAny(['name' => $author]);
+				if (empty($author) || empty($existsAuthor)) {
 					$this->notFound();
 				}
 				$posts = $this->_getBlogPosts(['author' => $author]);
@@ -327,7 +328,8 @@ class BlogController extends BlogAppController {
 			case 'tag':
 
 				$tag = h($pass[count($pass) - 1]);
-				if (empty($this->blogContent['BlogContent']['tag_use']) || empty($tag) || empty($this->BlogTag->hasAny(['name' => urldecode($tag)]))) {
+				$existsTag = $this->BlogTag->hasAny(['name' => urldecode($tag)]);
+				if (empty($this->blogContent['BlogContent']['tag_use']) || empty($tag) || empty($existsTag)) {
 					$this->notFound();
 				}
 				$posts = $this->_getBlogPosts(['tag' => $tag]);


### PR DESCRIPTION
下記の処理を追加いたしました。

1. ブログタグアーカイブページでタグが存在しない場合404に遷移
2. ブログ投稿者アーカイブページで投稿者が存在しない場合404に遷移

2.のブログ投稿者の存在確認については[フォーラム](https://forum.basercms.net/t/topic/256/3)に要望がありましたので併せて実装いたしました。
また、`blogURL/archives/author/`と投稿者を指定せずにアクセスした場合の動きも修正しております。今までは記事一覧が表示されましたが、他のアーカイブページに合わせ404に遷移するようにしております。

ご確認よろしくお願いいたします！