### PR TITLE
記事一覧(日付)の引数解析を修正

### DIFF
--- a/lib/Baser/Plugin/Blog/Controller/BlogController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogController.php
@@ -345,9 +345,16 @@ class BlogController extends BlogAppController {
 			/* 月別アーカイブ一覧 */
 			case 'date':
 
-				$year = h($pass[1]);
-				$month = h(@$pass[2]);
-				$day = h(@$pass[3]);
+				$year = $month = $day = null;
+				if (isset($pass[1]) && preg_match('/^\d{4}$/', $pass[1])) {
+					$year = $pass[1];
+					if ($year && isset($pass[2]) && preg_match('/^((0?[1-9])|(1[0-2]))$/', $pass[2])) {
+						$month = $pass[2];
+						if ($month && isset($pass[3]) && preg_match('/^((0?[1-9])|([1-2][0-9])|(3[0-1]))$/', $pass[3])) {
+							$day = $pass[3];
+						}
+					}
+				}
 				if (!$year && !$month && !$day) {
 					$this->notFound();
 				}


### PR DESCRIPTION
https://basercms.net/news/archives/date///19string

上記のような URL で、あらゆる年のあらゆる月の "19" 日の記事を出力するため、引数を制限しました。

なお、この項目では記事の存在しない日付だとしても「妥当な日付」であれば、404 にはしていません。
これは、既存の利用者が「明日」や「昨日」などのリンクを実装していた際、404 では影響がでてしまうと
考えたためです。

---

前段の修正で `archives/date` に対する問題は一時的に解消するのですが、

```php
$day = '19string';
```

で "19" 日の記事を取得できてしまうのは、別の箇所に問題を抱えており、

https://github.com/baserproject/basercms/blob/430edc0c0bc2f4d2d434374e8f088fb5101379e6/lib/Baser/Plugin/Blog/Model/BlogPost.php#L1017-L1021

ここで「文字列型」の $year, $month, $day を代入していることが原因です。

MySQL の YEAR(), MONTH(), DAY() は数値型を返すため、
MySQL  内で `'19string'` が `19` に暗黙的に変換されて、結果として "19" 日の記事が引っかかる状態です。
他方、SQLite では文字列同士で比較しているため、 ~~`'19string'` では "19" 日の記事は引っかかりません。~~
(訂正: $day は sprintf() の段階で変換されているので、MySQL と同様の結果です。SQLite の例としては、「`'2020string'` では 2020 年の記事は引っかかりません。」の方適切でした。MySQL は `'2020string'` で 2020 年の記事が引っかかります。)

例えば、

```php
if ($year) $conditions["DATE_FORMAT(BlogPost.posts_date, '%Y')"] = $year;
```

のように DATE_FORMAT() を使えば MySQL の文字列型と PHP の文字列型で正常な結果を取得できます。

YEAR() などで比較したい場合は、代入する $year を数値型にすればよいのですが、

```php
if ($year) $conditions["YEAR(BlogPost.posts_date)"] = (int)$year;
```

のように安直に代入してしまうと、今度は PHP の暗黙変換で `'19string'` が `19` になってから MySQL に渡るだけですので、変換する前の文字列検査が必要かと思います。

対応は開発方針次第かと存じますので、この検索値の問題については手をつけず、報告だけに留めておきます。
`archives/date` 以外から createYearMonthDayCondition() を呼ぶ際はご注意ください。
