### PR TITLE
管理画面 ブログカテゴリ一覧 カテゴリ削除時のメッセージを調整

### DIFF
--- a/app/webroot/theme/admin-third/BlogCategories/admin/index.php
+++ b/app/webroot/theme/admin-third/BlogCategories/admin/index.php
@@ -32,7 +32,7 @@ $this->BcAdmin->addAdminMainBodyHeaderLinks([
 
 <?php
 $this->BcBaser->i18nScript([
-	'message1' => __d('baser', 'このデータを本当に削除してもいいですか？\nこのカテゴリに関連する記事は、どのカテゴリにも関連しない状態として残ります。'),
+	'message1' => __d('baser', "このデータを本当に削除してもいいですか？\nこのカテゴリに関連する記事は、どのカテゴリにも関連しない状態として残ります。"),
     'message2' => __d('baser', '削除に失敗しました。'),
 ]);
 ?>


### PR DESCRIPTION
アラート内の改行が`\n`として表示されていたので調整しています。
ご確認お願いします。