### PR TITLE
fix #1246 ウィジェット管理 ウィジェット内のラジオボタンが押せない

### DIFF
--- a/app/webroot/theme/admin-third/js/admin/widget_areas/form.js
+++ b/app/webroot/theme/admin-third/js/admin/widget_areas/form.js
@@ -135,8 +135,11 @@ $(function() {
 				}
 			}
 		});
-		$("#"+settingId+" label[for=WidgetStatus]").attr('for','WidgetStatus'+baseId);
-
+		$("#WidgetUpdateWidgetForm"+baseId).find('label').each(function(){
+			if ($(this).attr('for')){
+				$(this).attr('for', $(this).attr('for')+baseId);
+			}
+		});
 	}
 	
 /**

--- a/lib/Baser/webroot/js/admin/widget_areas/form.js
+++ b/lib/Baser/webroot/js/admin/widget_areas/form.js
@@ -135,7 +135,11 @@ $(function() {
 				}
 			}
 		});
-		$("#"+settingId+" label[for=WidgetStatus]").attr('for','WidgetStatus'+baseId);
+		$("#WidgetUpdateWidgetForm"+baseId).find('label').each(function(){
+			if ($(this).attr('for')){
+				$(this).attr('for', $(this).attr('for')+baseId);
+			}
+		});
 
 	}
 	


### PR DESCRIPTION
Issue: https://github.com/baserproject/basercms/issues/1246

ウィジェットをドラッグアンドドロップで追加した際に、input要素のIDは変更されているにも関わらず、それに対応するlabelのforが追従できていないので修正しています。

ご確認よろしくお願いします。