### PR TITLE
fix #1385 インストールページで表示される404にテーマ適応

### DIFF
--- a/lib/Baser/Controller/BcAppController.php
+++ b/lib/Baser/Controller/BcAppController.php
@@ -337,7 +337,7 @@ class BcAppController extends Controller {
 		}
 
 		// コンソールから利用される場合、$isInstall だけでは判定できないので、BC_INSTALLED も判定に入れる
-		if(!BC_INSTALLED || $isInstall || $isUpdate) {
+		if((!BC_INSTALLED || $isInstall || $isUpdate) && $this->name != 'CakeError') {
 			$this->theme = Configure::read('BcApp.defaultAdminTheme');
 			return;
 		}


### PR DESCRIPTION
下記の処理を追加いたしました。

1. インストールページで表示される404にテーマ適応

インストール済の状態でインストールページにアクセスすると `notFound()` となりCakeErrorControllerが呼ばれ、CakeErrorControllerの `berforeFilter()` で再度インストールページ用の処理に入ります。
CakeErrorControllerの `beforeFilter()` ではインストールページ用の処理に入らないよう条件を追加いたしました。

https://github.com/baserproject/basercms/blob/430edc0c0bc2f4d2d434374e8f088fb5101379e6/lib/Baser/Controller/InstallationsController.php#L107-L111
https://github.com/baserproject/basercms/blob/430edc0c0bc2f4d2d434374e8f088fb5101379e6/lib/Baser/Controller/BcAppController.php#L339-L343

ご確認よろしくお願いいたします！