### PR TITLE
コメント投稿者名の XSS 脆弱性を修正

### DIFF
--- a/app/webroot/theme/admin-third/Elements/admin/blog_comments/index_row.php
+++ b/app/webroot/theme/admin-third/Elements/admin/blog_comments/index_row.php
@@ -30,14 +30,14 @@ if (!$data['BlogComment']['status']) {
 	<td class="bca-table-listup__tbody-td"><?php echo $data['BlogComment']['no'] ?></td>
 	<td class="bca-table-listup__tbody-td">
 		<?php if (!empty($data['BlogComment']['url'])): ?>
-			<?php $this->BcBaser->link($data['BlogComment']['name'], $data['BlogComment']['url'], ['target' => '_blank']) ?>
+			<?php $this->BcBaser->link($data['BlogComment']['name'], $data['BlogComment']['url'], ['target' => '_blank', 'escape' => true]) ?>
 		<?php else: ?>
-			<?php echo $data['BlogComment']['name'] ?>
+			<?php echo h($data['BlogComment']['name']) ?>
 		<?php endif ?>
 	</td>
 	<td class="bca-table-listup__tbody-td">
 		<?php if (!empty($data['BlogComment']['email'])): ?>
-			<?php $this->BcBaser->link($data['BlogComment']['email'], 'mailto:' . $data['BlogComment']['email']) ?>
+			<?php $this->BcBaser->link($data['BlogComment']['email'], 'mailto:' . $data['BlogComment']['email'], ['escape' => true]) ?>
 		<?php endif; ?>
 		<br />
 		<?php echo $this->BcText->autoLinkUrls($data['BlogComment']['url']) ?>

--- a/lib/Baser/Plugin/Blog/View/Elements/admin/blog_comments/index_row.php
+++ b/lib/Baser/Plugin/Blog/View/Elements/admin/blog_comments/index_row.php
@@ -40,14 +40,14 @@ if (!$data['BlogComment']['status']) {
 	<td><?php echo $data['BlogComment']['no'] ?></td>
 	<td>
 		<?php if (!empty($data['BlogComment']['url'])): ?>
-			<?php $this->BcBaser->link($data['BlogComment']['name'], $data['BlogComment']['url'], ['target' => '_blank']) ?>
+			<?php $this->BcBaser->link($data['BlogComment']['name'], $data['BlogComment']['url'], ['target' => '_blank', 'escape' => true]) ?>
 		<?php else: ?>
-			<?php echo $data['BlogComment']['name'] ?>
+			<?php echo h($data['BlogComment']['name']) ?>
 		<?php endif ?>
 	</td>
 	<td>
 		<?php if (!empty($data['BlogComment']['email'])): ?>
-			<?php $this->BcBaser->link($data['BlogComment']['email'], 'mailto:' . $data['BlogComment']['email']) ?>
+			<?php $this->BcBaser->link($data['BlogComment']['email'], 'mailto:' . $data['BlogComment']['email'], ['escape' => true]) ?>
 		<?php endif; ?>
 		<br />
 		<?php echo $this->BcText->autoLinkUrls($data['BlogComment']['url']) ?>

--- a/lib/Baser/Plugin/Blog/View/Elements/blog_comment.php
+++ b/lib/Baser/Plugin/Blog/View/Elements/blog_comment.php
@@ -22,9 +22,9 @@
 		<div class="comment" id="Comment<?php echo $dbData['no'] ?>">
 			<span class="comment-name">≫
 				<?php if ($dbData['url']): ?>
-					<?php echo $this->BcBaser->link($dbData['name'], $dbData['url'], ['target' => '_blank']) ?>
+					<?php echo $this->BcBaser->link($dbData['name'], $dbData['url'], ['target' => '_blank', 'escape' => true]) ?>
 				<?php else: ?>
-					<?php echo $dbData['name'] ?>
+					<?php echo h($dbData['name']) ?>
 				<?php endif ?>
 			</span><br />
 			<span class="comment-message"><?php echo nl2br($this->BcText->autoLinkUrls($dbData['message'])) ?></span>


### PR DESCRIPTION
第三者が入力するコメント投稿者名に HTML エスケープをかけていないため、任意のスクリプトが実行可能です。

投稿者名の例:
```
<script>alert(1)</script>
```

ブログと管理画面のコメント要素を修正しました。
