### PR TITLE
fix #1591 adminthirdを使用している場合、 システム管理グループに属していないユーザーで、固定ページのプレビュー時、co…

### DIFF
--- a/app/webroot/theme/admin-third/Pages/admin/form.php
+++ b/app/webroot/theme/admin-third/Pages/admin/form.php
@@ -75,6 +75,8 @@ $this->BcBaser->js('admin/pages/edit', false);
 	</table>
 </div>
 </section>
+<?php else: ?>
+	<?php echo $this->BcForm->input('Page.code', ['type' => 'hidden']) ?>
 <?php endif ?>
 
 <?php echo $this->BcFormTable->dispatchAfter() ?>


### PR DESCRIPTION
 [#1422 システム管理グループに属していないユーザーで、固定ページのプレビュー時、code欄に記載した内容が反映されないため #1423]
の内容をadminthirdに反映しました。