### PR TITLE
#1012 ブログ記事以外のアイキャッチ画像登録時にファイルサイズのエラーメッセージ追加

### DIFF
--- a/lib/Baser/Model/Behavior/BcUploadBehavior.php
+++ b/lib/Baser/Model/Behavior/BcUploadBehavior.php
@@ -196,7 +196,7 @@ class BcUploadBehavior extends ModelBehavior {
 					}
 				} elseif (!empty($Model->data[$Model->name][$field['name'] . '_'])) {
 					// 新しいデータが送信されず、既存データを引き継ぐ場合は、元のフィールド名に戻す
-					if ($data[$field['name']]['error'] == UPLOAD_ERR_NO_FILE) {
+					if (isset($data[$field['name']]['error']) && $data[$field['name']]['error'] == UPLOAD_ERR_NO_FILE) {
 						$Model->data[$Model->name][$field['name']] = $Model->data[$Model->name][$field['name'] . '_'];
 						unset($Model->data[$Model->name][$field['name'] . '_']);
 					}

--- a/lib/Baser/Model/Content.php
+++ b/lib/Baser/Model/Content.php
@@ -136,6 +136,8 @@ class Content extends AppModel {
 				['rule' => '/\A(?!.*(\t)).*\z/', 'message' => __d('baser', 'タイトルはタブを含む名前は付けられません。')],
 				['rule' => ['notBlank'], 'message' => __d('baser', 'タイトルを入力してください。')],
 				['rule' => ['maxLength', 230], 'message' => __d('baser', 'タイトルは230文字以内で入力してください。')]],
+			'eyecatch' => [
+				['rule' => ['fileCheck', $this->convertSize(ini_get('upload_max_filesize'))], 'message' => __d('baser', 'ファイルのアップロードに失敗しました。')]],
 			'self_publish_begin' => [
 				['rule' => ['checkDate'], 'allowEmpty' => true, 'message' => __d('baser', '公開開始日に不正な文字列が入っています。')]],
 			'self_publish_end' => [


### PR DESCRIPTION
#1396 のアイキャッチ画像のファイルアップロードエラーのチェックを下記画面にも追加いたしました。

1. 固定ページ情報編集
2. ブログ設定編集
3. メールフォーム設定編集
4. フォルダ編集
5. エイリアス編集
6. リンク編集

ご確認よろしくお願いいたします！