### PR TITLE
フォームの設定画面にて「BCC用送信先メールアドレス」の項目を「送信先メールアドレス 」の次に配置

### DIFF
--- a/app/webroot/theme/admin-third/MailContents/admin/form.php
+++ b/app/webroot/theme/admin-third/MailContents/admin/form.php
@@ -60,6 +60,18 @@ $this->BcBaser->js('Mail.admin/mail_contents/edit', false);
 			</td>
 		</tr>
 		<tr>
+			<th class="col-head bca-form-table__label"><?php echo $this->BcForm->label('MailContent.sender_2', __d('baser', 'BCC用送信先メールアドレス')) ?></th>
+			<td class="col-input bca-form-table__input">
+<?php echo $this->BcForm->input('MailContent.sender_2', ['type' => 'text', 'size' => 80, 'maxlength' => 255]) ?>
+<i class="bca-icon--question-circle btn help bca-help"></i>
+<?php echo $this->BcForm->error('MailContent.sender_2') ?>
+				<div id="helptextSender2" class="helptext">
+					<ul><li><?php echo __d('baser', 'BCC（ブラインドカーボンコピー）用のメールアドレスを指定します。') ?></li>
+						<li><?php echo __d('baser', '複数の送信先を指定するには、カンマで区切って入力します。') ?></li></ul>
+				</div>
+			</td>
+		</tr>
+		<tr>
 			<th class="col-head bca-form-table__label"><?php echo $this->BcForm->label('MailContent.sender_name', __d('baser', '送信先名')) ?>&nbsp;<span class="bca-label" data-bca-label-type="required"><?php echo __d('baser', '必須') ?></span></th>
 			<td class="col-input bca-form-table__input">
 <?php echo $this->BcForm->input('MailContent.sender_name', ['type' => 'text', 'size' => 80, 'maxlength' => 255]) ?>
@@ -173,18 +185,6 @@ $this->BcBaser->js('Mail.admin/mail_contents/edit', false);
 				<i class="bca-icon--question-circle btn help bca-help"></i>
 				<div id="helptextSslOn" class="helptext"><?php echo __d('baser', '管理者ページでSSLを利用する場合は、事前にSSLの申込、設定が必要です。また、SSL通信で利用するURLをシステム設定で指定している必要があります。') ?></div>
 				<?php echo $this->BcForm->error('MailContent.ssl_on', sprintf(__d('baser', 'SSL通信を利用するには、%s で、事前にSSL通信用のWebサイトURLを指定してください。'), $this->BcBaser->getLink(__d('baser', 'システム設定'), ['controller' => 'site_configs', 'action' => 'form', 'plugin' => null], ['target' => '_blank'])), ['escape' => false]) ?>
-			</td>
-		</tr>
-		<tr>
-			<th class="col-head bca-form-table__label"><?php echo $this->BcForm->label('MailContent.sender_2', __d('baser', 'BCC用送信先メールアドレス')) ?></th>
-			<td class="col-input bca-form-table__input">
-<?php echo $this->BcForm->input('MailContent.sender_2', ['type' => 'text', 'size' => 80, 'maxlength' => 255]) ?>
-<i class="bca-icon--question-circle btn help bca-help"></i>
-<?php echo $this->BcForm->error('MailContent.sender_2') ?>
-				<div id="helptextSender2" class="helptext">
-					<ul><li><?php echo __d('baser', 'BCC（ブラインドカーボンコピー）用のメールアドレスを指定します。') ?></li>
-						<li><?php echo __d('baser', '複数の送信先を指定するには、カンマで区切って入力します。') ?></li></ul>
-				</div>
 			</td>
 		</tr>
 		<tr>

--- a/lib/Baser/Plugin/Mail/View/MailContents/admin/form.php
+++ b/lib/Baser/Plugin/Mail/View/MailContents/admin/form.php
@@ -63,6 +63,18 @@ $this->BcBaser->js('Mail.admin/mail_contents/edit', false);
 			</td>
 		</tr>
 		<tr>
+			<th class="col-head"><?php echo $this->BcForm->label('MailContent.sender_2', __d('baser', 'BCC用送信先メールアドレス')) ?></th>
+			<td class="col-input">
+<?php echo $this->BcForm->input('MailContent.sender_2', array('type' => 'text', 'size' => 80)) ?>
+<?php echo $this->Html->image('admin/icn_help.png', array('id' => 'helpSender2', 'class' => 'btn help', 'alt' => __d('baser', 'ヘルプ'))) ?>
+<?php echo $this->BcForm->error('MailContent.sender_2') ?>
+				<div id="helptextSender2" class="helptext">
+					<ul><li><?php echo __d('baser', 'BCC（ブラインドカーボンコピー）用のメールアドレスを指定します。')?></li>
+						<li><?php echo __d('baser', '複数の送信先を指定するには、カンマで区切って入力します。')?></li></ul>
+				</div>
+			</td>
+		</tr>
+		<tr>
 			<th class="col-head"><?php echo $this->BcForm->label('MailContent.sender_name', __d('baser', '送信先名')) ?>&nbsp;<span class="required">*</span></th>
 			<td class="col-input">
 <?php echo $this->BcForm->input('MailContent.sender_name', array('type' => 'text', 'size' => 80, 'maxlength' => 255)) ?>
@@ -174,18 +186,6 @@ $this->BcBaser->js('Mail.admin/mail_contents/edit', false);
 ?>
 				<div id="helptextSslOn" class="helptext">
                     <?php echo __d('baser', '管理者ページでSSLを利用する場合は、事前にSSLの申込、設定が必要です。また、SSL通信で利用するURLをシステム設定で指定している必要があります。')?>
-				</div>
-			</td>
-		</tr>
-		<tr>
-			<th class="col-head"><?php echo $this->BcForm->label('MailContent.sender_2', __d('baser', 'BCC用送信先メールアドレス')) ?></th>
-			<td class="col-input">
-<?php echo $this->BcForm->input('MailContent.sender_2', array('type' => 'text', 'size' => 80)) ?>
-<?php echo $this->Html->image('admin/icn_help.png', array('id' => 'helpSender2', 'class' => 'btn help', 'alt' => __d('baser', 'ヘルプ'))) ?>
-<?php echo $this->BcForm->error('MailContent.sender_2') ?>
-				<div id="helptextSender2" class="helptext">
-					<ul><li><?php echo __d('baser', 'BCC（ブラインドカーボンコピー）用のメールアドレスを指定します。')?></li>
-						<li><?php echo __d('baser', '複数の送信先を指定するには、カンマで区切って入力します。')?></li></ul>
 				</div>
 			</td>
 		</tr>


### PR DESCRIPTION
https://github.com/baserproject/basercms/issues/1357#issue-567282440
こちらのissue関連の改修です。

- 現状、「送信先メールアドレス 」と「BCC用送信先メールアドレス」の項目が離れているため、手順に抜けが発生する可能性がある。
- 「BCC用送信先メールアドレス」については初期表示状態では「オプション」（admin-thirdでは「詳細設定」）内に隠れているため、存在を認識しづらい

「送信先メールアドレス 」の次に「BCC用送信先メールアドレス」を配置することで、問題が解決できるかと思います。
ご確認・ご検討をお願い致します。