### PR TITLE
ブログカレンダーが崩れる問題を修正

### DIFF
--- a/lib/Baser/Plugin/Blog/View/Elements/widgets/blog_calendar.php
+++ b/lib/Baser/Plugin/Blog/View/Elements/widgets/blog_calendar.php
@@ -68,7 +68,12 @@ $entryDates = $data['entryDates'];
 		} else {
 			$day = 1;
 		}
-		$time = mktime(0, 0, 0, $month, $day, $year);
+		if ($_time = mktime(0, 0, 0, $month, $day, $year)) {
+			$time = $_time;
+		}
+		$year = date("Y", $time);
+		$month = date("n", $time);
+		$day = date("j", $time);
 	}
 
 //今月の日付の数
@@ -109,6 +114,7 @@ $entryDates = $data['entryDates'];
 	if ($data['next']) {
 		print $this->BcBaser->getLink('≫', $this->BcBaser->getBlogContentsUrl($id) . 'archives/date/' . $year4 . '/' . $month4, null, false);
 	}
+	print "</center>";
 	print "</td></tr>";
 
 	print '


### PR DESCRIPTION
https://basercms.net/news/archives/date//string/

「数値に暗黙変換できる文字列」の入力を前提としているため、tr タグを閉じられず、ブログカレンダーが崩れてしまいます。

https://github.com/baserproject/basercms/blob/430edc0c0bc2f4d2d434374e8f088fb5101379e6/lib/Baser/Plugin/Blog/View/Elements/widgets/blog_calendar.php#L129-L132

mktime() は不正な引数の場合、 `false` を返すため、$w の値が固定されて、tr の閉じタグが出力できません。ここに到達する前に、正常な引数になるように修正しました。
