### PR TITLE
【ブログ】ブログカテゴリごとの記事数を表示した際に親カテゴリの記事数が子カテゴリの記事数の合計にならない問題を修正 #1496

### DIFF
--- a/lib/Baser/Plugin/Blog/Model/BlogCategory.php
+++ b/lib/Baser/Plugin/Blog/Model/BlogCategory.php
@@ -201,7 +201,7 @@ class BlogCategory extends BlogAppModel {
 			'limit' => false,
 			'viewCount' => false,
 			'parentId' => null,
-			'fields' => ['BlogCategory.id', 'BlogCategory.name', 'BlogCategory.title'],
+			'fields' => ['BlogCategory.id', 'BlogCategory.name', 'BlogCategory.title', 'BlogCategory.lft', 'BlogCategory.rght'],
 		], $options);
 		$fields = $options['fields'];
 		$depth = $options['depth'];
@@ -306,10 +306,22 @@ class BlogCategory extends BlogAppModel {
 		if ($datas && $findType == 'all') {
 			foreach ($datas as $key => $data) {
 				if ($viewCount) {
+					$childrenIds = $this->find('list', array(
+						'fields' => ['id'],
+						'conditions' => array(
+							['BlogCategory.lft > ' => $data['BlogCategory']['lft']],
+							['BlogCategory.rght < ' => $data['BlogCategory']['rght']],
+						),
+						'recursive' => -1
+					));
+					$categoryId = [$data['BlogCategory']['id']];
+					if($childrenIds){
+						$categoryId = array_merge($categoryId, $childrenIds);
+					}
 					$datas[$key]['BlogCategory']['count'] = $this->BlogPost->find('count', [
 						'conditions' =>
 						array_merge(
-							['BlogPost.blog_category_id' => $data['BlogCategory']['id']], $this->BlogPost->getConditionAllowPublish()
+							['BlogPost.blog_category_id' => $categoryId], $this->BlogPost->getConditionAllowPublish()
 						),
 						'cache' => false
 					]);

--- a/lib/Baser/Plugin/Blog/Test/Case/View/Helper/BlogHelperTest.php
+++ b/lib/Baser/Plugin/Blog/Test/Case/View/Helper/BlogHelperTest.php
@@ -438,7 +438,7 @@ class BlogHelperTest extends BaserTestCase {
 			[3, false, [], '<ul class="depth-1"><li><a href="/news/archives/category/release">プレスリリース</a><ul class="depth-2"><li><a href="/news/archives/category/release/child">子カテゴリ</a></li></ul></li><li><a href="/news/archives/category/child-no-parent">親子関係なしカテゴリ</a></li></ul>'],
 			[1, false, [], '<ul class="depth-1"><li><a href="/news/archives/category/release">プレスリリース</a></li><li><a href="/news/archives/category/child-no-parent">親子関係なしカテゴリ</a></li></ul>'],
 			[0, false, [], ''],
-			[3, true, [], '<ul class="depth-1"><li><a href="/news/archives/category/release">プレスリリース(1)</a><ul class="depth-2"><li><a href="/news/archives/category/release/child">子カテゴリ(2)</a></li></ul></li><li><a href="/news/archives/category/child-no-parent">親子関係なしカテゴリ(0)</a></li></ul>'],
+			[3, true, [], '<ul class="depth-1"><li><a href="/news/archives/category/release">プレスリリース(3)</a><ul class="depth-2"><li><a href="/news/archives/category/release/child">子カテゴリ(2)</a></li></ul></li><li><a href="/news/archives/category/child-no-parent">親子関係なしカテゴリ(0)</a></li></ul>'],
 		];
 	}
 


### PR DESCRIPTION
下記Issue対応しました。
https://github.com/baserproject/basercms/issues/1496