### PR TITLE
fix #1377 ブログカテゴリ一覧 子カテゴリの前の半角スペースがエスケープ文字で表示されてしまう問題を解決

### DIFF
--- a/lib/Baser/Plugin/Blog/Controller/BlogCategoriesController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogCategoriesController.php
@@ -103,7 +103,7 @@ class BlogCategoriesController extends BlogAppController {
 		foreach ($_dbDatas as $key => $dbData) {
 			$category = $this->BlogCategory->find('first', ['conditions' => ['BlogCategory.id' => $key]]);
 			if (preg_match("/^([_]+)/i", $dbData, $matches)) {
-				$prefix = str_replace('_', '&nbsp&nbsp&nbsp', $matches[1]);
+				$prefix = str_replace('_', '   ', $matches[1]);
 				$category['BlogCategory']['title'] = $prefix . '└' . $category['BlogCategory']['title'];
 				$category['BlogCategory']['depth'] = strlen($matches[1]);
 			} else {


### PR DESCRIPTION
@ryuring 
取り急ぎ、
`&nbsp&nbsp&nbsp` ＝＞　`   ` に置き換えて正常に表示できるようにしております。
お手数ですが、ご確認の上、マージをお願いします。