### PR TITLE
外部からログを書き込まれる問題を修正

### DIFF
--- a/lib/Baser/Controller/BcAppController.php
+++ b/lib/Baser/Controller/BcAppController.php
@@ -1558,7 +1558,7 @@ class BcAppController extends Controller {
  * @return void
  * @deprecated 5.0.0 since 4.1.5 BcMessage に移行
  */
-	public function setMessage($message, $alert = false, $saveDblog = false, $setFlash = true) {
+	protected function setMessage($message, $alert = false, $saveDblog = false, $setFlash = true) {
 		$this->BcMessage->set($message, $alert, $saveDblog, $setFlash);
 	}
 


### PR DESCRIPTION
http://trial.basercms.net/maintenance/setMessage/外部からログを書き込まれました。/0/1

外部から任意のログを書き込まれてしまう問題を修正しました。
上記 URL で書き込み後、管理側のダッシュボードで結果を確認できます。

過去のコミットを遡ると public と protected を二転三転しているようでしたが、
現在は機能が BcMessage に移行しているため、メソッドの権限を改めてご検討ください。
