### PR TITLE
fix #1553 【検索】ブログを指定して記事を検索する機能が欲しい問題を解決

### DIFF
--- a/lib/Baser/Controller/SearchIndicesController.php
+++ b/lib/Baser/Controller/SearchIndicesController.php
@@ -175,6 +175,9 @@ class SearchIndicesController extends AppController {
 		if (isset($data['SearchIndex']['s'])) {
 			$conditions['SearchIndex.site_id'] = $data['SearchIndex']['s'];
 		}
+		if (isset($data['SearchIndex']['c'])) {
+			$conditions['SearchIndex.content_id'] = $data['SearchIndex']['c'];
+		}
 		if (!empty($data['SearchIndex']['f'])) {
 			$content = $this->Content->find('first', ['fields' => ['lft', 'rght'], 'conditions' => ['Content.id' => $data['SearchIndex']['f']], 'recursive' => -1]);
 			$conditions['SearchIndex.rght <='] = $content['Content']['rght'];


### PR DESCRIPTION
実際に使用する場合、
/element/site_serch_form.php などで

１，ブログコンテンツのリストを呼び出し

`$blogContents = $this->BcContents->getTree($this->BcContents->getSiteRootId($siteId), null, ['type' => 'BlogContent']);
$blogs = [];
foreach ($blogContents as $blogContent) {
	$blogs[$blogContent['Content']['id']] = $blogContent['Content']['title'];
}
`

２，検索の絞り込み条件に追加することができます。

`	<?php if (!empty($blogs)) : ?>
		<?php echo $this->BcForm->label('SearchIndex.c', __('ブログ')) ?><br>
		<?php echo $this->BcForm->input('SearchIndex.c', ['type' => 'select', 'options' => $blogs, 'empty' => __('指定しない'), 'escape' => false]) ?><br>
	<?php endif ?>
`