### PR TITLE
記事一覧(タグ)の引数解析を修正

### DIFF
--- a/lib/Baser/Plugin/Blog/Controller/BlogController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogController.php
@@ -329,9 +329,9 @@ class BlogController extends BlogAppController {
 			/* タグ別記事一覧 */
 			case 'tag':
 
-				$tag = h($pass[count($pass) - 1]);
+				$tag = isset($pass[1]) ? $pass[1] : '';
 				$existsTag = $this->BlogTag->hasAny(['name' => urldecode($tag)]);
-				if (empty($this->blogContent['BlogContent']['tag_use']) || empty($tag) || empty($existsTag)) {
+				if (empty($this->blogContent['BlogContent']['tag_use']) || $existsTag === false) {
 					$this->notFound();
 				}
 				$posts = $this->_getBlogPosts(['tag' => $tag]);


### PR DESCRIPTION
ブログの `archives/tag` にいくつか問題があるため、修正しました。

* `archives/tag` のとき、count($pass) は 1 のため、`tag` というタグ名で find をしてしまう。
* `archives/tag/a/b/c` のとき、`a` ではなく `c` のタグ名で find をしてしまう。
* `archives/tag/a&b` のとき、指定のタグ `a&b` を HTML エスケープしてから find するため、一覧に表示されない。

HTML エスケープを処理の途中でかけたかった、とは考えづらいので、単純に過去の負債が残っていただけでは？と推測しています。$tag は最終的に以下で処理されるため、エスケープ漏れの心配もないです。

https://github.com/baserproject/basercms/blob/a53023c46999b7648ed22f84c100ffc36977e584/lib/Baser/View/Helper/BcBaserHelper.php#L393-L395

---

また、これらとは別に、タグに登録できる文字列に不都合な問題があります。

例えば、`%40` というタグの登録を許してしまうと、`archives/tag/%40` でアクセスした際、
`urldecode('%40')` の値を指定されたタグとして処理が進むため、一覧に表示されません。

タグのバリデーション変更やマイグレーションは、後方互換性に影響がでそうなため、この問題については認識しつつも、手をつけていません。取り急ぎ報告として。