### PR TITLE
fix #1424 ブログ設定保存時にブログ記事を検索インデックスに登録しない

### DIFF
--- a/lib/Baser/Plugin/Blog/Controller/BlogContentsController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogContentsController.php
@@ -132,6 +132,8 @@ class BlogContentsController extends BlogAppController {
 			$this->redirect(['plugin' => false, 'admin' => true, 'controller' => 'contents', 'action' => 'index']);
 		}
 
+		$blogContentData = $this->BlogContent->constructEyeCatchSize($this->BlogContent->findById($id));
+
 		if ($this->request->is(['post', 'put'])) {
 			if ($this->BlogContent->isOverPostSize()) {
 				$this->BcMessage->setError(__d('baser', '送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。', ini_get('post_max_size')));
@@ -143,6 +145,10 @@ class BlogContentsController extends BlogAppController {
 
 			if ($this->BlogContent->save()) {
 				$this->BcMessage->setSuccess(sprintf(__d('baser', 'ブログ「%s」を更新しました。'), $this->request->data['Content']['title']));
+
+				if ($blogContentData['Content']['name'] !== $this->request->data['Content']['name']) {
+					$this->BcMessage->setInfo(sprintf(__d('baser', 'ブログのURLを変更した際は、検索インデックスの再構築をしてください。')));
+				}
 				if ($this->request->data['BlogContent']['edit_blog_template']) {
 					$this->redirectEditBlog($this->request->data['BlogContent']['template']);
 				} else {
@@ -153,7 +159,7 @@ class BlogContentsController extends BlogAppController {
 			}
 			$this->request->data = $this->BlogContent->constructEyeCatchSize($this->request->data);
 		} else {
-			$this->request->data = $this->BlogContent->constructEyeCatchSize($this->BlogContent->read(null, $id));
+			$this->request->data = $blogContentData;
 			if(!$this->request->data) {
 				$this->BcMessage->setError(__d('baser', '無効な処理です。'));
 				$this->redirect(['plugin' => false, 'admin' => true, 'controller' => 'contents', 'action' => 'index']);

--- a/lib/Baser/Plugin/Blog/Controller/BlogContentsController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogContentsController.php
@@ -151,7 +151,7 @@ class BlogContentsController extends BlogAppController {
 					$blogContentData['Content']['self_status'] != $this->request->data['Content']['self_status'] ||
 					$blogContentData['Content']['self_publish_begin'] != $this->request->data['Content']['self_publish_begin'] ||
 					$blogContentData['Content']['self_publish_end'] != $this->request->data['Content']['self_publish_end']
-                ) {
+				) {
 					$successMessage = sprintf(__d('baser', 'ブログ「%s」を更新しました。サイト内検索機能を使用している場合は検索インデックスの再構築を行ってください。'), $this->request->data['Content']['title']);
 				}
 				$this->BcMessage->setSuccess($successMessage);

--- a/lib/Baser/Plugin/Blog/Controller/BlogContentsController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogContentsController.php
@@ -143,12 +143,18 @@ class BlogContentsController extends BlogAppController {
 			$this->request->data = $this->BlogContent->deconstructEyeCatchSize($this->request->data);
 			$this->BlogContent->set($this->request->data);
 
-			if ($this->BlogContent->save()) {
-				$this->BcMessage->setSuccess(sprintf(__d('baser', 'ブログ「%s」を更新しました。'), $this->request->data['Content']['title']));
-
-				if ($blogContentData['Content']['name'] !== $this->request->data['Content']['name']) {
-					$this->BcMessage->setInfo(sprintf(__d('baser', 'ブログのURLを変更した際は、検索インデックスの再構築をしてください。')));
+			if ($this->BlogContent->save(null, ['skipBlogPostSearchIndexSave' => true])) {
+				$successMessage = sprintf(__d('baser', 'ブログ「%s」を更新しました。'), $this->request->data['Content']['title']);
+				if (
+					$blogContentData['Content']['name'] != $this->request->data['Content']['name'] ||
+					$blogContentData['Content']['exclude_search'] != $this->request->data['Content']['exclude_search'] ||
+					$blogContentData['Content']['self_status'] != $this->request->data['Content']['self_status'] ||
+					$blogContentData['Content']['self_publish_begin'] != $this->request->data['Content']['self_publish_begin'] ||
+					$blogContentData['Content']['self_publish_end'] != $this->request->data['Content']['self_publish_end']
+                ) {
+					$successMessage = sprintf(__d('baser', 'ブログ「%s」を更新しました。サイト内検索機能を使用している場合は検索インデックスの再構築を行ってください。'), $this->request->data['Content']['title']);
 				}
+				$this->BcMessage->setSuccess($successMessage);
 				if ($this->request->data['BlogContent']['edit_blog_template']) {
 					$this->redirectEditBlog($this->request->data['BlogContent']['template']);
 				} else {

--- a/lib/Baser/Plugin/Blog/Model/BlogContent.php
+++ b/lib/Baser/Plugin/Blog/Model/BlogContent.php
@@ -164,14 +164,6 @@ class BlogContent extends BlogAppModel {
 		if (!$this->data['Content']['exclude_search'] && $this->data['Content']['status']) {
 			$this->saveSearchIndex($this->createSearchIndex($this->data));
 			clearDataCache();
-			$datas = $this->BlogPost->find('all', [
-				'conditions' => ['BlogPost.blog_content_id' => $this->data['BlogContent']['id']],
-				'recursive' => -1
-			]);
-			foreach($datas as $data) {
-				$this->BlogPost->set($data);
-				$this->BlogPost->afterSave(true);
-			}
 		} else {
 			$this->deleteSearchIndex($this->data['BlogContent']['id']);
 		}

--- a/lib/Baser/Plugin/Blog/Model/BlogContent.php
+++ b/lib/Baser/Plugin/Blog/Model/BlogContent.php
@@ -164,6 +164,16 @@ class BlogContent extends BlogAppModel {
 		if (!$this->data['Content']['exclude_search'] && $this->data['Content']['status']) {
 			$this->saveSearchIndex($this->createSearchIndex($this->data));
 			clearDataCache();
+			if (empty($options['skipBlogPostSearchIndexSave'])) {
+				$datas = $this->BlogPost->find('all', [
+					'conditions' => ['BlogPost.blog_content_id' => $this->data['BlogContent']['id']],
+					'recursive' => -1
+				]);
+				foreach($datas as $data) {
+					$this->BlogPost->set($data);
+					$this->BlogPost->afterSave(true);
+				}
+			}
 		} else {
 			$this->deleteSearchIndex($this->data['BlogContent']['id']);
 		}


### PR DESCRIPTION
以下のissueでブログ設定保存時のブログ記事のインデックス登録は、「検索インデックスの再構築」に任せるという方針でしたので対応を行いました。

【ブログ】ブログ記事の件数が多い場合にブログ設定を保存しようとするとエラーになる
https://github.com/baserproject/basercms/issues/1424

ご確認をお願いします。
