### PR TITLE
fix #1347 ブログカテゴリ一覧画面で、小カテゴリに「&nbsp&nbsp&nbsp」が表示されるため

### DIFF
--- a/lib/Baser/Plugin/Blog/View/Elements/admin/blog_categories/index_row.php
+++ b/lib/Baser/Plugin/Blog/View/Elements/admin/blog_categories/index_row.php
@@ -43,7 +43,7 @@ if (isset($user['user_group_id'])) {
 			<?php echo $this->BcText->arrayValue($data['BlogCategory']['owner_id'], $owners) ?>
 		<?php endif ?>
 	</td>
-	<td><?php echo h($data['BlogCategory']['title']) ?></td>
+	<td><?php echo html_entity_decode(h($data['BlogCategory']['title'])) ?></td>
 	<?php echo $this->BcListTable->dispatchShowRow($data) ?>
 	<td><?php echo $this->BcTime->format('Y-m-d', $data['BlogCategory']['created']); ?><br />
 		<?php echo $this->BcTime->format('Y-m-d', $data['BlogCategory']['modified']); ?></td>


### PR DESCRIPTION
管理側表示一覧のみ「&nbsp&nbsp&nbsp」の付与処理が入っているため、表示時での変換対応としました。
可能な際に取込み検討お願いします。
