### PR TITLE
記事一覧(カテゴリ)の引数解析を修正

### DIFF
--- a/lib/Baser/Plugin/Blog/Controller/BlogController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogController.php
@@ -275,10 +275,7 @@ class BlogController extends BlogAppController {
 			/* カテゴリ一覧 */
 			case 'category':
 
-				$category = $pass[count($pass) - 1];
-				if (empty($category)) {
-					//$this->notFound();
-				}
+				$category = isset($pass[1]) ? $pass[1] : '';
 
 				// ナビゲーションを設定
 				$categoryId = $this->BlogCategory->field('id', [
@@ -291,7 +288,7 @@ class BlogController extends BlogAppController {
 				}
 
 				// 記事を取得
-				$posts = $this->_getBlogPosts(['category' => urlencode($category)]);
+				$posts = $this->_getBlogPosts(['category' => $category]);
 				$blogCategories = $this->BlogCategory->getPath($categoryId, ['name', 'title']);
 				if (count($blogCategories) > 1) {
 					foreach ($blogCategories as $key => $blogCategory) {


### PR DESCRIPTION
ブログの `archives/category` にいくつか問題があるため、修正しました。

内容は #1359 と同様です。
加えて、二重に URL エンコードしている問題も修正しました。
