### PR TITLE
fix bc_sample テーマのメールフォームの書き直すボタンが動作していない件を修正

### DIFF
--- a/lib/Baser/Config/theme/bc_sample/Elements/mail_form.php
+++ b/lib/Baser/Config/theme/bc_sample/Elements/mail_form.php
@@ -61,11 +61,11 @@ $this->Mail->token();
 
 <div class="bs-mail-form-submit">
 	<?php if ($freezed): ?>
-		<?php echo $this->Mailform->submit('　' . __('書き直す') . '　', ['div' => false, 'id' => 'BtnMessageBack']) ?>
-		<?php echo $this->Mailform->submit('　' . __('送信する') . '　', ['div' => false, 'id' => 'BtnMessageSubmit']) ?>
+		<?php echo $this->Mailform->submit('　' . __('書き直す') . '　', ['div' => false, 'class' => 'form-submit', 'id' => 'BtnMessageBack']) ?>
+		<?php echo $this->Mailform->submit('　' . __('送信する') . '　', ['div' => false, 'class' => 'form-submit', 'id' => 'BtnMessageSubmit']) ?>
 	<?php else: ?>
 		<input name="resetdata" value="　取り消す　" type="reset" />
-		<?php echo $this->Mailform->submit('　' . __('入力内容を確認する') . '　', ['div' => false, 'id' => 'BtnMessageConfirm']) ?>
+		<?php echo $this->Mailform->submit('　' . __('入力内容を確認する') . '　', ['div' => false, 'class' => 'form-submit', 'id' => 'BtnMessageConfirm']) ?>
 	<?php endif; ?>
 </div>
 


### PR DESCRIPTION
bc_sample テーマのレスポンシブ対応時にメールフォームの動作に必要なクラス名が消えていたので該当箇所を戻しました。
（書き直すボタンを押すとそのまま送信の動作になってしまっておりました）

よろしくお願いいたします。