### PR TITLE
サーバ情報の公開を抑制

### DIFF
--- a/app/webroot/theme/admin-third/.htaccess
+++ b/app/webroot/theme/admin-third/.htaccess
@@ -1,0 +1,3 @@
+<Files ~ "^phpinfo\.php$">
+deny from all
+</Files>


### PR DESCRIPTION
http://trial.basercms.net/theme/admin-third/SiteConfigs/admin/phpinfo.php

ドキュメントルート配下に phpinfo を出力するスクリプトが存在するため、直アクセスを防ぎました。

theme 配下の他の PHP (ビューファイル) も、直アクセスで大抵は 500 になるはずです。そして、フレームワーク外で動作するため、エラー画面を出力することもできません。

この修正では、最低限の抑制に留めていますので、お好みで対象範囲を広げてください。