### PR TITLE
存在しないコンテンツフォルダのレスポンスを NotFound に変更

### DIFF
--- a/lib/Baser/Controller/ContentFoldersController.php
+++ b/lib/Baser/Controller/ContentFoldersController.php
@@ -123,8 +123,13 @@ class ContentFoldersController extends AppController {
  * @return void
  */
 	public function view() {
-		$entityId = $this->request->params['entityId'];
-		$data = $this->ContentFolder->find('first', ['conditions' => ['ContentFolder.id' => $entityId]]);
+		if(empty($this->request->params['entityId'])) {
+			$this->notFound();
+		}
+		$data = $this->ContentFolder->find('first', ['conditions' => ['ContentFolder.id' => $this->request->params['entityId']]]);
+		if(empty($data)) {
+			$this->notFound();
+		}
 		$this->ContentFolder->Content->Behaviors->Tree->settings['Content']['scope'] = ['Content.site_root' => false] + $this->ContentFolder->Content->getConditionAllowPublish();
 		// 公開期間を条件に入れている為、キャッシュをオフにしないとキャッシュが無限増殖してしまう
 		$this->ContentFolder->Content->Behaviors->unload('BcCache');


### PR DESCRIPTION
https://basercms.net/content_folders/view

#1353 と同様の対応として、存在しない場合は 404 にしました。