### PR TITLE
ブログ記事のタイトルに「/」が入る場合、削除時に「\/」と表示される問題を改善

### DIFF
--- a/app/webroot/theme/admin-third/js/admin/libs/jquery.bcToken.js
+++ b/app/webroot/theme/admin-third/js/admin/libs/jquery.bcToken.js
@@ -177,9 +177,7 @@
 				$(selector).click(function() {
 					if($(this).attr('data-confirm-message')) {
 						var message = $(this).attr('data-confirm-message');
-						message = message.replace(/\\u([a-fA-F0-9]{4})/g, function(matchedString, group) {
-							return String.fromCharCode(parseInt(group, 16));
-						}).replace(/\\n/g, '\n');
+						message = JSON.parse('"' + message + '"').replace(/\\n/g, '\n');
 						if(!confirm(message)) {
 							return false;
 						}

--- a/lib/Baser/webroot/js/admin/libs/jquery.bcToken.js
+++ b/lib/Baser/webroot/js/admin/libs/jquery.bcToken.js
@@ -177,9 +177,7 @@
 				$(selector).click(function() {
 					if($(this).attr('data-confirm-message')) {
 						var message = $(this).attr('data-confirm-message');
-						message = message.replace(/\\u([a-fA-F0-9]{4})/g, function(matchedString, group) {
-							return String.fromCharCode(parseInt(group, 16));
-						}).replace(/\\n/g, '\n');
+						message = JSON.parse('"' + message + '"').replace(/\\n/g, '\n');
 						if(!confirm(message)) {
 							return false;
 						}


### PR DESCRIPTION
## 概要

ブログ記事のタイトルに `/` が入る場合、削除時のアラートに`\/` と表示されている問題の改善を行いました。

## 原因

ブログ記事を削除する際には、削除ボタンに submit-tokenクラス がついている関係で、confirmイベントを書き換える処理が実行されます。
この、confirmのメッセージ取得後の変換処理が原因で、`/` が `\/` として表示されてしまっていました。

## 対応内容

もともとconfirmのイベントはJSONとしてHTMLに出力されます。
https://github.com/baserproject/basercms/blob/dev-4/lib/Cake/View/Helper.php#L553
これに合わせて、メッセージ表示時の変換もJSONとして処理するように変更を行いました。

ご確認お願いします。
