### PR TITLE
なりすまし投稿ができる問題を修正

### DIFF
--- a/lib/Baser/Plugin/Blog/Controller/BlogPostsController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogPostsController.php
@@ -292,6 +292,11 @@ class BlogPostsController extends BlogAppController {
 			$this->request->data['BlogPost']['no'] = $this->BlogPost->getMax('no', ['BlogPost.blog_content_id' => $blogContentId]) + 1;
 			$this->request->data['BlogPost']['posts_date'] = str_replace('/', '-', $this->request->data['BlogPost']['posts_date']);
 
+			if(!BcUtil::isAdminUser()) {
+				$user = $this->BcAuth->user();
+				$this->request->data['BlogPost']['user_id'] = $user['id'];
+			}
+
 			// EVENT BlogPosts.beforeAdd
 			$event = $this->dispatchEvent('beforeAdd', [
 				'data' => $this->request->data
@@ -382,6 +387,10 @@ class BlogPostsController extends BlogAppController {
 		} else {
 			if (!empty($this->request->data['BlogPost']['posts_date'])) {
 				$this->request->data['BlogPost']['posts_date'] = str_replace('/', '-', $this->request->data['BlogPost']['posts_date']);
+			}
+
+			if (!BcUtil::isAdminUser()) {
+				unset($this->request->data['BlogPost']['user_id']);
 			}
 
 			// EVENT BlogPosts.beforeEdit


### PR DESCRIPTION
http://trial.basercms.net/admin/blog/blog_posts/add/1
http://trial.basercms.net/admin/blog/blog_posts/edit/1/1

管理者でないユーザが記事を投稿する際、「作成者」を `input type="hidden" name=data[BlogPost][user_id]` の値で確定しているため、なりすまし投稿が可能な状態です。
管理者でない場合は、ログイン情報を参照するように修正しました。