### PR TITLE
pages/display の引数解析を修正

### DIFF
--- a/lib/Baser/Controller/PagesController.php
+++ b/lib/Baser/Controller/PagesController.php
@@ -276,8 +276,10 @@ class PagesController extends AppController {
 			}
 		}
 
-		$urlTmp = preg_replace('/^\//', '', $urlTmp);
-		$path = explode('/', $urlTmp);
+		if (isset($urlTmp)) {
+			$urlTmp = preg_replace('/^\//', '', $urlTmp);
+			$path = explode('/', $urlTmp);
+		}
 		// <<<
 		
 		$count = count($path);


### PR DESCRIPTION
https://basercms.net/pages/display

func_get_args() が空でもリダイレクトしない状態でした。

https://github.com/baserproject/basercms/blob/dd44fa6e87cbea513059e4e48ae7ddd2bd85d10a/lib/Baser/Controller/PagesController.php#L283-L286

この辺りのブロックは CakePHP オリジナル通りなので、パラメータ無しの場合はリダイレクトを想定しているかと思うのですが、

https://github.com/baserproject/basercms/blob/dd44fa6e87cbea513059e4e48ae7ddd2bd85d10a/lib/Baser/Controller/PagesController.php#L279-L280

直前の preg_replace() で $urlTmp が `''` になり、explode() で $path が `['']` になります。
配列要素が常に 1 以上でリダイレクトすることがないため、意図した挙動になるよう修正しました。
