### PR TITLE
fix #1011 ファイルアップロード時にpost_max_size超過のエラーメッセージ追加

### DIFF
--- a/lib/Baser/Controller/ContentFoldersController.php
+++ b/lib/Baser/Controller/ContentFoldersController.php
@@ -69,16 +69,11 @@ class ContentFoldersController extends AppController {
  */
 	public function admin_edit($entityId) {
 		$this->pageTitle = __d('baser', 'フォルダ編集');
-		if(!$this->request->data) {
-			$this->request->data = $this->ContentFolder->read(null, $entityId);
+		if ($this->request->is(['post', 'put'])) {
 			if ($this->ContentFolder->isOverPostSize()) {
 				$this->BcMessage->setError(__d('baser', '送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。', ini_get('post_max_size')));
+				$this->redirect(['action' => 'edit', $entityId]);
 			}
-			if(!$this->request->data) {
-				$this->BcMessage->setError(__d('baser', '無効な処理です。'));
-				$this->redirect(['plugin' => false, 'admin' => true, 'controller' => 'contents', 'action' => 'index']);
-			}
-		} else {
 			if ($this->ContentFolder->save($this->request->data, ['reconstructSearchIndices' => true])) {
 				clearViewCache();
 				$this->BcMessage->setSuccess(sprintf(__d('baser', 'フォルダ「%s」を更新しました。'), $this->request->data['Content']['title']));
@@ -90,6 +85,12 @@ class ContentFoldersController extends AppController {
 				]);
 			} else {
 				$this->BcMessage->setError('保存中にエラーが発生しました。入力内容を確認してください。');
+			}
+		} else {
+			$this->request->data = $this->ContentFolder->read(null, $entityId);
+			if(!$this->request->data) {
+				$this->BcMessage->setError(__d('baser', '無効な処理です。'));
+				$this->redirect(['plugin' => false, 'admin' => true, 'controller' => 'contents', 'action' => 'index']);
 			}
 		}
 

--- a/lib/Baser/Controller/ContentFoldersController.php
+++ b/lib/Baser/Controller/ContentFoldersController.php
@@ -71,6 +71,9 @@ class ContentFoldersController extends AppController {
 		$this->pageTitle = __d('baser', 'フォルダ編集');
 		if(!$this->request->data) {
 			$this->request->data = $this->ContentFolder->read(null, $entityId);
+			if ($this->ContentFolder->isOverPostSize()) {
+				$this->BcMessage->setError(__d('baser', '送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。', ini_get('post_max_size')));
+			}
 			if(!$this->request->data) {
 				$this->BcMessage->setError(__d('baser', '無効な処理です。'));
 				$this->redirect(['plugin' => false, 'admin' => true, 'controller' => 'contents', 'action' => 'index']);

--- a/lib/Baser/Controller/ContentLinksController.php
+++ b/lib/Baser/Controller/ContentLinksController.php
@@ -62,16 +62,11 @@ class ContentLinksController extends AppController {
  */
 	public function admin_edit($entityId) {
 		$this->pageTitle = __d('baser', 'リンク編集');
-		if(!$this->request->data) {
-			$this->request->data = $this->ContentLink->read(null, $entityId);
+		if ($this->request->is(['post', 'put'])) {
 			if ($this->ContentLink->isOverPostSize()) {
 				$this->BcMessage->setError(__d('baser', '送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。', ini_get('post_max_size')));
+				$this->redirect(['action' => 'edit', $entityId]);
 			}
-			if(!$this->request->data) {
-				$this->BcMessage->setError(__d('baser', '無効な処理です。'));
-				$this->redirect(['plugin' => false, 'admin' => true, 'controller' => 'contents', 'action' => 'index']);
-			}
-		} else {
 			if ($this->ContentLink->save($this->request->data)) {
 				clearViewCache();
 				$this->BcMessage->setSuccess(sprintf(__d('baser', 'リンク「%s」を更新しました。'), $this->request->data['Content']['title']));
@@ -83,6 +78,12 @@ class ContentLinksController extends AppController {
 				]);
 			} else {
 				$this->BcMessage->setError('保存中にエラーが発生しました。入力内容を確認してください。');
+			}
+		} else {
+			$this->request->data = $this->ContentLink->read(null, $entityId);
+			if(!$this->request->data) {
+				$this->BcMessage->setError(__d('baser', '無効な処理です。'));
+				$this->redirect(['plugin' => false, 'admin' => true, 'controller' => 'contents', 'action' => 'index']);
 			}
 		}
 		$site = BcSite::findById($this->request->data['Content']['site_id']);

--- a/lib/Baser/Controller/ContentLinksController.php
+++ b/lib/Baser/Controller/ContentLinksController.php
@@ -64,6 +64,9 @@ class ContentLinksController extends AppController {
 		$this->pageTitle = __d('baser', 'リンク編集');
 		if(!$this->request->data) {
 			$this->request->data = $this->ContentLink->read(null, $entityId);
+			if ($this->ContentLink->isOverPostSize()) {
+				$this->BcMessage->setError(__d('baser', '送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。', ini_get('post_max_size')));
+			}
 			if(!$this->request->data) {
 				$this->BcMessage->setError(__d('baser', '無効な処理です。'));
 				$this->redirect(['plugin' => false, 'admin' => true, 'controller' => 'contents', 'action' => 'index']);

--- a/lib/Baser/Controller/ContentsController.php
+++ b/lib/Baser/Controller/ContentsController.php
@@ -353,6 +353,9 @@ class ContentsController extends AppController {
 		$this->pageTitle = __d('baser', 'エイリアス編集');
 		if(!$this->request->data) {
 			$this->request->data = $this->Content->find('first', ['conditions' => ['Content.id' => $id]]);
+			if ($this->Content->isOverPostSize()) {
+				$this->BcMessage->setError(__d('baser', '送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。', ini_get('post_max_size')));
+			}
 			if(!$this->request->data) {
 				$this->BcMessage->setError(__d('baser', '無効な処理です。'));
 				$this->redirect(['plugin' => false, 'admin' => true, 'controller' => 'contents', 'action' => 'index']);

--- a/lib/Baser/Controller/ContentsController.php
+++ b/lib/Baser/Controller/ContentsController.php
@@ -351,19 +351,12 @@ class ContentsController extends AppController {
 	public function admin_edit_alias($id) {
 
 		$this->pageTitle = __d('baser', 'エイリアス編集');
-		if(!$this->request->data) {
-			$this->request->data = $this->Content->find('first', ['conditions' => ['Content.id' => $id]]);
+		if ($this->request->is(['post', 'put'])) {
 			if ($this->Content->isOverPostSize()) {
 				$this->BcMessage->setError(__d('baser', '送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。', ini_get('post_max_size')));
+				$this->redirect(['action' => 'edit_alias', $id]);
 			}
-			if(!$this->request->data) {
-				$this->BcMessage->setError(__d('baser', '無効な処理です。'));
-				$this->redirect(['plugin' => false, 'admin' => true, 'controller' => 'contents', 'action' => 'index']);
-			}
-			$srcContent = $this->Content->find('first', ['conditions' => ['Content.id' => $this->request->data['Content']['alias_id']], 'recursive' => -1]);
-			$srcContent = $srcContent['Content'];
-		} else {
-			if($this->Content->save($this->request->data)) {
+			if ($this->Content->save($this->request->data)) {
 				$srcContent = $this->Content->find('first', ['conditions' => ['Content.id' => $this->request->data['Content']['alias_id']], 'recursive' => -1]);
 				$srcContent = $srcContent['Content'];
 				$message = Configure::read('BcContents.items.' . $srcContent['plugin'] . '.' . $srcContent['type'] . '.title') .
@@ -378,7 +371,14 @@ class ContentsController extends AppController {
 			} else {
 				$this->BcMessage->setError('保存中にエラーが発生しました。入力内容を確認してください。');
 			}
-
+		} else {
+			$this->request->data = $this->Content->find('first', ['conditions' => ['Content.id' => $id]]);
+			if(!$this->request->data) {
+				$this->BcMessage->setError(__d('baser', '無効な処理です。'));
+				$this->redirect(['plugin' => false, 'admin' => true, 'controller' => 'contents', 'action' => 'index']);
+			}
+			$srcContent = $this->Content->find('first', ['conditions' => ['Content.id' => $this->request->data['Content']['alias_id']], 'recursive' => -1]);
+			$srcContent = $srcContent['Content'];
 		}
 
 		$this->set('srcContent', $srcContent);

--- a/lib/Baser/Controller/EditorTemplatesController.php
+++ b/lib/Baser/Controller/EditorTemplatesController.php
@@ -73,7 +73,11 @@ class EditorTemplatesController extends AppController {
 		$this->pageTitle = __d('baser', 'エディタテンプレート新規登録');
 		$this->help = 'editor_templates_form';
 
-		if ($this->request->data) {
+		if ($this->request->is(['post', 'put'])) {
+			if ($this->EditorTemplate->isOverPostSize()) {
+				$this->BcMessage->setError(__d('baser', '送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。', ini_get('post_max_size')));
+				$this->redirect(['action' => 'add']);
+			}
 			$this->EditorTemplate->create($this->request->data);
 			$result = $this->EditorTemplate->save();
 			if ($result) {
@@ -85,10 +89,6 @@ class EditorTemplatesController extends AppController {
 				$this->redirect(['action' => 'index']);
 			} else {
 				$this->BcMessage->setError(__d('baser', '保存中にエラーが発生しました。'));
-			}
-		} else {
-			if ($this->EditorTemplate->isOverPostSize()) {
-				$this->BcMessage->setError(__d('baser', '送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。', ini_get('post_max_size')));
 			}
 		}
 		$this->render('form');
@@ -103,12 +103,11 @@ class EditorTemplatesController extends AppController {
 		$this->pageTitle = __d('baser', 'エディタテンプレート編集');
 		$this->help = 'editor_templates_form';
 
-		if (!$this->request->data) {
-			$this->request->data = $this->EditorTemplate->read(null, $id);
+		if ($this->request->is(['post', 'put'])) {
 			if ($this->EditorTemplate->isOverPostSize()) {
 				$this->BcMessage->setError(__d('baser', '送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。', ini_get('post_max_size')));
+				$this->redirect(['action' => 'edit', $id]);
 			}
-		} else {
 			$this->EditorTemplate->set($this->request->data);
 			$result = $this->EditorTemplate->save();
 			if ($result) {
@@ -121,6 +120,8 @@ class EditorTemplatesController extends AppController {
 			} else {
 				$this->BcMessage->setError(__d('baser', '保存中にエラーが発生しました。'));
 			}
+		} else {
+			$this->request->data = $this->EditorTemplate->read(null, $id);
 		}
 
 		$this->render('form');

--- a/lib/Baser/Controller/EditorTemplatesController.php
+++ b/lib/Baser/Controller/EditorTemplatesController.php
@@ -86,6 +86,10 @@ class EditorTemplatesController extends AppController {
 			} else {
 				$this->BcMessage->setError(__d('baser', '保存中にエラーが発生しました。'));
 			}
+		} else {
+			if ($this->EditorTemplate->isOverPostSize()) {
+				$this->BcMessage->setError(__d('baser', '送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。', ini_get('post_max_size')));
+			}
 		}
 		$this->render('form');
 	}
@@ -101,6 +105,9 @@ class EditorTemplatesController extends AppController {
 
 		if (!$this->request->data) {
 			$this->request->data = $this->EditorTemplate->read(null, $id);
+			if ($this->EditorTemplate->isOverPostSize()) {
+				$this->BcMessage->setError(__d('baser', '送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。', ini_get('post_max_size')));
+			}
 		} else {
 			$this->EditorTemplate->set($this->request->data);
 			$result = $this->EditorTemplate->save();

--- a/lib/Baser/Controller/PagesController.php
+++ b/lib/Baser/Controller/PagesController.php
@@ -119,17 +119,11 @@ class PagesController extends AppController {
 			$this->redirect(['plugin' => false, 'admin' => true, 'controller' => 'contents', 'action' => 'index']);
 		}
 
-		if (empty($this->request->data)) {
-			$this->Page->recursive = 2;
-			$this->request->data = $this->Page->read(null, $id);
+		if ($this->request->is(['post', 'put'])) {
 			if ($this->Page->isOverPostSize()) {
 				$this->BcMessage->setError(__d('baser', '送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。', ini_get('post_max_size')));
+				$this->redirect(['action' => 'edit', $id]);
 			}
-			if(!$this->request->data) {
-				$this->BcMessage->setError(__d('baser', '無効な処理です。'));
-				$this->redirect(['plugin' => false, 'admin' => true, 'controller' => 'contents', 'action' => 'index']);
-			}
-		} else {
 			$isChangedStatus = $this->Content->isChangedStatus($id, $this->request->data);
 			if (empty($this->request->data['Page']['page_type'])) {
 				$this->request->data['Page']['page_type'] = 1;
@@ -164,6 +158,13 @@ class PagesController extends AppController {
 				$this->redirect(['action' => 'edit', $id]);
 			} else {
 				$this->BcMessage->setError(__d('baser', '入力エラーです。内容を修正してください。'));
+			}
+		} else {
+			$this->Page->recursive = 2;
+			$this->request->data = $this->Page->read(null, $id);
+			if(!$this->request->data) {
+				$this->BcMessage->setError(__d('baser', '無効な処理です。'));
+				$this->redirect(['plugin' => false, 'admin' => true, 'controller' => 'contents', 'action' => 'index']);
 			}
 		}
 

--- a/lib/Baser/Controller/PagesController.php
+++ b/lib/Baser/Controller/PagesController.php
@@ -122,6 +122,9 @@ class PagesController extends AppController {
 		if (empty($this->request->data)) {
 			$this->Page->recursive = 2;
 			$this->request->data = $this->Page->read(null, $id);
+			if ($this->Page->isOverPostSize()) {
+				$this->BcMessage->setError(__d('baser', '送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。', ini_get('post_max_size')));
+			}
 			if(!$this->request->data) {
 				$this->BcMessage->setError(__d('baser', '無効な処理です。'));
 				$this->redirect(['plugin' => false, 'admin' => true, 'controller' => 'contents', 'action' => 'index']);

--- a/lib/Baser/Controller/PluginsController.php
+++ b/lib/Baser/Controller/PluginsController.php
@@ -77,6 +77,9 @@ class PluginsController extends AppController {
 
 		//データなし
 		if (empty($this->request->data)) {
+			if ($this->Plugin->isOverPostSize()) {
+				$this->BcMessage->setError(__d('baser', '送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。', ini_get('post_max_size')));
+			}
 			return;
 		}
 

--- a/lib/Baser/Controller/ThemeConfigsController.php
+++ b/lib/Baser/Controller/ThemeConfigsController.php
@@ -65,13 +65,11 @@ class ThemeConfigsController extends AppController {
 		$this->pageTitle = __d('baser', 'テーマ設定');
 		$this->help = 'theme_configs_form';
 
-		if (empty($this->request->data)) {
-			$this->request->data = ['ThemeConfig' => $this->ThemeConfig->findExpanded()];
+		if ($this->request->is(['post', 'put'])) {
 			if ($this->ThemeConfig->isOverPostSize()) {
 				$this->BcMessage->setError(__d('baser', '送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。', ini_get('post_max_size')));
+				$this->redirect(['action' => 'form']);
 			}
-		} else {
-
 			$this->ThemeConfig->set($this->request->data);
 			if (!$this->ThemeConfig->validates()) {
 				$this->BcMessage->setError(__d('baser', '入力エラーです。内容を修正してください。'));
@@ -92,6 +90,8 @@ class ThemeConfigsController extends AppController {
 					$this->BcMessage->setError(__d('baser', '保存中にエラーが発生しました。'));
 				}
 			}
+		} else {
+			$this->request->data = ['ThemeConfig' => $this->ThemeConfig->findExpanded()];
 		}
 	}
 

--- a/lib/Baser/Controller/ThemeConfigsController.php
+++ b/lib/Baser/Controller/ThemeConfigsController.php
@@ -67,6 +67,9 @@ class ThemeConfigsController extends AppController {
 
 		if (empty($this->request->data)) {
 			$this->request->data = ['ThemeConfig' => $this->ThemeConfig->findExpanded()];
+			if ($this->ThemeConfig->isOverPostSize()) {
+				$this->BcMessage->setError(__d('baser', '送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。', ini_get('post_max_size')));
+			}
 		} else {
 
 			$this->ThemeConfig->set($this->request->data);

--- a/lib/Baser/Controller/ThemeFilesController.php
+++ b/lib/Baser/Controller/ThemeFilesController.php
@@ -581,7 +581,7 @@ class ThemeFilesController extends AppController {
 		$Folder->create(dirname($filePath), 0777);
 
 		if (@move_uploaded_file($this->request->data['ThemeFile']['file']['tmp_name'], $filePath)) {
-			$messages[] = __d('baser', 'アップロードに成功しました。');
+			$messages = [__d('baser', 'アップロードに成功しました。')];
 		} else {
 			$messages[] = __d('baser', 'アップロードに失敗しました。');
 		}

--- a/lib/Baser/Controller/ThemeFilesController.php
+++ b/lib/Baser/Controller/ThemeFilesController.php
@@ -563,8 +563,13 @@ class ThemeFilesController extends AppController {
  * @return void
  */
 	public function admin_upload() {
+		$messages = [];
 		if (!$this->request->data) {
-			$this->notFound();
+			if ($this->ThemeFile->isOverPostSize()) {
+				$messages[] = __d('baser', '送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。', ini_get('post_max_size'));
+			} else {
+				$this->notFound();
+			}
 		}
 		$args = $this->_parseArgs(func_get_args());
 		extract($args);
@@ -576,10 +581,11 @@ class ThemeFilesController extends AppController {
 		$Folder->create(dirname($filePath), 0777);
 
 		if (@move_uploaded_file($this->request->data['ThemeFile']['file']['tmp_name'], $filePath)) {
-			$this->BcMessage->setInfo(__d('baser', 'アップロードに成功しました。'));
+			$messages[] = __d('baser', 'アップロードに成功しました。');
 		} else {
-			$this->BcMessage->setError(__d('baser', 'アップロードに失敗しました。'));
+			$messages[] = __d('baser', 'アップロードに失敗しました。');
 		}
+		$this->BcMessage->setError(implode("\n", $messages));
 		$this->redirect(array_merge(['action' => 'index', $theme, $type], explode('/', $path)));
 	}
 

--- a/lib/Baser/Controller/ThemesController.php
+++ b/lib/Baser/Controller/ThemesController.php
@@ -88,6 +88,10 @@ class ThemesController extends AppController {
 					$this->BcMessage->setError($msg);
 				}
 			}
+		} else {
+			if ($this->Theme->isOverPostSize()) {
+				$this->BcMessage->setError(__d('baser', '送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。', ini_get('post_max_size')));
+			}
 		}
 	}
 

--- a/lib/Baser/Controller/ThemesController.php
+++ b/lib/Baser/Controller/ThemesController.php
@@ -65,7 +65,10 @@ class ThemesController extends AppController {
 	public function admin_add() {
 		$this->pageTitle = __d('baser', 'テーマアップロード');
 		$this->subMenuElements = ['themes'];
-		if($this->request->data) {
+		if ($this->request->is(['post', 'put'])) {
+			if ($this->Theme->isOverPostSize()) {
+				$this->BcMessage->setError(__d('baser', '送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。', ini_get('post_max_size')));
+			}
 			if(empty($this->request->data['Theme']['file']['tmp_name'])) {
 				$message = __d('baser', 'ファイルのアップロードに失敗しました。');
 				if($this->request->data['Theme']['file']['error'] == 1) {
@@ -87,10 +90,6 @@ class ThemesController extends AppController {
 					$msg .= "\n" . $BcZip->error;
 					$this->BcMessage->setError($msg);
 				}
-			}
-		} else {
-			if ($this->Theme->isOverPostSize()) {
-				$this->BcMessage->setError(__d('baser', '送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。', ini_get('post_max_size')));
 			}
 		}
 	}

--- a/lib/Baser/Controller/ToolsController.php
+++ b/lib/Baser/Controller/ToolsController.php
@@ -94,10 +94,14 @@ class ToolsController extends AppController {
 				break;
 			case 'restore':
 				set_time_limit(0);
-				if (!$this->request->data) {
-					$this->notFound();
-				}
 				$messages = [];
+				if (!$this->request->data) {
+					if ($this->Tool->isOverPostSize()) {
+						$messages[] = __d('baser', '送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。', ini_get('post_max_size'));
+					} else {
+						$this->notFound();
+					}
+				}
 				if ($this->_restoreDb($this->request->data)) {
 					$messages[] = __d('baser', 'データの復元が完了しました。');
 					$error = false;
@@ -331,6 +335,9 @@ class ToolsController extends AppController {
 	public function admin_load_schema() {
 		if (!$this->request->data) {
 			$this->request->data['Tool']['schema_type'] = 'create';
+			if ($this->Tool->isOverPostSize()) {
+				$this->BcMessage->setError(__d('baser', '送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。', ini_get('post_max_size')));
+			}
 		} else {
 			if (is_uploaded_file($this->request->data['Tool']['schema_file']['tmp_name'])) {
 				$path = TMP . 'schemas' . DS;

--- a/lib/Baser/Controller/ToolsController.php
+++ b/lib/Baser/Controller/ToolsController.php
@@ -333,12 +333,11 @@ class ToolsController extends AppController {
  * @return void
  */
 	public function admin_load_schema() {
-		if (!$this->request->data) {
-			$this->request->data['Tool']['schema_type'] = 'create';
+		if ($this->request->is(['post', 'put'])) {
 			if ($this->Tool->isOverPostSize()) {
 				$this->BcMessage->setError(__d('baser', '送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。', ini_get('post_max_size')));
+				$this->redirect(['action' => 'load_schema']);
 			}
-		} else {
 			if (is_uploaded_file($this->request->data['Tool']['schema_file']['tmp_name'])) {
 				$path = TMP . 'schemas' . DS;
 				if (!$this->_resetTmpSchemaFolder()) {
@@ -354,6 +353,8 @@ class ToolsController extends AppController {
 			} else {
 				$this->BcMessage->setError(__d('baser', 'ファイルアップロードに失敗しました。'));
 			}
+		} else {
+			$this->request->data['Tool']['schema_type'] = 'create';
 		}
 		/* 表示設定 */
 		$this->pageTitle = __d('baser', 'スキーマファイル読込');

--- a/lib/Baser/Locale/baser.pot
+++ b/lib/Baser/Locale/baser.pot
@@ -541,18 +541,18 @@ msgstr ""
 msgid "無効な処理です。"
 msgstr ""
 
-#: Controller/ContentFoldersController.php:75
-#: Controller/ContentLinksController.php:68
-#: Controller/ContentsController.php:357
-#: Controller/EditorTemplatesControlle.php:91;109
-#: Controller/PagesController.php:126
+#: Controller/ContentFoldersController.php:74
+#: Controller/ContentLinksController.php:67
+#: Controller/ContentsController.php:356
+#: Controller/EditorTemplatesController.php:78;108
+#: Controller/PagesController.php:124
 #: Controller/PluginsController.php:81
-#: Controller/ThemeConfigsController.php:71
+#: Controller/ThemeConfigsController.php:70
 #: Controller/ThemeFilesController.php:569
-#: Controller/ThemesController.php:93
-#: Controller/ToolController.php:100;339
-#: Plugin/Blog/Controller/BlogContentsController.php:138
-#: Plugin/Blog/Controller/BlogPostsController.php:290;382
+#: Controller/ThemesController.php:70
+#: Controller/ToolsController.php:100;338
+#: Plugin/Blog/Controller/BlogContentsController.php:137
+#: Plugin/Blog/Controller/BlogPostsController.php:289;377
 #: Plugin/Mail/Controller/MailContentsController.php:152
 msgid "送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。"
 msgstr ""

--- a/lib/Baser/Locale/baser.pot
+++ b/lib/Baser/Locale/baser.pot
@@ -541,6 +541,9 @@ msgstr ""
 msgid "無効な処理です。"
 msgstr ""
 
+#: Controller/ContentFoldersController.php:75
+#: Controller/ContentLinksController.php:68
+#: Controller/ContentsController.php:357
 #: Controller/EditorTemplatesControlle.php:91;109
 #: Controller/PagesController.php:126
 #: Controller/PluginsController.php:81

--- a/lib/Baser/Locale/baser.pot
+++ b/lib/Baser/Locale/baser.pot
@@ -541,6 +541,19 @@ msgstr ""
 msgid "無効な処理です。"
 msgstr ""
 
+#: Controller/EditorTemplatesControlle.php:91;109
+#: Controller/PagesController.php:126
+#: Controller/PluginsController.php:81
+#: Controller/ThemeConfigsController.php:71
+#: Controller/ThemeFilesController.php:569
+#: Controller/ThemesController.php:93
+#: Controller/ToolController.php:100;339
+#: Plugin/Blog/Controller/BlogContentsController.php:138
+#: Plugin/Blog/Controller/BlogPostsController.php:290;382
+#: Plugin/Mail/Controller/MailContentsController.php:152
+msgid "送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。"
+msgstr ""
+
 #: Controller/ContentFoldersController.php:57
 msgid "フォルダ「%s」を追加しました。"
 msgstr ""

--- a/lib/Baser/Locale/eng/LC_MESSAGES/baser.po
+++ b/lib/Baser/Locale/eng/LC_MESSAGES/baser.po
@@ -562,6 +562,19 @@ msgstr ""
 msgid "無効な処理です。"
 msgstr "Invalid process."
 
+#: Controller/EditorTemplatesControlle.php:91;109
+#: Controller/PagesController.php:126
+#: Controller/PluginsController.php:81
+#: Controller/ThemeConfigsController.php:71
+#: Controller/ThemeFilesController.php:569
+#: Controller/ThemesController.php:93
+#: Controller/ToolController.php:100;339
+#: Plugin/Blog/Controller/BlogContentsController.php:138
+#: Plugin/Blog/Controller/BlogPostsController.php:290;382
+#: Plugin/Mail/Controller/MailContentsController.php:152
+msgid "送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。"
+msgstr "Exceeding sendable data size. Please send data size within %s."
+
 #: Controller/ContentFoldersController.php:57
 msgid "フォルダ「%s」を追加しました。"
 msgstr "Added Folder \"%s\"."

--- a/lib/Baser/Locale/eng/LC_MESSAGES/baser.po
+++ b/lib/Baser/Locale/eng/LC_MESSAGES/baser.po
@@ -562,18 +562,18 @@ msgstr ""
 msgid "無効な処理です。"
 msgstr "Invalid process."
 
-#: Controller/ContentFoldersController.php:75
-#: Controller/ContentLinksController.php:68
-#: Controller/ContentsController.php:357
-#: Controller/EditorTemplatesControlle.php:91;109
-#: Controller/PagesController.php:126
+#: Controller/ContentFoldersController.php:74
+#: Controller/ContentLinksController.php:67
+#: Controller/ContentsController.php:356
+#: Controller/EditorTemplatesController.php:78;108
+#: Controller/PagesController.php:124
 #: Controller/PluginsController.php:81
-#: Controller/ThemeConfigsController.php:71
+#: Controller/ThemeConfigsController.php:70
 #: Controller/ThemeFilesController.php:569
-#: Controller/ThemesController.php:93
-#: Controller/ToolController.php:100;339
-#: Plugin/Blog/Controller/BlogContentsController.php:138
-#: Plugin/Blog/Controller/BlogPostsController.php:290;382
+#: Controller/ThemesController.php:70
+#: Controller/ToolwController.php:100;338
+#: Plugin/Blog/Controller/BlogContentsController.php:137
+#: Plugin/Blog/Controller/BlogPostsController.php:289;377
 #: Plugin/Mail/Controller/MailContentsController.php:152
 msgid "送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。"
 msgstr "Exceeding sendable data size. Please send data size within %s."

--- a/lib/Baser/Locale/eng/LC_MESSAGES/baser.po
+++ b/lib/Baser/Locale/eng/LC_MESSAGES/baser.po
@@ -562,6 +562,9 @@ msgstr ""
 msgid "無効な処理です。"
 msgstr "Invalid process."
 
+#: Controller/ContentFoldersController.php:75
+#: Controller/ContentLinksController.php:68
+#: Controller/ContentsController.php:357
 #: Controller/EditorTemplatesControlle.php:91;109
 #: Controller/PagesController.php:126
 #: Controller/PluginsController.php:81

--- a/lib/Baser/Model/BcAppModel.php
+++ b/lib/Baser/Model/BcAppModel.php
@@ -1845,4 +1845,18 @@ class BcAppModel extends Model {
 		return $outSize;
 	}
 
+/**
+ * 送信されたPOSTがpost_max_sizeを超えているかチェックする
+ * @return boolean
+ */
+	public function isOverPostSize() {
+		if (empty($_POST) &&
+			env('REQUEST_METHOD') === 'POST' &&
+			env('CONTENT_LENGTH') > $this->convertSize(ini_get('post_max_size'))) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+
 }

--- a/lib/Baser/Plugin/Blog/Controller/BlogContentsController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogContentsController.php
@@ -134,6 +134,9 @@ class BlogContentsController extends BlogAppController {
 
 		if (empty($this->request->data)) {
 			$this->request->data = $this->BlogContent->constructEyeCatchSize($this->BlogContent->read(null, $id));
+			if ($this->BlogContent->isOverPostSize()) {
+				$this->BcMessage->setError(__d('baser', '送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。', ini_get('post_max_size')));
+			}
 			if(!$this->request->data) {
 				$this->BcMessage->setError(__d('baser', '無効な処理です。'));
 				$this->redirect(['plugin' => false, 'admin' => true, 'controller' => 'contents', 'action' => 'index']);

--- a/lib/Baser/Plugin/Blog/Controller/BlogContentsController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogContentsController.php
@@ -132,16 +132,12 @@ class BlogContentsController extends BlogAppController {
 			$this->redirect(['plugin' => false, 'admin' => true, 'controller' => 'contents', 'action' => 'index']);
 		}
 
-		if (empty($this->request->data)) {
-			$this->request->data = $this->BlogContent->constructEyeCatchSize($this->BlogContent->read(null, $id));
+		if ($this->request->is(['post', 'put'])) {
 			if ($this->BlogContent->isOverPostSize()) {
 				$this->BcMessage->setError(__d('baser', '送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。', ini_get('post_max_size')));
+				$this->redirect(['action' => 'edit', $id]);
 			}
-			if(!$this->request->data) {
-				$this->BcMessage->setError(__d('baser', '無効な処理です。'));
-				$this->redirect(['plugin' => false, 'admin' => true, 'controller' => 'contents', 'action' => 'index']);
-			}
-		} else {
+
 			$this->request->data = $this->BlogContent->deconstructEyeCatchSize($this->request->data);
 			$this->BlogContent->set($this->request->data);
 
@@ -156,6 +152,12 @@ class BlogContentsController extends BlogAppController {
 				$this->BcMessage->setError(__d('baser', '入力エラーです。内容を修正してください。'));
 			}
 			$this->request->data = $this->BlogContent->constructEyeCatchSize($this->request->data);
+		} else {
+			$this->request->data = $this->BlogContent->constructEyeCatchSize($this->BlogContent->read(null, $id));
+			if(!$this->request->data) {
+				$this->BcMessage->setError(__d('baser', '無効な処理です。'));
+				$this->redirect(['plugin' => false, 'admin' => true, 'controller' => 'contents', 'action' => 'index']);
+			}
 		}
 		$site = BcSite::findById($this->request->data['Content']['site_id']);
 		if(!empty($this->request->data['Content']['status'])) {

--- a/lib/Baser/Plugin/Blog/Controller/BlogPostsController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogPostsController.php
@@ -284,12 +284,11 @@ class BlogPostsController extends BlogAppController {
 			$this->redirect(['controller' => 'blog_contents', 'action' => 'index']);
 		}
 
-		if (empty($this->request->data)) {
-			$this->request->data = $this->BlogPost->getDefaultValue($this->BcAuth->user());
+		if ($this->request->is(['post', 'put'])) {
 			if ($this->BlogPost->isOverPostSize()) {
 				$this->BcMessage->setError(__d('baser', '送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。', ini_get('post_max_size')));
+				$this->redirect(['action' => 'add', $blogContentId]);
 			}
-		} else {
 
 			$this->request->data['BlogPost']['blog_content_id'] = $blogContentId;
 			$this->request->data['BlogPost']['no'] = $this->BlogPost->getMax('no', ['BlogPost.blog_content_id' => $blogContentId]) + 1;
@@ -323,6 +322,8 @@ class BlogPostsController extends BlogAppController {
 			} else {
 				$this->BcMessage->setError(__d('baser', 'エラーが発生しました。内容を確認してください。'));
 			}
+		} else {
+			$this->request->data = $this->BlogPost->getDefaultValue($this->BcAuth->user());
 		}
 
 		// 表示設定
@@ -371,21 +372,11 @@ class BlogPostsController extends BlogAppController {
 		}
 
 		$this->BlogPost->recursive = 2;
-		if (empty($this->request->data)) {
-			$this->request->data = $this->BlogPost->find('first', array(
-				'conditions' => array(
-					'BlogPost.id' => $id,
-					'BlogPost.blog_content_id' => $blogContentId
-				)
-			));
+		if ($this->request->is(['post', 'put'])) {
 			if ($this->BlogPost->isOverPostSize()) {
 				$this->BcMessage->setError(__d('baser', '送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。', ini_get('post_max_size')));
+				$this->redirect(['action' => 'edit', $blogContentId, $id]);
 			}
-			if(!$this->request->data) {
-				$this->BcMessage->setError(__d('baser', '無効な処理です。'));
-				$this->redirect(['plugin' => 'blog', 'admin' => true, 'controller' => 'blog_posts', 'action' => 'index', $blogContentId]);
-			}
-		} else {
 			if (!empty($this->request->data['BlogPost']['posts_date'])) {
 				$this->request->data['BlogPost']['posts_date'] = str_replace('/', '-', $this->request->data['BlogPost']['posts_date']);
 			}
@@ -411,6 +402,17 @@ class BlogPostsController extends BlogAppController {
 				$this->redirect(['action' => 'edit', $blogContentId, $id]);
 			} else {
 				$this->BcMessage->setError(__d('baser', 'エラーが発生しました。内容を確認してください。'));
+			}
+		} else {
+			$this->request->data = $this->BlogPost->find('first', array(
+				'conditions' => array(
+					'BlogPost.id' => $id,
+					'BlogPost.blog_content_id' => $blogContentId
+				)
+			));
+			if(!$this->request->data) {
+				$this->BcMessage->setError(__d('baser', '無効な処理です。'));
+				$this->redirect(['plugin' => 'blog', 'admin' => true, 'controller' => 'blog_posts', 'action' => 'index', $blogContentId]);
 			}
 		}
 

--- a/lib/Baser/Plugin/Blog/Controller/BlogPostsController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogPostsController.php
@@ -286,6 +286,9 @@ class BlogPostsController extends BlogAppController {
 
 		if (empty($this->request->data)) {
 			$this->request->data = $this->BlogPost->getDefaultValue($this->BcAuth->user());
+			if ($this->BlogPost->isOverPostSize()) {
+				$this->BcMessage->setError(__d('baser', '送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。', ini_get('post_max_size')));
+			}
 		} else {
 
 			$this->request->data['BlogPost']['blog_content_id'] = $blogContentId;
@@ -375,6 +378,9 @@ class BlogPostsController extends BlogAppController {
 					'BlogPost.blog_content_id' => $blogContentId
 				)
 			));
+			if ($this->BlogPost->isOverPostSize()) {
+				$this->BcMessage->setError(__d('baser', '送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。', ini_get('post_max_size')));
+			}
 			if(!$this->request->data) {
 				$this->BcMessage->setError(__d('baser', '無効な処理です。'));
 				$this->redirect(['plugin' => 'blog', 'admin' => true, 'controller' => 'blog_posts', 'action' => 'index', $blogContentId]);

--- a/lib/Baser/Plugin/Mail/Controller/MailContentsController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailContentsController.php
@@ -148,6 +148,9 @@ class MailContentsController extends MailAppController {
 
 		if (empty($this->request->data['MailContent']['id'])) {
 			$this->request->data = $this->MailContent->read(null, $id);
+			if ($this->MailContent->isOverPostSize()) {
+				$this->BcMessage->setError(__d('baser', '送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。', ini_get('post_max_size')));
+			}
 			if(!$this->request->data) {
 				$this->BcMessage->setError(__d('baser', '無効な処理です。'));
 				$this->redirect(['plugin' => false, 'admin' => true, 'controller' => 'contents', 'action' => 'index']);

--- a/lib/Baser/Plugin/Uploader/Controller/UploaderFilesController.php
+++ b/lib/Baser/Plugin/Uploader/Controller/UploaderFilesController.php
@@ -294,6 +294,10 @@ class UploaderFilesController extends AppController {
 		Configure::write('debug',0);
 
 		if(!$this->request->data) {
+			if ($this->UploaderFile->isOverPostSize()) {
+				echo null;
+				die;
+			}
 			$this->ajaxError(500, __d('baser', '無効な処理です。'));
 		}
 		


### PR DESCRIPTION
下記の処理を追加いたしました。

1. POSTが `post_max_size` 超過で初期化されているかチェックする処理を追加
2. ファイルアップロード時に `post_max_size` 超過のエラーメッセージを追加
3. 言語ファイルにエラーメッセージを追加

ご確認よろしくお願いいたします！