### PR TITLE
エスケープ漏れと二重エスケープの問題を修正

### DIFF
--- a/app/webroot/theme/admin-third/Contents/admin/ajax_contents_info.php
+++ b/app/webroot/theme/admin-third/Contents/admin/ajax_contents_info.php
@@ -15,7 +15,7 @@
 <?php if($sites): ?>
 <div class="bca-content-info">
 <?php foreach($sites as $site): ?>
-<h3 class="bca-content-info__title"><?php echo $site['Site']['display_name'] ?></h3>
+<h3 class="bca-content-info__title"><?php echo h($site['Site']['display_name']) ?></h3>
 <ul class="bca-content-info__list">
 	<li class="bca-content-info__list-item">
 		<?php echo sprintf(__d('baser', '公開中： %s ページ'), $site['published']) ?><br>

--- a/app/webroot/theme/admin-third/Elements/admin/content_fields.php
+++ b/app/webroot/theme/admin-third/Elements/admin/content_fields.php
@@ -137,7 +137,7 @@ if($this->BcContents->isEditable()) {
 					<?php echo $this->BcForm->input('Content.title', ['type' => 'text', 'size' => 50]) ?>　
 					<?php echo $this->BcForm->error('Content.title') ?>
 				<?php else: ?>
-					<?php echo $this->BcForm->value('Content.title') ?>　
+					<?php echo h($this->BcForm->value('Content.title')) ?>　
 					<?php echo $this->BcForm->hidden('Content.title') ?>
 				<?php endif ?>
 			</td>

--- a/app/webroot/theme/admin-third/Elements/admin/content_info.php
+++ b/app/webroot/theme/admin-third/Elements/admin/content_info.php
@@ -31,7 +31,7 @@
       <li class="bca-list__item"><span><?php echo __d('baser', 'コンテンツタイプ') ?></span>：<?php echo $this->request->data['Content']['type'] ?></li>
       <li class="bca-list__item"><span><?php echo __d('baser', 'データ作成日') ?></span>：<?php echo $this->BcTime->format('Y/m/d H:i:s', $this->request->data['Content']['created']) ?></li>
       <li class="bca-list__item"><span><?php echo __d('baser', 'データ更新日') ?></span>：<?php echo $this->BcTime->format('Y/m/d H:i:s', $this->request->data['Content']['modified']) ?></li>
-      <li class="bca-list__item"><span><?php echo __d('baser', 'サイト') ?></span>：<?php echo $this->BcText->noValue($this->request->data['Site']['display_name'], $mainSiteDisplayName) ?></li>
+      <li class="bca-list__item"><span><?php echo __d('baser', 'サイト') ?></span>：<?php echo $this->BcText->noValue(h($this->request->data['Site']['display_name']), h($mainSiteDisplayName)) ?></li>
       <li class="bca-list__item"><span><?php echo __d('baser', 'タイプ') ?></span>：
       <?php if(!$this->BcForm->value('Content.alias_id')): ?>
         <?php if(!empty($this->BcContents->settings[$this->BcForm->value('Content.type')])): ?>

--- a/app/webroot/theme/admin-third/Elements/admin/contents/index_row_table.php
+++ b/app/webroot/theme/admin-third/Elements/admin/contents/index_row_table.php
@@ -86,7 +86,7 @@ if($data['Content']['self_status']) {
 		<?php echo $this->BcText->booleanMark($data['Content']['status']); ?>
 	</td>
 	<td class="bca-table-listup__tbody-td" style="width:8%;text-align:center">
-		<?php echo $this->BcText->arrayValue($data['Content']['author_id'], $authors); ?>
+		<?php echo h($this->BcText->arrayValue($data['Content']['author_id'], $authors)); ?>
 	</td>
 
 	<?php echo $this->BcListTable->dispatchShowRow($data) ?>

--- a/app/webroot/theme/admin-third/Elements/admin/searches/blog_posts_index.php
+++ b/app/webroot/theme/admin-third/Elements/admin/searches/blog_posts_index.php
@@ -26,13 +26,13 @@ $users = $this->BcForm->getControlSource("BlogPost.user_id");
 <?php if ($this->BlogCategories): ?>
 	<span class="bca-search__input-item">
 		<?php echo $this->BcForm->label('BlogPost.blog_category_id', __d('baser', 'カテゴリー'), ['class' => 'bca-search__input-item-label']) ?>
-		<?php echo $this->BcForm->input('BlogPost.blog_category_id', ['type' => 'select', 'options' => $this->BlogCategories, 'escape' => false, 'empty' => __d('baser', '指定なし')]) ?>
+		<?php echo $this->BcForm->input('BlogPost.blog_category_id', ['type' => 'select', 'options' => $this->BlogCategories, 'empty' => __d('baser', '指定なし')]) ?>
 	</span>
 <?php endif ?>
 <?php if ($blogContent['BlogContent']['tag_use'] && $this->BlogTags): ?>
 	<span class="bca-search__input-item">
 		<?php echo $this->BcForm->label('BlogPost.blog_tag_id', __d('baser', 'タグ'), ['class' => 'bca-search__input-item-label']) ?>
-		<?php echo $this->BcForm->input('BlogPost.blog_tag_id', ['type' => 'select', 'options' => $this->BlogTags, 'escape' => false, 'empty' => __d('baser', '指定なし')]) ?>
+		<?php echo $this->BcForm->input('BlogPost.blog_tag_id', ['type' => 'select', 'options' => $this->BlogTags, 'empty' => __d('baser', '指定なし')]) ?>
 	</span>
 <?php endif ?>
 	<span class="bca-search__input-item">

--- a/app/webroot/theme/admin-third/Elements/admin/searches/contents_index.php
+++ b/app/webroot/theme/admin-third/Elements/admin/searches/contents_index.php
@@ -26,7 +26,7 @@
 <p class="bca-search__input-list">
 	<span class="bca-search__input-item">
 		<?php echo $this->BcForm->label('Content.folder_id', __d('baser', 'フォルダ'), ['class' => 'bca-search__input-item-label']) ?>
-		<?php echo $this->BcForm->input('Content.folder_id', ['type' => 'select', 'options' => $folders, 'empty' => __d('baser', '指定なし'), 'escape' => false]) ?>
+		<?php echo $this->BcForm->input('Content.folder_id', ['type' => 'select', 'options' => $folders, 'empty' => __d('baser', '指定なし')]) ?>
 	</span>
 	<span class="bca-search__input-item">
 		<?php echo $this->BcForm->label('Content.name', __d('baser', '名称'), ['class' => 'bca-search__input-item-label']) ?>

--- a/app/webroot/theme/admin-third/Elements/admin/searches/search_indices_index.php
+++ b/app/webroot/theme/admin-third/Elements/admin/searches/search_indices_index.php
@@ -40,7 +40,7 @@ $types = BcUtil::unserialize($this->BcBaser->siteConfig['content_types']);
 	<?php $this->BcBaser->img('admin/ajax-loader-s.gif', ['style' => 'vertical-align:middle;display:none', 'id' => 'SearchIndexSiteIdLoader']) ?>
 	<span class="bca-search__input-item">
 		<?php echo $this->BcForm->label('SearchIndex.folder_id', __d('baser', 'フォルダ'), ['class' => 'bca-search__input-item-label']) ?>
-		<?php echo $this->BcForm->input('SearchIndex.folder_id', ['type' => 'select', 'options' => $folders, 'empty' => __d('baser', '指定なし'), 'escape' => false]) ?>
+		<?php echo $this->BcForm->input('SearchIndex.folder_id', ['type' => 'select', 'options' => $folders, 'empty' => __d('baser', '指定なし')]) ?>
 	</span>
 	<span class="bca-search__input-item">
 		<?php echo $this->BcForm->label('SearchIndex.keyword', __d('baser', 'キーワード'), ['class' => 'bca-search__input-item-label']) ?>

--- a/app/webroot/theme/admin-third/Elements/admin/sites/index_row.php
+++ b/app/webroot/theme/admin-third/Elements/admin/sites/index_row.php
@@ -26,7 +26,7 @@ $url = $this->BcContents->getUrl('/' . $data['Site']['alias'] . '/', true, $data
 
 <tr id="Row<?php echo $count ?>" <?php echo $class; ?>>
 	<td class="bca-table-listup__tbody-td" style="width:5%"><?php echo $data['Site']['id']; ?></td>
-	<td class="bca-table-listup__tbody-td"><?php echo $data['Site']['display_name'] ?></td>
+	<td class="bca-table-listup__tbody-td"><?php echo h($data['Site']['display_name']) ?></td>
 	<td class="bca-table-listup__tbody-td"><?php $this->BcBaser->link($data['Site']['name'], ['action' => 'edit', $data['Site']['id']]); ?><br>
 		<?php echo $data['Site']['alias'] ?>
 	</td>

--- a/app/webroot/theme/admin-third/Elements/admin/sites/index_row.php
+++ b/app/webroot/theme/admin-third/Elements/admin/sites/index_row.php
@@ -37,7 +37,7 @@ $url = $this->BcContents->getUrl('/' . $data['Site']['alias'] . '/', true, $data
 		<?php echo $this->BcText->arrayValue($data['Site']['device'], $devices, ''); ?><br>
 		<?php echo $this->BcText->arrayValue($data['Site']['lang'], $langs, ''); ?>
 	</td>
-	<td class="bca-table-listup__tbody-td"><?php echo $this->BcText->arrayValue($data['Site']['main_site_id'], $mainSites, ''); ?><br>
+	<td class="bca-table-listup__tbody-td"><?php echo h($this->BcText->arrayValue($data['Site']['main_site_id'], $mainSites, ''), false); ?><br>
 		<?php echo $this->BcText->noValue($data['Site']['theme'], $this->BcBaser->siteConfig['theme']) ?>
 	</td>
 	<?php echo $this->BcListTable->dispatchShowRow($data) ?>

--- a/app/webroot/theme/admin-third/Elements/admin/users/index_row.php
+++ b/app/webroot/theme/admin-third/Elements/admin/users/index_row.php
@@ -19,7 +19,7 @@
 	<td class="bca-table-listup__tbody-td"><?php echo $data['User']['id'] ?></td>
 	<td class="bca-table-listup__tbody-td"><?php $this->BcBaser->link($data['User']['name'], ['action' => 'edit', $data['User']['id']], ['escape' => true]) ?></td>
 	<td class="bca-table-listup__tbody-td"><?php echo h($data['User']['nickname']) ?></td>
-	<td class="bca-table-listup__tbody-td"><?php echo $this->BcText->listValue('User.user_group_id', $data['User']['user_group_id']); ?></td>
+	<td class="bca-table-listup__tbody-td"><?php echo h($this->BcText->listValue('User.user_group_id', $data['User']['user_group_id'])); ?></td>
 	<td class="bca-table-listup__tbody-td"><?php echo h($data['User']['real_name_1']) ?>
 		&nbsp;<?php echo h($data['User']['real_name_2']) ?></td>
 	<?php echo $this->BcListTable->dispatchShowRow($data) ?>

--- a/app/webroot/theme/admin-third/Users/admin/form.php
+++ b/app/webroot/theme/admin-third/Users/admin/form.php
@@ -169,7 +169,7 @@ $this->BcBaser->js('admin/users/edit', false);
 			</ul>
 		<?php endif ?>
 		<?php if ($this->Session->check('AuthAgent') || $this->BcBaser->isAdminUser()): ?>
-			<div class="submit"><?php echo $this->BcForm->button($this->request->data['UserGroup']['title'] . 'グループの初期値に設定', ['label' => __d('baser', 'グループ初期データに設定'), 'id' => 'btnSetUserGroupDefault', 'class' => 'button bca-btn']) ?></div>
+			<div class="submit"><?php echo $this->BcForm->button(h($this->request->data['UserGroup']['title']) . 'グループの初期値に設定', ['label' => __d('baser', 'グループ初期データに設定'), 'id' => 'btnSetUserGroupDefault', 'class' => 'button bca-btn']) ?></div>
 		<?php endif ?>
 	</div>
 <?php endif ?>

--- a/lib/Baser/Config/theme/bc_sample/Blog/default/archives.php
+++ b/lib/Baser/Config/theme/bc_sample/Blog/default/archives.php
@@ -20,7 +20,7 @@ $this->BcBaser->setDescription($this->Blog->getTitle() . '｜' . $this->BcBaser-
 ?>
 
 
-<h2 class="bs-blog-title"><?php $this->Blog->title() ?></h2>
+<h2 class="bs-blog-title"><?php $this->Blog->title(true) ?></h2>
 
 <h3 class="bs-blog-category-title"><?php $this->BcBaser->contentsTitle() ?></h3>
 

--- a/lib/Baser/Config/theme/bc_sample/Blog/default/index.php
+++ b/lib/Baser/Config/theme/bc_sample/Blog/default/index.php
@@ -21,7 +21,7 @@ $this->BcBaser->setDescription($this->Blog->getDescription());
 ?>
 
 
-<h2 class="bs-blog-title"><?php $this->Blog->title() ?></h2>
+<h2 class="bs-blog-title"><?php $this->Blog->title(true) ?></h2>
 
 <?php if ($this->Blog->descriptionExists()): ?>
 <div class="bs-blog-description"><?php $this->Blog->description() ?></div>

--- a/lib/Baser/Config/theme/bc_sample/Blog/default/single.php
+++ b/lib/Baser/Config/theme/bc_sample/Blog/default/single.php
@@ -21,7 +21,7 @@ $this->BcBaser->setDescription($this->Blog->getTitle() . '｜' . $this->Blog->ge
 ?>
 
 
-<h2 class="bs-blog-title"><?php $this->Blog->title() ?></h2>
+<h2 class="bs-blog-title"><?php $this->Blog->title(true) ?></h2>
 
 <h3 class="bs-blog-post-title"><?php $this->BcBaser->contentsTitle() ?></h3>
 

--- a/lib/Baser/Config/theme/bc_sample/Elements/widgets/search.php
+++ b/lib/Baser/Config/theme/bc_sample/Elements/widgets/search.php
@@ -46,7 +46,7 @@ $folders = $this->BcContents->getContentFolderList($siteId, ['excludeId' => $thi
 		<?php echo $this->BcForm->label('SearchIndex.f', __('カテゴリ')) ?><br>
 		<?php echo $this->BcForm->input('SearchIndex.f', ['type' => 'select', 'options' => $folders, 'empty' => __('指定しない')]) ?><br>
 	<?php endif ?>
-	<?php echo $this->BcForm->input('SearchIndex.q', ['placeholder' => __('キーワード')]) ?>
+	<?php echo $this->BcForm->input('SearchIndex.q', ['placeholder' => __('キーワード'), 'escape' => false]) ?>
 	<?php echo $this->BcForm->hidden('SearchIndex.s', ['value' => $siteId]) ?>
 	<?php echo $this->BcForm->submit(__('検索'), ['div' => false, 'class' => 'bs-button-small']) ?>
 	<?php echo $this->BcForm->end() ?>

--- a/lib/Baser/Config/theme/bc_sample/Elements/widgets/search.php
+++ b/lib/Baser/Config/theme/bc_sample/Elements/widgets/search.php
@@ -44,7 +44,7 @@ $folders = $this->BcContents->getContentFolderList($siteId, ['excludeId' => $thi
 	<?php echo $this->BcForm->create('SearchIndex', ['type' => 'get', 'url' => $url]) ?>
 	<?php if($folders): ?>
 		<?php echo $this->BcForm->label('SearchIndex.f', __('カテゴリ')) ?><br>
-		<?php echo $this->BcForm->input('SearchIndex.f', ['type' => 'select', 'options' => $folders, 'empty' => __('指定しない'), 'escape' => false]) ?><br>
+		<?php echo $this->BcForm->input('SearchIndex.f', ['type' => 'select', 'options' => $folders, 'empty' => __('指定しない')]) ?><br>
 	<?php endif ?>
 	<?php echo $this->BcForm->input('SearchIndex.q', ['placeholder' => __('キーワード')]) ?>
 	<?php echo $this->BcForm->hidden('SearchIndex.s', ['value' => $siteId]) ?>

--- a/lib/Baser/Config/theme/bccolumn/Elements/site_search_form.php
+++ b/lib/Baser/Config/theme/bccolumn/Elements/site_search_form.php
@@ -15,7 +15,7 @@ if (!empty($this->passedArgs['num'])) {
 
 <div class="section search-box">
 	<?php echo $this->BcForm->create('SearchIndex', array('type' => 'get', 'url' => $url)) ?>
-	<?php echo $this->BcForm->input('SearchIndex.q') ?>
+	<?php echo $this->BcForm->input('SearchIndex.q', ['escape' => false]) ?>
 	<?php echo $this->BcForm->hidden('SearchIndex.site_id', ['value' => 0]) ?>
 	<?php echo $this->BcForm->submit('検索', array('div' => false, 'class' => 'submit_button button')) ?>
 	<?php echo $this->BcForm->end() ?>

--- a/lib/Baser/Config/theme/bccolumn/Layouts/default.php
+++ b/lib/Baser/Config/theme/bccolumn/Layouts/default.php
@@ -72,7 +72,7 @@ $(function(){
 	<div id="PageTitle">
 	    <div class="body-wrap">
 	    <?php if (!empty($this->Blog)): ?>
-	        <h1><?php $this->Blog->title() ?></h1>
+	        <h1><?php $this->Blog->title(true) ?></h1>
     	<?php else: ?>
 	        <h1><?php $this->BcBaser->contentsTitle() ?></h1>
 	    <?php endif ?>

--- a/lib/Baser/Config/theme/bccolumn/Layouts/left_column.php
+++ b/lib/Baser/Config/theme/bccolumn/Layouts/left_column.php
@@ -56,7 +56,7 @@
 	<div id="PageTitle">
 	    <div class="body-wrap">
 	    <?php if (!empty($this->Blog)): ?>
-	        <h1><?php $this->Blog->title() ?></h1>
+	        <h1><?php $this->Blog->title(true) ?></h1>
     	<?php else: ?>
 	        <h1><?php $this->BcBaser->contentsTitle() ?></h1>
 	    <?php endif ?>

--- a/lib/Baser/Config/theme/bccolumn/Layouts/right_column.php
+++ b/lib/Baser/Config/theme/bccolumn/Layouts/right_column.php
@@ -56,7 +56,7 @@
 	<div id="PageTitle">
 	    <div class="body-wrap">
 	    <?php if (!empty($this->Blog)): ?>
-	        <h1><?php $this->Blog->title() ?></h1>
+	        <h1><?php $this->Blog->title(true) ?></h1>
     	<?php else: ?>
 	        <h1><?php $this->BcBaser->contentsTitle() ?></h1>
 	    <?php endif ?>

--- a/lib/Baser/Config/theme/nada-icons/Blog/default/archives.php
+++ b/lib/Baser/Config/theme/nada-icons/Blog/default/archives.php
@@ -14,7 +14,7 @@ $(function(){
 </script>
 
 <h2 class="contents-head">
-<?php $this->Blog->title() ?>
+<?php $this->Blog->title(true) ?>
 </h2>
 <h3 class="contents-head">
 <?php $this->BcBaser->contentsTitle() ?>

--- a/lib/Baser/Config/theme/nada-icons/Blog/default/index.php
+++ b/lib/Baser/Config/theme/nada-icons/Blog/default/index.php
@@ -14,7 +14,7 @@ $(function(){
 	});
 </script>
 <h2 class="contents-head">
-<?php $this->Blog->title() ?>
+<?php $this->Blog->title(true) ?>
 </h2>
 <!-- blog description -->
 <?php if ($this->Blog->descriptionExists()): ?>

--- a/lib/Baser/Config/theme/nada-icons/Blog/default/single.php
+++ b/lib/Baser/Config/theme/nada-icons/Blog/default/single.php
@@ -16,7 +16,7 @@ $(function(){
 
 
 <h2 class="contents-head">
-<?php $this->Blog->title() ?>
+<?php $this->Blog->title(true) ?>
 </h2>
 <h3 class="contents-head">
 <?php $this->BcBaser->contentsTitle() ?>

--- a/lib/Baser/Config/theme/nada-icons/Elements/site_search_form.php
+++ b/lib/Baser/Config/theme/nada-icons/Elements/site_search_form.php
@@ -15,7 +15,7 @@ if (!empty($this->passedArgs['num'])) {
 
 <div class="section search-box">
 	<?php echo $this->BcForm->create('SearchIndex', ['type' => 'get', 'url' => $url]) ?>
-	<?php echo $this->BcForm->input('SearchIndex.q') ?>
+	<?php echo $this->BcForm->input('SearchIndex.q', ['escape' => false]) ?>
 	<?php echo $this->BcForm->hidden('SearchIndex.s', ['value' => 0]) ?>
 	<?php echo $this->BcForm->submit('検索', array('div' => false, 'class' => 'submit_button')) ?>
 	<?php echo $this->BcForm->end() ?>

--- a/lib/Baser/Controller/UsersController.php
+++ b/lib/Baser/Controller/UsersController.php
@@ -134,7 +134,7 @@ class UsersController extends AppController {
 				}
 				App::uses('BcBaserHelper', 'View/Helper');
 				$BcBaser = new BcBaserHelper(new View());
-				$this->BcMessage->setInfo(sprintf(__d('baser', 'ようこそ、%s さん。'), h($BcBaser->getUserName($user))));
+				$this->BcMessage->setInfo(sprintf(__d('baser', 'ようこそ、%s さん。'), $BcBaser->getUserName($user)));
 				$this->redirect($this->BcAuth->redirect());
 			} else {
 				$this->BcMessage->setError(__d('baser', 'アカウント名、パスワードが間違っています。'));

--- a/lib/Baser/Plugin/Blog/View/Blog/default/archives.php
+++ b/lib/Baser/Plugin/Blog/View/Blog/default/archives.php
@@ -26,7 +26,7 @@ $(function(){
 
 <!-- title -->
 <h1 class="contents-head">
-<?php $this->Blog->title() ?>
+<?php $this->Blog->title(true) ?>
 </h1>
 
 <!-- archives title -->

--- a/lib/Baser/Plugin/Blog/View/Blog/default/index.php
+++ b/lib/Baser/Plugin/Blog/View/Blog/default/index.php
@@ -25,7 +25,7 @@ $(function(){
 
 <!-- title -->
 <h1 class="contents-head">
-<?php $this->Blog->title() ?>
+<?php $this->Blog->title(true) ?>
 </h1>
 
 <!-- description -->

--- a/lib/Baser/Plugin/Blog/View/Blog/default/single.php
+++ b/lib/Baser/Plugin/Blog/View/Blog/default/single.php
@@ -26,7 +26,7 @@ $(function(){
 
 <!-- blog title -->
 <h1 class="contents-head">
-<?php $this->Blog->title() ?>
+<?php $this->Blog->title(true) ?>
 </h1>
 
 <!-- post title -->

--- a/lib/Baser/Plugin/Blog/View/Blog/smartphone/default/archives.php
+++ b/lib/Baser/Plugin/Blog/View/Blog/smartphone/default/archives.php
@@ -20,7 +20,7 @@ $this->BcBaser->setDescription(sprintf(__d('baser', '%s｜%sのアーカイブ�
 
 <!-- title -->
 <h1 class="contents-head">
-	<?php $this->Blog->title() ?>
+	<?php $this->Blog->title(true) ?>
 </h1>
 
 <!-- archives title -->

--- a/lib/Baser/Plugin/Blog/View/Blog/smartphone/default/index.php
+++ b/lib/Baser/Plugin/Blog/View/Blog/smartphone/default/index.php
@@ -20,7 +20,7 @@ $this->BcBaser->setDescription($this->Blog->getDescription());
 
 <!-- title -->
 <h1 class="contents-head">
-	<?php $this->Blog->title() ?>
+	<?php $this->Blog->title(true) ?>
 </h1>
 
 <!-- description -->

--- a/lib/Baser/Plugin/Blog/View/Blog/smartphone/default/single.php
+++ b/lib/Baser/Plugin/Blog/View/Blog/smartphone/default/single.php
@@ -20,7 +20,7 @@ $this->BcBaser->setDescription($this->Blog->getTitle() . '｜' . $this->Blog->ge
 
 <!-- blog title -->
 <h1 class="contents-head">
-	<?php $this->Blog->title() ?>
+	<?php $this->Blog->title(true) ?>
 </h1>
 
 <!-- post detail -->

--- a/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
+++ b/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
@@ -153,10 +153,11 @@ class BlogHelper extends AppHelper {
 /**
  * ブログタイトルを出力する
  *
+ * @param boolean $escape エスケープ処理を行うかどうか(初期値 : v4.4.3まではfalse)
  * @return void
  */
-	public function title() {
-		echo $this->getTitle();
+	public function title($escape = false) {
+		echo $escape ? h($this->getTitle($escape)) : $this->getTitle($escape);
 	}
 
 /**

--- a/lib/Baser/View/Contents/admin/ajax_contents_info.php
+++ b/lib/Baser/View/Contents/admin/ajax_contents_info.php
@@ -13,7 +13,7 @@
 
 
 <?php foreach($sites as $site): ?>
-<h3><?php echo $site['Site']['display_name'] ?></h3>
+<h3><?php echo h($site['Site']['display_name']) ?></h3>
 <ul style="margin-bottom:15px;">
 	<li><?php echo sprintf(__d('baser', '公開中： %s ページ'), $site['published']) ?><br>
 		<?php echo sprintf(__d('baser', '非公開： %s ページ'), $site['unpublished']) ?><br>

--- a/lib/Baser/View/Elements/admin/content_fields.php
+++ b/lib/Baser/View/Elements/admin/content_fields.php
@@ -140,7 +140,7 @@ if($this->BcContents->isEditable()) {
 			<tr>
 				<th><?php echo $this->BcForm->label('Content.name', 'URL') ?>&nbsp;<span class="required">*</span></th>
 				<td>
-					<smalL>[<?php echo __d('baser', 'サイト')?>]</smalL> <?php echo $this->BcText->noValue($this->request->data['Site']['display_name'], h($mainSiteDisplayName)) ?>　
+					<smalL>[<?php echo __d('baser', 'サイト')?>]</smalL> <?php echo h($this->BcText->noValue($this->request->data['Site']['display_name'], h($mainSiteDisplayName)), false) ?>　
 					<?php if(!$this->request->data['Content']['site_root']): ?>
 					<small>[<?php echo __d('baser', 'フォルダ')?>]</small>
 					<?php echo $this->BcForm->input('Content.parent_id', ['type' => 'select', 'options' => $parentContents, 'escape' => true]) ?>　

--- a/lib/Baser/View/Elements/admin/content_fields.php
+++ b/lib/Baser/View/Elements/admin/content_fields.php
@@ -140,7 +140,7 @@ if($this->BcContents->isEditable()) {
 			<tr>
 				<th><?php echo $this->BcForm->label('Content.name', 'URL') ?>&nbsp;<span class="required">*</span></th>
 				<td>
-					<smalL>[<?php echo __d('baser', 'サイト')?>]</smalL> <?php echo $this->BcText->noValue($this->request->data['Site']['display_name'], $mainSiteDisplayName) ?>　
+					<smalL>[<?php echo __d('baser', 'サイト')?>]</smalL> <?php echo $this->BcText->noValue($this->request->data['Site']['display_name'], h($mainSiteDisplayName)) ?>　
 					<?php if(!$this->request->data['Content']['site_root']): ?>
 					<small>[<?php echo __d('baser', 'フォルダ')?>]</small>
 					<?php echo $this->BcForm->input('Content.parent_id', ['type' => 'select', 'options' => $parentContents, 'escape' => true]) ?>　
@@ -166,7 +166,7 @@ if($this->BcContents->isEditable()) {
 						<?php echo $this->BcForm->input('Content.title', ['size' => 50]) ?>　
 						<?php echo $this->BcForm->error('Content.title') ?>
 					<?php else: ?>
-						<?php echo $this->BcForm->value('Content.title') ?>　
+						<?php echo h($this->BcForm->value('Content.title')) ?>　
 						<?php echo $this->BcForm->hidden('Content.title') ?>
 					<?php endif ?>
 					<small>[<?php echo __d('baser', 'タイプ')?>]</small>

--- a/lib/Baser/View/Elements/admin/contents/index_row_table.php
+++ b/lib/Baser/View/Elements/admin/contents/index_row_table.php
@@ -100,7 +100,7 @@ if($data['Content']['self_status']) {
 		<?php echo $this->BcText->booleanMark($data['Content']['status']); ?>
 	</td>
 	<td style="width:8%;text-align:center">
-		<?php echo $this->BcText->arrayValue($data['Content']['author_id'], $authors); ?>
+		<?php echo h($this->BcText->arrayValue($data['Content']['author_id'], $authors)); ?>
 	</td>
 	<?php echo $this->BcListTable->dispatchShowRow($data) ?>
 	<td style="width:8%;white-space: nowrap">

--- a/lib/Baser/View/Elements/admin/searches/contents_index.php
+++ b/lib/Baser/View/Elements/admin/searches/contents_index.php
@@ -21,7 +21,7 @@
 <p>
 	<span>
 		<?php echo $this->BcForm->label('Content.folder_id', __d('baser', 'フォルダ')) ?>
-		<?php echo $this->BcForm->input('Content.folder_id', ['type' => 'select', 'options' => $folders, 'empty' => __d('baser', '指定しない'), 'escape' => false]) ?>　
+		<?php echo $this->BcForm->input('Content.folder_id', ['type' => 'select', 'options' => $folders, 'empty' => __d('baser', '指定しない')]) ?>　
 	</span>
 	<span>
 		<?php echo $this->BcForm->label('Content.name', __d('baser', 'コンテンツ名')) ?>

--- a/lib/Baser/View/Elements/admin/searches/search_indices_index.php
+++ b/lib/Baser/View/Elements/admin/searches/search_indices_index.php
@@ -25,7 +25,7 @@ $types = BcUtil::unserialize($this->BcBaser->siteConfig['content_types']);
 	<span><?php echo $this->BcForm->label('SearchIndex.type', __d('baser', 'タイプ')) ?> <?php echo $this->BcForm->input('SearchIndex.type', ['type' => 'select', 'options' => $types, 'empty' => __d('baser', '指定なし')]) ?></span>
 	<span><?php echo $this->BcForm->label('SearchIndex.site_id', __d('baser', 'サブサイト')) ?> <?php echo $this->BcForm->input('SearchIndex.site_id', ['type' => 'select', 'options' => $sites]) ?></span>
 	<?php $this->BcBaser->img('admin/ajax-loader-s.gif', ['style' => 'vertical-align:middle;display:none', 'id' => 'SearchIndexSiteIdLoader']) ?>
-	<span><?php echo $this->BcForm->label('SearchIndex.folder_id', __d('baser', 'フォルダ')) ?> <?php echo $this->BcForm->input('SearchIndex.folder_id', ['type' => 'select', 'options' => $folders, 'empty' => __d('baser', '指定なし'), 'escape' => false]) ?></span>
+	<span><?php echo $this->BcForm->label('SearchIndex.folder_id', __d('baser', 'フォルダ')) ?> <?php echo $this->BcForm->input('SearchIndex.folder_id', ['type' => 'select', 'options' => $folders, 'empty' => __d('baser', '指定なし')]) ?></span>
 	<span><?php echo $this->BcForm->label('SearchIndex.keyword', __d('baser', 'キーワード')) ?> <?php echo $this->BcForm->input('SearchIndex.keyword', ['type' => 'text', 'size' => '30']) ?></span>
 	<span><?php echo $this->BcForm->label('SearchIndex.status', __d('baser', '公開状態')) ?> 
 		<?php echo $this->BcForm->input('SearchIndex.status', ['type' => 'select', 'options' => $this->BcText->booleanMarkList(), 'empty' => __d('baser', '指定なし')]) ?></span>　

--- a/lib/Baser/View/Elements/admin/sites/index_row.php
+++ b/lib/Baser/View/Elements/admin/sites/index_row.php
@@ -45,7 +45,7 @@ $url = $this->BcContents->getUrl('/' . $data['Site']['alias'] . '/', true, $data
 		<?php echo $this->BcText->arrayValue($data['Site']['device'], $devices, ''); ?><br>
 		<?php echo $this->BcText->arrayValue($data['Site']['lang'], $langs, ''); ?>
 	</td>
-	<td><?php echo $this->BcText->arrayValue($data['Site']['main_site_id'], $mainSites, ''); ?><br>
+	<td><?php echo h($this->BcText->arrayValue($data['Site']['main_site_id'], $mainSites, ''), false); ?><br>
 		<?php echo $this->BcText->noValue($data['Site']['theme'], $this->BcBaser->siteConfig['theme']) ?>
 	</td>
 	<?php echo $this->BcListTable->dispatchShowRow($data) ?>

--- a/lib/Baser/View/Elements/admin/sites/index_row.php
+++ b/lib/Baser/View/Elements/admin/sites/index_row.php
@@ -34,7 +34,7 @@ $url = $this->BcContents->getUrl('/' . $data['Site']['alias'] . '/', true, $data
 		<?php $this->BcBaser->link($this->BcBaser->getImg('admin/icn_tool_edit.png', ['alt' => __d('baser', '編集'), 'class' => 'btn']), ['action' => 'edit', $data['Site']['id']], ['title' => __d('baser', '編集')]) ?>
 	</td>
 	<td style="width:5%"><?php echo $data['Site']['id']; ?></td>
-	<td><?php echo $data['Site']['display_name'] ?></td>
+	<td><?php echo h($data['Site']['display_name']) ?></td>
 	<td><?php $this->BcBaser->link($data['Site']['name'], ['action' => 'edit', $data['Site']['id']]); ?><br>
 		<?php echo $data['Site']['alias'] ?>
 	</td>

--- a/lib/Baser/View/Elements/admin/users/index_row.php
+++ b/lib/Baser/View/Elements/admin/users/index_row.php
@@ -27,7 +27,7 @@
 	<td><?php echo $data['User']['id'] ?></td>
 	<td><?php $this->BcBaser->link(h($data['User']['name']), ['action' => 'edit', $data['User']['id']]) ?></td>
 	<td><?php echo h($data['User']['nickname']) ?></td>
-	<td><?php echo $this->BcText->listValue('User.user_group_id', $data['User']['user_group_id']); ?><br />
+	<td><?php echo h($this->BcText->listValue('User.user_group_id', $data['User']['user_group_id'])); ?><br />
 		<?php echo h($data['User']['real_name_1']); ?>&nbsp;<?php echo h($data['User']['real_name_2']) ?></td>
 	<?php echo $this->BcListTable->dispatchShowRow($data) ?>
 	<td><?php echo $this->BcTime->format('Y-m-d', $data['User']['created']) ?><br />

--- a/lib/Baser/View/Elements/site_search_form.php
+++ b/lib/Baser/View/Elements/site_search_form.php
@@ -34,7 +34,7 @@ $folders = $this->BcContents->getContentFolderList($siteId, ['excludeId' => $thi
 	<?php echo $this->BcForm->create('SearchIndex', ['type' => 'get', 'url' => $url]) ?>
 	<?php if($folders): ?>
 		<?php echo $this->BcForm->label('SearchIndex.f', __d('baser', 'カテゴリ')) ?><br>
-		<?php echo $this->BcForm->input('SearchIndex.f', ['type' => 'select', 'options' => $folders, 'empty' => __d('baser', '指定しない'), 'escape' => false]) ?><br>
+		<?php echo $this->BcForm->input('SearchIndex.f', ['type' => 'select', 'options' => $folders, 'empty' => __d('baser', '指定しない')]) ?><br>
 	<?php endif ?>
 	<?php echo $this->BcForm->input('SearchIndex.q', ['placeholder' => __d('baser', 'キーワード')]) ?>
 	<?php echo $this->BcForm->hidden('SearchIndex.s', ['value' => $siteId]) ?>

--- a/lib/Baser/View/Elements/site_search_form.php
+++ b/lib/Baser/View/Elements/site_search_form.php
@@ -36,7 +36,7 @@ $folders = $this->BcContents->getContentFolderList($siteId, ['excludeId' => $thi
 		<?php echo $this->BcForm->label('SearchIndex.f', __d('baser', 'カテゴリ')) ?><br>
 		<?php echo $this->BcForm->input('SearchIndex.f', ['type' => 'select', 'options' => $folders, 'empty' => __d('baser', '指定しない')]) ?><br>
 	<?php endif ?>
-	<?php echo $this->BcForm->input('SearchIndex.q', ['placeholder' => __d('baser', 'キーワード')]) ?>
+	<?php echo $this->BcForm->input('SearchIndex.q', ['placeholder' => __d('baser', 'キーワード'), 'escape' => false]) ?>
 	<?php echo $this->BcForm->hidden('SearchIndex.s', ['value' => $siteId]) ?>
 	<?php echo $this->BcForm->submit(__d('baser', '検索'), ['div' => false, 'class' => 'submit_button']) ?>
 	<?php echo $this->BcForm->end() ?>

--- a/lib/Baser/View/Elements/widgets/search.php
+++ b/lib/Baser/View/Elements/widgets/search.php
@@ -35,7 +35,7 @@ $folders = $this->BcContents->getContentFolderList($siteId, ['excludeId' => $thi
 
 <div class="widget widget-search-box widget-search-box-<?php echo $id ?>">
 	<?php echo $this->BcForm->create('SearchIndex', ['type' => 'get', 'url' => $url]) ?>
-	<?php echo $this->BcForm->input('SearchIndex.q') ?>
+	<?php echo $this->BcForm->input('SearchIndex.q', ['escape' => false]) ?>
 	<?php echo $this->BcForm->hidden('SearchIndex.s', ['value' => $siteId]) ?>
 	<?php echo $this->BcForm->submit(__d('baser', '検索'), ['div' => false, 'class' => 'submit_button']) ?>
 	<?php echo $this->BcForm->end() ?>

--- a/lib/Baser/View/Users/admin/form.php
+++ b/lib/Baser/View/Users/admin/form.php
@@ -164,7 +164,7 @@ $this->BcBaser->js('admin/users/edit', false);
 			</ul>
 		<?php endif ?>
 		<?php if ($this->Session->check('AuthAgent') || $this->BcBaser->isAdminUser()): ?>
-			<div class="submit"><?php echo $this->BcForm->button($this->request->data['UserGroup']['title'] . __d('baser', 'グループの初期値に設定'), ['label' => __d('baser', 'グループ初期データに設定'), 'id' => 'btnSetUserGroupDefault', 'class' => 'button']) ?></div>
+			<div class="submit"><?php echo $this->BcForm->button(h($this->request->data['UserGroup']['title']) . __d('baser', 'グループの初期値に設定'), ['label' => __d('baser', 'グループ初期データに設定'), 'id' => 'btnSetUserGroupDefault', 'class' => 'button']) ?></div>
 		<?php endif ?>
 	</div>
 <?php endif ?>


### PR DESCRIPTION
エスケープ漏れと二重エスケープの問題をひととおり修正しました。
改修箇所は多いですが、基本的には hで囲む・escapeパラメータのオンオフだけです。
外部からxssを仕込むような深刻な脆弱性につながる修正はありません。

https://github.com/baserproject/basercms/commit/e26e46c82ab10386a725f6970e496786d237b1eb
システム側(ヘルパー)で1ヶ所だけ変更を加えており、BlogHelper::title() にescapeパラメータを
追加しています。デフォルトではfalseとなっていて従来どおりの処理になるため、今までどおり
使うことができます。
