### PR TITLE
fix #1538 サブサイトのコンテンツ編集画面のリンクURLがおかしくなる問題

### DIFF
--- a/lib/Baser/View/Helper/BcContentsHelper.php
+++ b/lib/Baser/View/Helper/BcContentsHelper.php
@@ -609,7 +609,8 @@ class BcContentsHelper extends AppHelper {
 		} else {
 			$host = $this->getUrl('/', true, $content['Site']['use_subdomain']);
 		}
-		if($content['Site']['alias']) {
+		/* サブサイトであっても、urlが「/エイリアス/」のときは、検索条件に追加しない */
+		if($content['Site']['alias'] && $content['Site']['alias'] !== $urlArray[0]) {
 			$checkUrl = '/' . $content['Site']['alias'] . '/';
 		} else {
 			$checkUrl = '/';


### PR DESCRIPTION
@ryuring 

該当問題の修正にて

lib/Baser/View/Helper/BcContentsHelper.php
getFolderLinkedUrl()
の、サブサイトのエイリアスの判定に $urlarrayの最初とサブサイトのエイリアスが同じではないことを条件として追加しました。

ご確認の上、マージをお願いできますでしょうか？