### PR TITLE
fix #1384 【アップローダー】名前に%を含むファイルをアップロードすると画像が表示されない問題を改善

### DIFF
--- a/lib/Baser/Plugin/Uploader/Controller/UploaderFilesController.php
+++ b/lib/Baser/Plugin/Uploader/Controller/UploaderFilesController.php
@@ -311,7 +311,7 @@ class UploaderFilesController extends AppController {
 		if(!empty($user['id'])) {
 			$this->request->data['UploaderFile']['user_id'] = $user['id'];
 		}
-		$this->request->data['UploaderFile']['file']['name'] = str_replace(['/', '&', '?', '=', '#', ':'], '', h($this->request->data['UploaderFile']['file']['name']));
+		$this->request->data['UploaderFile']['file']['name'] = str_replace(['/', '&', '?', '=', '#', ':', '%', '+'], '_', h($this->request->data['UploaderFile']['file']['name']));
 		$this->request->data['UploaderFile']['name'] = $this->request->data['UploaderFile']['file'];
 		$this->request->data['UploaderFile']['alt'] = $this->request->data['UploaderFile']['name']['name'];
 		$this->UploaderFile->create($this->request->data);


### PR DESCRIPTION
アップローダープラグインで名前に「%」と「+」を含むファイルをアップロードすると画像が表示されなくなる問題を修正しました。

また、既存の処理だと記号は削除する動作になっていますが、その場合ファイル名が記号のみの場合にファイル名が空になる問題が発生するため、記号を「_」に置換するよう変更しています。

ご確認お願いします。

https://github.com/baserproject/basercms/issues/1384