### PR TITLE
#1280 ブログのタグアーカイブで、閲覧中のブログタグ情報をビュー側で取得する機能を実装

### DIFF
--- a/lib/Baser/Plugin/Blog/Model/BlogTag.php
+++ b/lib/Baser/Plugin/Blog/Model/BlogTag.php
@@ -180,4 +180,19 @@ class BlogTag extends BlogAppModel {
 		$ajaxAddUrl = preg_replace('|^/index.php|', '', Router::url(['plugin' => 'blog', 'controller' => 'blog_tags', 'action' => 'ajax_add', $blogContentId]));
 		return $Permission->check($ajaxAddUrl, $userGroupId);
 	}
+
+/**
+ * 指定した名称のブログタグ情報を取得する
+ *
+ * @param string $name
+ * @return array
+ */
+	public function getByName($name) {
+		return $this->find('first', [
+			'conditions' => ['BlogTag.name' => $name],
+			'recursive' => -1,
+			'callbacks' => false,
+		]);
+	}
+
 }

--- a/lib/Baser/Plugin/Blog/Test/Case/Model/BlogTagTest.php
+++ b/lib/Baser/Plugin/Blog/Test/Case/Model/BlogTagTest.php
@@ -14,7 +14,7 @@ App::uses('BlogTag', 'Blog.Model');
 
 /**
  * Class BlogTagTest
- * 
+ *
  * @property BlogTag $BlogTag
  */
 class BlogTagTest extends BaserTestCase {
@@ -83,7 +83,7 @@ class BlogTagTest extends BaserTestCase {
 
 /**
  * ブログタグリスト取得
- * 
+ *
  * @param string $type
  * @param mixed $expected
  * @param array $options
@@ -102,7 +102,7 @@ class BlogTagTest extends BaserTestCase {
 		}
 		$this->assertEquals($expected, $result);
 	}
-	
+
 	public function findCustomParamsDataProvider() {
 		return [
 			['count', 5, []],
@@ -115,5 +115,26 @@ class BlogTagTest extends BaserTestCase {
 			['id', [5, 4, 3, 2, 1], ['sort' => 'id', 'direction' => 'DESC']],	// 並び替え指定
 		];
 	}
-	
+
+/**
+ * 指定した名称のブログタグ情報を取得する
+ * @dataProvider getByNameDataProvider
+ * @param string $name
+ * @param bool $expects
+ */
+	public function testGetByName($name, $expects) {
+		$result = $this->BlogTag->getByName($name);
+		$this->assertEquals($expects, (bool) $result);
+	}
+
+	public function getByNameDataProvider() {
+		return [
+			['タグ１', true],
+			['タグ２', true],
+			['新製品', false],
+			['%90V%90%BB%95i', false], // 文字列 新製品 をURLエンコード化
+			['hoge', false],
+		];
+	}
+
 }

--- a/lib/Baser/Plugin/Blog/Test/Case/View/Helper/BlogHelperTest.php
+++ b/lib/Baser/Plugin/Blog/Test/Case/View/Helper/BlogHelperTest.php
@@ -1060,4 +1060,85 @@ class BlogHelperTest extends BaserTestCase {
 		$this->assertEquals(10, $this->Blog->getPostCount());
 	}
 
+	/**
+	 * ブログのアーカイブタイプを取得する
+	 * @dataProvider getBlogArchiveTypeDataProvider
+	 */
+	public function testGetBlogArchiveType($url, $type, $expects) {
+		$this->Blog->request = $this->_getRequest($url);
+		$this->View->set('blogArchiveType', $type);
+		$result = $this->Blog->getBlogArchiveType();
+		$this->assertEquals($type, $result);
+
+		$isArchive = false;
+		if ($expects) {
+			$isArchive = true;
+		}
+		$this->assertEquals($expects, $isArchive);
+	}
+
+	public function getBlogArchiveTypeDataProvider() {
+		return [
+			['/news/archives/category/release', 'category', true],
+			['/news/archives/tag/新製品', 'tag', true],
+			['/news/archives/archives/date/2016', 'yearly', true],
+			['/news/archives/archives/date/2016/02', 'monthly', true],
+			['/news/archives/archives/date/2016/02/10', 'daily', true],
+			['/news/archives/hoge', 'hoge', false], // 存在しないアーカイブの場合
+			['/news/', '', false],
+		];
+	}
+
+	/**
+	 * タグ別記事一覧ページ判定
+	 * @dataProvider isTagDataProvider
+	 */
+	public function testIsTag($type, $expects) {
+		$this->View->set('blogArchiveType', $type);
+		$result = $this->Blog->isTag();
+		$this->assertEquals($expects, $result);
+	}
+
+	public function isTagDataProvider() {
+		return [
+			['category', false],
+			['tag', true],
+			['yearly', false],
+			['monthly', false],
+			['daily', false],
+			['hoge', false], // 存在しないアーカイブの場合
+			['', false], // アーカイブ指定がない場合
+		];
+	}
+
+	/**
+	 * 現在のブログタグアーカイブのブログタグ情報を取得する
+	 * @dataProvider getCurrentBlogTagDataProvider
+	 */
+	public function testGetCurrentBlogTag($url, $type, $isTag, $expects) {
+		$this->Blog->request = $this->_getRequest($url);
+		$this->View->set('blogArchiveType', $type);
+
+		$result = $this->Blog->isTag();
+		$this->assertEquals($isTag, $result);
+
+		$result = $this->Blog->getCurrentBlogTag();
+		$this->assertEquals($expects, $result);
+	}
+
+	public function getCurrentBlogTagDataProvider() {
+		return [
+			['/news/archives/tag/新製品', 'tag', true, [
+				'BlogTag' => [
+					'name' => '新製品',
+					'id' => '1',
+					'created' => '2015-08-10 18:57:47',
+					'modified' => null,
+				],
+			]],
+			['/news/archives/tag/test1', 'tag', true, []],
+			['/news/archives/category/test2', 'category', false, []],
+		];
+	}
+
 }

--- a/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
+++ b/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
@@ -1870,4 +1870,20 @@ class BlogHelper extends AppHelper {
 		return false;
 	}
 
+/**
+ * 現在のブログタグアーカイブのブログタグ情報を取得する
+ *
+ * @return array
+ */
+	public function getCurrentBlogTag() {
+		$blogTag = [];
+		if ($this->isTag()) {
+			$pass = $this->request->params['pass'];
+			$name = isset($pass[1]) ? $pass[1] : '';
+			$BlogTagModel = ClassRegistry::init('Blog.BlogTag');
+			$blogTag = $BlogTagModel->getByName(urldecode($name));
+		}
+		return $blogTag;
+	}
+
 }


### PR DESCRIPTION
再挑戦です。可能な際に取込み検討お願いします。

- issueはこちら https://github.com/baserproject/basercms/issues/1280
- travis-ci の結果はこちら https://travis-ci.org/github/materializing/basercms/builds/751927334

