### PR TITLE
リンクページで無限ループが起きる問題を修正

### DIFF
--- a/lib/Baser/View/ContentLinks/view.php
+++ b/lib/Baser/View/ContentLinks/view.php
@@ -13,5 +13,7 @@
 
 
 <?php $this->Html->scriptStart(['inline' => false]); ?>
+<?php if (isset($data['ContentLink']['url'][0])): ?>
 window.location.href = "<?php echo $data['ContentLink']['url'] ?>";
+<?php endif ?>
 <?php $this->Html->scriptEnd(); ?>


### PR DESCRIPTION
https://basercms.net/content_links/view

パラメータ無しでアクセスする機会は少ないかと思いますが、
公開されている URL のため、リダイレクトの無限ループを修正しました。