### PR TITLE
記事作成者名の XSS 脆弱性を修正

### DIFF
--- a/app/webroot/theme/admin-third/BlogPosts/admin/form.php
+++ b/app/webroot/theme/admin-third/BlogPosts/admin/form.php
@@ -243,7 +243,7 @@ $this->BcBaser->js('Blog.admin/blog_posts/form', false, [
           <?php echo $this->BcForm->error('BlogPost.user_id') ?>
         <?php else: ?>
           <?php if (isset($users[$this->BcForm->value('BlogPost.user_id')])): ?>
-            <?php echo $users[$this->BcForm->value('BlogPost.user_id')] ?>
+            <?php echo h($users[$this->BcForm->value('BlogPost.user_id')]) ?>
           <?php endif ?>
           <?php echo $this->BcForm->hidden('BlogPost.user_id') ?>
         <?php endif ?>

--- a/lib/Baser/Plugin/Blog/View/BlogPosts/admin/form.php
+++ b/lib/Baser/Plugin/Blog/View/BlogPosts/admin/form.php
@@ -187,7 +187,7 @@ $this->BcBaser->js('Blog.admin/blog_posts/form', false, [
 					<?php echo $this->BcForm->error('BlogPost.user_id') ?>
 				<?php else: ?>
 					<?php if (isset($users[$this->BcForm->value('BlogPost.user_id')])): ?>
-					<?php echo $users[$this->BcForm->value('BlogPost.user_id')] ?>
+					<?php echo h($users[$this->BcForm->value('BlogPost.user_id')]) ?>
 					<?php endif ?>
 					<?php echo $this->BcForm->hidden('BlogPost.user_id') ?>
 				<?php endif ?>


### PR DESCRIPTION
http://trial.basercms.net/admin/blog/blog_posts/add/1
http://trial.basercms.net/admin/blog/blog_posts/edit/1/1

管理者でないユーザが記事を投稿する際、「作成者」の項目がエスケープされていない状態です。
`<script>alert(0)</script>` などがニックネームの記事を編集時、任意のスクリプトが実行可能なため、エスケープ処理を追加しました。
