### PR TITLE
fix  #1514 【メール】全角カタカナチェックの際にスペースも許可したい問題を解決

### DIFF
--- a/lib/Baser/Plugin/Mail/Model/MailMessage.php
+++ b/lib/Baser/Plugin/Mail/Model/MailMessage.php
@@ -300,7 +300,7 @@ class MailMessage extends MailAppModel {
 						}
 					}
 				} elseif (in_array('VALID_ZENKAKU_KATAKANA', $valids)) {
-					if(!preg_match('/^(|[ァ-ヾ]+)$/u', $data['MailMessage'][$mailField['field_name']])) {
+					if(!preg_match('/^(|[ァ-ヾ 　]+)$/u', $data['MailMessage'][$mailField['field_name']])) {
 						$this->invalidate($mailField['field_name'], __('全て全角カタカナで入力してください。'));
 					}
 				}


### PR DESCRIPTION
案件で発生。
フリガナの入力の際に姓・名の間にスペースを入れてもバリデーションが通るようにしたい。

例）タカヤマ タロウ
（現在はエラーになります。）

対応内容
正規表現のカナチェックに
・「 」（半角スペース）
・「　」（全角スペース）
を追加
