### PR TITLE
fix #1389【admin-third】アップローダーの設定にて、レイアウトタイプを「テーブル」にした場合、記事添付時に画像の説明文に「f」が設定される

### DIFF
--- a/app/webroot/theme/admin-third/Elements/admin/uploader_files/index_row.php
+++ b/app/webroot/theme/admin-third/Elements/admin/uploader_files/index_row.php
@@ -30,7 +30,7 @@ $class = ' class="' . implode(' ', $classies) . '"';
 			<span class="url"><?php echo $this->BcHtml->url($this->Uploader->getFileUrl($file['UploaderFile']['name'])) ?></span>
 			<span class="user-id"><?php echo $file['UploaderFile']['user_id'] ?></span>
 			<span class="name"><?php echo $file['UploaderFile']['name'] ?></span>
-			<span class="alt"><?php echo h(file['UploaderFile']['alt']) ?></span>
+			<span class="alt"><?php echo h($file['UploaderFile']['alt']) ?></span>
 		</div>
 	</td>
 	<td class="img bca-table-listup__tbody-td"><?php echo $this->Uploader->file($file,['size' => 'small', 'alt' => h($file['UploaderFile']['alt']), 'style' => 'width:80px']) ?></td>


### PR DESCRIPTION
$抜けの様です。
マージお願いします。