### PR TITLE
管理画面でアラートに改行タグが表示される問題を改善

### DIFF
--- a/app/webroot/theme/admin-third/SiteConfigs/admin/form.php
+++ b/app/webroot/theme/admin-third/SiteConfigs/admin/form.php
@@ -26,7 +26,7 @@ $this->BcBaser->i18nScript([
 	'confirmMessage2' => __d('baser', 'テストメールを送信します。いいですか？'),
     'infoMessage1' => __d('baser', 'テストメールを送信しました。'),
     'confirmTitle1' => __d('baser', '管理システムSSL設定確認')
-]);
+], ['escape' => false]);
 $this->BcBaser->js('admin/site_configs/form', false, ['id' => 'AdminSiteConfigsFormScript',
 	'data-safeModeOn' => (string) $safeModeOn,
 	'data-isAdminSsl' => (string) $this->request->data['SiteConfig']['admin_ssl']

--- a/app/webroot/theme/admin-third/Sites/admin/edit.php
+++ b/app/webroot/theme/admin-third/Sites/admin/edit.php
@@ -17,7 +17,7 @@ $this->BcBaser->i18nScript([
 	'confirmMessage1' => __d('baser', "サブサイトを削除してもよろしいですか？\nサブサイトに関連しているコンテンツは全てゴミ箱に入ります。"),
 	'confirmMessage2' => __d('baser', 'エイリアスを本当に変更してもいいですか？<br><br>エイリアスを変更する場合、サイト全体のURLが変更となる為、保存に時間がかかりますのでご注意ください。'),
 	'confirmTitle1' => __d('baser', 'エイリアス変更')
-]);
+], ['escape' => false]);
 $this->BcBaser->js('admin/sites/edit', false);
 ?>
 

--- a/lib/Baser/View/SiteConfigs/admin/form.php
+++ b/lib/Baser/View/SiteConfigs/admin/form.php
@@ -25,7 +25,7 @@ $this->BcBaser->i18nScript([
 	'confirmMessage2' => __d('baser', 'テストメールを送信します。いいですか？'),
     'infoMessage1' => __d('baser', 'テストメールを送信しました。'),
     'confirmTitle1' => __d('baser', '管理システムSSL設定確認')
-]);
+], ['escape' => false]);
 $this->BcBaser->js('admin/site_configs/form', false, ['id' => 'AdminSiteConfigsFormScript',
 	'data-safeModeOn' => (string) $safeModeOn,
 	'data-isAdminSsl' => (string) $this->request->data['SiteConfig']['admin_ssl']

--- a/lib/Baser/View/Sites/admin/edit.php
+++ b/lib/Baser/View/Sites/admin/edit.php
@@ -18,7 +18,7 @@ $this->BcBaser->i18nScript([
 	'confirmMessage1' => __d('baser', "サブサイトを削除してもよろしいですか？\nサブサイトに関連しているコンテンツは全てゴミ箱に入ります。"),
 	'confirmMessage2' => __d('baser', 'エイリアスを本当に変更してもいいですか？<br><br>エイリアスを変更する場合、サイト全体のURLが変更となる為、保存に時間がかかりますのでご注意ください。'),
 	'confirmTitle1' => __d('baser', 'エイリアス変更')
-]);
+], ['escape' => false]);
 $this->BcBaser->js('admin/sites/edit', false);
 ?>
 


### PR DESCRIPTION
ご確認お願いします。

■変更前
<img width="1129" alt="before" src="https://user-images.githubusercontent.com/30764014/78865791-3f4f1400-7a79-11ea-92ea-2c0e0830b475.png">

■変更後
<img width="1130" alt="after" src="https://user-images.githubusercontent.com/30764014/78865795-40804100-7a79-11ea-9dfe-1ddcd009a421.png">
