### PR TITLE
サイト名・GoogleMaps住所にシングルクオートが含まれているときの表示不具合を修正

### DIFF
--- a/lib/Baser/Config/theme/bc_sample/Elements/google_maps.php
+++ b/lib/Baser/Config/theme/bc_sample/Elements/google_maps.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * グールグルマップ：スマホ用
+ * グーグルマップ
  *
  * $this->BcBaser->googleMaps() で呼び出す
  */
@@ -8,8 +8,8 @@ $_width = 600;
 $_height = 400;
 $_zoom = 16;
 $_mapId = 'map';
-$_address = $this->BcBaser->siteConfig['address'];
-$_markerText = '<span class="sitename">' . $this->BcBaser->siteConfig['name'] . '</span><br><span class="address">' . $_address . '</span>';
+$_address = h($this->BcBaser->siteConfig['address']);
+$_markerText = '<span class="sitename">' . h($this->BcBaser->siteConfig['name']) . '</span><br><span class="address">' . $_address . '</span>';
 if (isset($width)) {
 	$_width = $width;
 }

--- a/lib/Baser/Config/theme/bc_sample/Elements/smartphone/google_maps.php
+++ b/lib/Baser/Config/theme/bc_sample/Elements/smartphone/google_maps.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * グールグルマップ（スマホ用）
+ * グーグルマップ（スマホ用）
  *
  * BcBaserHelper::googleMaps() で呼び出す
  * （例）<?php $this->BcBaser->googleMaps() ?>
@@ -11,8 +11,8 @@ $_width = 600;
 $_height = 400;
 $_zoom = 16;
 $_mapId = 'map';
-$_address = $this->BcBaser->siteConfig['address'];
-$_markerText = '<span class="sitename">' . $this->BcBaser->siteConfig['name'] . '</span><br><span class="address">' . $_address . '</span>';
+$_address = h($this->BcBaser->siteConfig['address']);
+$_markerText = '<span class="sitename">' . h($this->BcBaser->siteConfig['name']) . '</span><br><span class="address">' . $_address . '</span>';
 if (isset($width)) {
 	$_width = $width;
 }

--- a/lib/Baser/View/Elements/google_maps.php
+++ b/lib/Baser/View/Elements/google_maps.php
@@ -17,8 +17,8 @@ $_width = 600;
 $_height = 400;
 $_zoom = 16;
 $_mapId = 'map';
-$_address = $this->BcBaser->siteConfig['address'];
-$_markerText = '<span class="sitename">' . $this->BcBaser->siteConfig['name'] . '</span><br /><span class="address">' . $_address . '</span>';
+$_address = h($this->BcBaser->siteConfig['address']);
+$_markerText = '<span class="sitename">' . h($this->BcBaser->siteConfig['name']) . '</span><br /><span class="address">' . $_address . '</span>';
 if (isset($width)) {
 	$_width = $width;
 }

--- a/lib/Baser/View/Elements/smartphone/googlemaps.php
+++ b/lib/Baser/View/Elements/smartphone/googlemaps.php
@@ -11,7 +11,7 @@
  */
 
 /**
- * [SMARTPHONE] グールグルマップ
+ * [SMARTPHONE] グーグルマップ
  */
 $width = 294;
 $height = 400;


### PR DESCRIPTION
フォーラムのトピック

> サイト名にシングルクォートを使えるようにして欲しい
> https://forum.basercms.net/t/topic/440 

の修正です。レビューお願いいたします。