### PR TITLE
fix #1536 コンテンツ編集画面のURL表示のリンクの箇所がエスケープされている問題を解決

### DIFF
--- a/app/webroot/theme/admin-third/Elements/admin/content_fields.php
+++ b/app/webroot/theme/admin-third/Elements/admin/content_fields.php
@@ -119,7 +119,7 @@ if($this->BcContents->isEditable()) {
 				<?php echo $this->BcForm->error('Content.name') ?>
 				<?php echo $this->BcForm->error('Content.parent_id') ?>
 				<span class="bca-post__url">
-          			<?php echo h($linkedFullUrl) ?>
+          			<?php echo strip_tags($linkedFullUrl, '<a>') ?>
         		</span>
 			</td>
 		</tr>


### PR DESCRIPTION
@gondoh 
@ryuring 
お手数ですが、ご確認の上、マージお願いできますでしょうか？