### PR TITLE
fix #1404 URLのクエリがセッションに保存されない問題を解決

### DIFF
--- a/lib/Baser/Lib/BcSite.php
+++ b/lib/Baser/Lib/BcSite.php
@@ -393,6 +393,9 @@ class BcSite {
  */
 	public function existsUrl(CakeRequest $request) {
 		$url = $this->makeUrl($request);
+		if (strpos($url, '?') !== false) {
+			$url = explode('?', $url)[0];
+		}
 		/* @var Content $Content */
 		$Content = ClassRegistry::init('Content');
 		if($Content->findByUrl($url, true, false, $this->sameMainUrl, $this->useSubDomain) || 


### PR DESCRIPTION
@ryuring 

先程の改修をコミットしています。
お手数ですが、ご確認の上、マージをお願いできますでしょうか？