### PR TITLE
記事一覧(投稿者)の引数解析を修正

### DIFF
--- a/lib/Baser/Plugin/Blog/Controller/BlogController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogController.php
@@ -310,9 +310,9 @@ class BlogController extends BlogAppController {
 			/* 投稿者別記事一覧 */
 			case 'author':
 
-				$author = h($pass[count($pass) - 1]);
+				$author = isset($pass[1]) ? $pass[1] : '';
 				$existsAuthor = $this->User->hasAny(['name' => $author]);
-				if (empty($author) || empty($existsAuthor)) {
+				if ($existsAuthor === false) {
 					$this->notFound();
 				}
 				$posts = $this->_getBlogPosts(['author' => $author]);


### PR DESCRIPTION
ブログの `archives/author` にいくつか問題があるため、修正しました。

内容は #1359 と同様です。
