### PR TITLE
0 で検索できない問題を修正

### DIFF
--- a/lib/Baser/Controller/SearchIndicesController.php
+++ b/lib/Baser/Controller/SearchIndicesController.php
@@ -114,7 +114,7 @@ class SearchIndicesController extends AppController {
 				$this->request->data['SearchIndex'][$key] = h($value);
 			}
 		}
-		if (!empty($this->request->query['q'])) {
+		if (isset($this->request->query['q'][0])) {
 			$this->paginate = [
 				'conditions' => $this->_createSearchConditions($this->request->data),
 				'order' => 'SearchIndex.priority DESC, SearchIndex.modified DESC, SearchIndex.id',

--- a/lib/Baser/View/SearchIndices/search.php
+++ b/lib/Baser/View/SearchIndices/search.php
@@ -35,7 +35,7 @@
 			<p class="result-link"><small><?php $this->BcBaser->link(fullUrl(urldecode($data['SearchIndex']['url'])), $data['SearchIndex']['url']) ?></small></p>
 		</div>
 	<?php endforeach ?>
-<?php elseif (empty($this->request->query['q'])): ?>
+<?php elseif (!isset($this->request->query['q'][0])): ?>
 	<div class="section">
 		<p class="no-data"><?php echo __d('baser', '検索キーワードを入力してください。')?></p>
 	</div>


### PR DESCRIPTION
https://basercms.net/search_indices/search?q=0

PHP の empty() は 0 に対して true を返すため、空の判定を修正しました。