### PR TITLE
fix #1321 コンテンツプレビュー時、アイキャッチ画像がプレビューで表示されない

### DIFF
--- a/lib/Baser/Plugin/Blog/Controller/BlogController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogController.php
@@ -39,7 +39,7 @@ class BlogController extends BlogAppController {
  *
  * @var array
  */
-	public $uses = ['Blog.BlogCategory', 'Blog.BlogPost', 'Blog.BlogContent'];
+	public $uses = ['Blog.BlogCategory', 'Blog.BlogPost', 'Blog.BlogContent', 'Content'];
 
 /**
  * ヘルパー
@@ -183,6 +183,8 @@ class BlogController extends BlogAppController {
 		}
 		if($this->BcContents->preview == 'default' && $this->request->data) {
 			$this->blogContent['BlogContent'] = $this->request->data['BlogContent'];
+			$this->request->data = $this->Content->saveTmpFiles($this->request->data, mt_rand(0, 99999999));
+			$this->request->params['Content']['eyecatch'] = $this->request->data['Content']['eyecatch'];
 		}
 		if ($this->RequestHandler->isRss()) {
 			Configure::write('debug', 0);

--- a/lib/Baser/Plugin/Mail/Controller/MailController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailController.php
@@ -42,7 +42,7 @@ class MailController extends MailAppController {
  *
  * @var array
  */
-	public $uses = ['Mail.MailMessage', 'Mail.MailContent', 'Mail.MailField', 'Mail.MailConfig'];
+	public $uses = ['Mail.MailMessage', 'Mail.MailContent', 'Mail.MailField', 'Mail.MailConfig', 'Content'];
 
 /**
  * ヘルパー
@@ -200,6 +200,8 @@ class MailController extends MailAppController {
 
 		if($this->BcContents->preview == 'default' && $this->request->data && empty($this->request->params['requested'])) {
 			$this->dbDatas['mailContent']['MailContent'] = $this->request->data['MailContent'];
+			$this->request->data = $this->Content->saveTmpFiles($this->request->data, mt_rand(0, 99999999));
+			$this->request->params['Content']['eyecatch'] = $this->request->data['Content']['eyecatch'];
 		}
 		
 		$this->Session->write('Mail.valid', true);


### PR DESCRIPTION
ブログコンテンツ・メールコンテンツのプレビュー時に、アイキャッチ画像に設定した画像が表示されない問題を修正しました。

以前マージいただいたプルリクエストは、固定ページのみの対応でしたので他のコンテンツにも対応しています。
https://github.com/baserproject/basercms/pull/1338

ご確認よろしくお願いします。