### PR TITLE
*.rss でエラー発生時、テーマが反映されない問題を修正

### DIFF
--- a/lib/Baser/View/BcAppView.php
+++ b/lib/Baser/View/BcAppView.php
@@ -206,9 +206,16 @@ class BcAppView extends View {
 		// CUSTOMIZE ADD 2012/04/11 ryuring
 		// CakeErrorの場合はサブフォルダを除外
 		// >>>
-		if ($this->name == 'CakeError' && $this->viewPath == 'Errors') {
+		if ($this->name == 'CakeError' && preg_match('/^Errors\/?/', $this->viewPath)) {
 			$subDir = $this->subDir . DS;
 			$this->subDir = null;
+
+			if ($this->layoutPath == 'rss') {
+				$this->layoutPath = null;
+				$this->viewPath = 'Errors';
+				$this->response->type('html');
+			}
+
 			$exception = $this->get('error');
 			if($exception && $exception instanceof MissingConnectionException) {
 				$this->layout = 'missing_connection';


### PR DESCRIPTION
https://basercms.net/index.rss

*.rss が存在しないアドレスにアクセスすると、
"Errors/rss" からビューを探すため、設定したテーマが反映されませんでした。

https://github.com/baserproject/basercms/blob/9af525297d0fc0f74bcce9d1c08eba4a685de912/lib/Baser/Config/routes.php#L135

に起因するエラー対応を修正しました。
