### PR TITLE
fix #1398 システム管理者以外でも受信メッセージの一括削除を可能に変更

### DIFF
--- a/app/webroot/theme/admin-third/Elements/admin/mail_messages/index_list.php
+++ b/app/webroot/theme/admin-third/Elements/admin/mail_messages/index_list.php
@@ -19,12 +19,10 @@ $this->BcListTable->setColumnNumber(6);
 
 <div class="bca-data-list__top">
 <!-- 一括処理 -->
-	<?php if ($this->BcBaser->isAdminUser()): ?>
-		<div class="bca-action-table-listup">
-			<?php echo $this->BcForm->input('ListTool.batch', ['type' => 'select', 'options' => ['del' => __d('baser', '削除')], 'empty' => __d('baser', '一括処理'), 'data-bca-select-size' =>'lg']) ?>
-			<?php echo $this->BcForm->button(__d('baser', '適用'), ['id' => 'BtnApplyBatch', 'disabled' => 'disabled', 'class' => 'bca-btn', 'data-bca-btn-size' => 'lg']) ?>
-		</div>
-	<?php endif ?>
+	<div class="bca-action-table-listup">
+		<?php echo $this->BcForm->input('ListTool.batch', ['type' => 'select', 'options' => ['del' => __d('baser', '削除')], 'empty' => __d('baser', '一括処理'), 'data-bca-select-size' =>'lg']) ?>
+		<?php echo $this->BcForm->button(__d('baser', '適用'), ['id' => 'BtnApplyBatch', 'disabled' => 'disabled', 'class' => 'bca-btn', 'data-bca-btn-size' => 'lg']) ?>
+	</div>
   <div class="bca-data-list__sub">
     <!-- pagination -->
     <?php $this->BcBaser->element('pagination') ?>
@@ -36,9 +34,7 @@ $this->BcListTable->setColumnNumber(6);
 <thead class="bca-table-listup__thead">
 	<tr>
 		<th class="list-tool bca-table-listup__thead-th bca-table-listup__thead-th--select"><?php // 一括選択 ?>
-			<?php if ($this->BcBaser->isAdminUser()): ?>
-				<?php echo $this->BcForm->input('ListTool.checkall', ['type' => 'checkbox', 'label' => __d('baser', '一括選択')]) ?>
-			<?php endif; ?>
+			<?php echo $this->BcForm->input('ListTool.checkall', ['type' => 'checkbox', 'label' => __d('baser', '一括選択')]) ?>
 		</th>
 		<th class="bca-table-listup__thead-th" style="white-space: nowrap"><?php // id ?>
 			<?php

--- a/app/webroot/theme/admin-third/Elements/admin/mail_messages/index_row.php
+++ b/app/webroot/theme/admin-third/Elements/admin/mail_messages/index_row.php
@@ -18,9 +18,7 @@
 
 <tr id="Row<?php echo $count + 1 ?>">
 	<td class="row-tools bca-table-listup__tbody-td">
-		<?php if ($this->BcBaser->isAdminUser()): ?>
-			<?php echo $this->BcForm->input('ListTool.batch_targets.' . $data['MailMessage']['id'], ['type' => 'checkbox', 'label'=> '<span class="bca-visually-hidden">チェックする</span>', 'class' => 'batch-targets bca-checkbox__input', 'value' => $data['MailMessage']['id']]) ?>
-		<?php endif ?>		
+		<?php echo $this->BcForm->input('ListTool.batch_targets.' . $data['MailMessage']['id'], ['type' => 'checkbox', 'label'=> '<span class="bca-visually-hidden">チェックする</span>', 'class' => 'batch-targets bca-checkbox__input', 'value' => $data['MailMessage']['id']]) ?>
 	</td>
 	<td class="row-tools bca-table-listup__tbody-td"><?php echo $data['MailMessage']['id'] ?></td>
 	<td class="row-tools bca-table-listup__tbody-td"><?php echo date('Y/m/d H:i', strtotime($data['MailMessage']['created'])); ?></td>


### PR DESCRIPTION
#1398  についてです。