### PR TITLE
CAPTCHA 認証を回避してコメント投稿できる問題を修正

### DIFF
--- a/lib/Baser/Plugin/Blog/Controller/BlogController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogController.php
@@ -399,9 +399,9 @@ class BlogController extends BlogAppController {
 					}
 
 					// コメント送信
-					if (isset($this->request->data['BlogComment'])) {
-						$this->add_comment($id);
-					}
+					//if (isset($this->request->data['BlogComment'])) {
+					//	$this->add_comment($id);
+					//}
 
 					$post = $this->_getBlogPosts(['no' => $id]);
 					if (!empty($post[0])) {
@@ -458,49 +458,49 @@ class BlogController extends BlogAppController {
  * @param int $id
  * @return void
  */
-	public function add_comment($id) {
+	//public function add_comment($id) {
 		// blog_post_idを取得
-		$conditions = [
-			'BlogPost.no' => $id,
-			'BlogPost.blog_content_id' => $this->contentId
-		];
-		$conditions = am($conditions, $this->BlogPost->getConditionAllowPublish());
+	//	$conditions = [
+	//		'BlogPost.no' => $id,
+	//		'BlogPost.blog_content_id' => $this->contentId
+	//	];
+	//	$conditions = am($conditions, $this->BlogPost->getConditionAllowPublish());
 
 		// 毎秒抽出条件が違うのでキャッシュしない
-		$data = $this->BlogPost->find('first', [
-			'conditions' => $conditions,
-			'fields' => ['BlogPost.id'],
-			'cache' => false,
-			'recursive' => -1
-		]);
-		$postId = null;
-		if (empty($data['BlogPost']['id'])) {
-			$this->notFound();
-		} else {
-			$postId = $data['BlogPost']['id'];
-		}
+	//	$data = $this->BlogPost->find('first', [
+	//		'conditions' => $conditions,
+	//		'fields' => ['BlogPost.id'],
+	//		'cache' => false,
+	//		'recursive' => -1
+	//	]);
+	//	$postId = null;
+	//	if (empty($data['BlogPost']['id'])) {
+	//		$this->notFound();
+	//	} else {
+	//		$postId = $data['BlogPost']['id'];
+	//	}
 
-		if ($this->BlogPost->BlogComment->add($this->request->data, $this->contentId, $postId, $this->blogContent['BlogContent']['comment_approve'])) {
-			$content = $this->BlogPost->BlogContent->Content->findByType('Blog.BlogContent', $this->blogContent['BlogContent']['id']);
-			$this->request->data['Content'] = $content['Content'];
-			$this->_sendCommentAdmin($postId, $this->request->data);
+	//	if ($this->BlogPost->BlogComment->add($this->request->data, $this->contentId, $postId, $this->blogContent['BlogContent']['comment_approve'])) {
+	//		$content = $this->BlogPost->BlogContent->Content->findByType('Blog.BlogContent', $this->blogContent['BlogContent']['id']);
+	//		$this->request->data['Content'] = $content['Content'];
+	//		$this->_sendCommentAdmin($postId, $this->request->data);
 			// コメント承認機能を利用していない場合は、公開されているコメント投稿者にアラートを送信
-			if (!$this->blogContent['BlogContent']['comment_approve']) {
-				$this->_sendCommentContributor($postId, $this->request->data);
-			}
-			if ($this->blogContent['BlogContent']['comment_approve']) {
-				$commentMessage = __('送信が完了しました。送信された内容は確認後公開させて頂きます。');
-			} else {
-				$commentMessage = __('コメントの送信が完了しました。');
-			}
-			$this->request->data = null;
-		} else {
+	//		if (!$this->blogContent['BlogContent']['comment_approve']) {
+	//			$this->_sendCommentContributor($postId, $this->request->data);
+	//		}
+	//		if ($this->blogContent['BlogContent']['comment_approve']) {
+	//			$commentMessage = __('送信が完了しました。送信された内容は確認後公開させて頂きます。');
+	//		} else {
+	//			$commentMessage = __('コメントの送信が完了しました。');
+	//		}
+	//		$this->request->data = null;
+	//	} else {
 
-			$commentMessage = __('コメントの送信に失敗しました。');
-		}
-		clearViewCache();
-		$this->set('commentMessage', $commentMessage);
-	}
+	//		$commentMessage = __('コメントの送信に失敗しました。');
+	//	}
+	//	clearViewCache();
+	//	$this->set('commentMessage', $commentMessage);
+	//}
 
 /**
  * ブログ記事を取得する


### PR DESCRIPTION
Blog プラグインについて、CAPTCHA 認証を回避してコメント投稿できる問題が存在します。

表面上は BlogCommentsController の

https://github.com/baserproject/basercms/blob/430edc0c0bc2f4d2d434374e8f088fb5101379e6/lib/Baser/Plugin/Blog/Controller/BlogCommentsController.php#L304

を呼び出して処理しているのですが、
それとは別に BlogController にもコメント投稿機能が存在しており、

https://github.com/baserproject/basercms/blob/430edc0c0bc2f4d2d434374e8f088fb5101379e6/lib/Baser/Plugin/Blog/Controller/BlogController.php#L461

を通すと CAPTCHA 認証を回避してコメント投稿が成功します。

http://trial.basercms.net/news/archives/1 宛てに `data['BlogComment']` を送ることで確認できます。
別の方法としては、http://trial.basercms.net/news/add_comment/1 をクリックするだけでも無言のコメント投稿が確認できます。(こちらは BcAuth が効いているため、事前にログインが必要)

旧機能が残っていただけでは？と推測していますが、何らかの事情で add_comment() を継続するのであれば、このメソッドにも CAPTCHA 認証が必要かと思われます。

こちらではステータスを判断できなかったため、一旦コメントアウトで修正しました。
