### PR TITLE
fix #1577 【メール】リファクタリング

### DIFF
--- a/lib/Baser/Plugin/Mail/Controller/MailContentsController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailContentsController.php
@@ -84,17 +84,22 @@ class MailContentsController extends MailAppController {
 		}
 		$this->request->data['MailContent'] = $this->MailContent->getDefaultValue()['MailContent'];
 		$data = $this->MailContent->save($this->request->data);
-		if ($data) {
-			$this->MailMessage->createTable($data['MailContent']['id']);
-			$message = sprintf(__d('baser', 'メールフォーム「%s」を追加しました。'), $this->request->data['Content']['title']);
-			$this->BcMessage->setSuccess($message, true, false);
-			return json_encode($data['Content']);
-		} else {
+		if (!$data) {
 			$this->ajaxError(500, $this->MailContent->validationErrors);
+			return false;
 		}
-		return false;
+		$this->MailMessage->createTable($data['MailContent']['id']);
+		$this->BcMessage->setSuccess(
+			sprintf(
+				__d('baser', 'メールフォーム「%s」を追加しました。'),
+				$this->request->data['Content']['title']
+			),
+			true,
+			false
+		);
+		return json_encode($data['Content']);
 	}
-	
+
 /**
  * [ADMIN] メールフォーム追加
  *
@@ -102,34 +107,47 @@ class MailContentsController extends MailAppController {
  */
 	public function admin_add() {
 		$this->pageTitle = __d('baser', '新規メールフォーム登録');
+		$this->subMenuElements = ['mail_common'];
+		$this->help = 'mail_contents_form';
 
 		if (!$this->request->data) {
 			$this->request->data = $this->MailContent->getDefaultValue();
-		} else {
-
-			/* 登録処理 */
-			if (!$this->request->data['MailContent']['sender_1_']) {
-				$this->request->data['MailContent']['sender_1'] = '';
-			}
-			$this->MailContent->create($this->request->data);
-			if ($this->MailContent->validates()) {
-				if ($this->MailMessage->createTable($this->request->data['MailContent']['id'])) {
-					/* データを保存 */
-					if ($this->MailContent->save(null, false)) {
-						$this->BcMessage->setSuccess(sprintf(__d('baser', '新規メールフォーム「%s」を追加しました。'), $this->request->data['MailContent']['title']));
-						$this->redirect(array('action' => 'edit', $this->MailContent->id));
-					} else {
-						$this->BcMessage->setError(__d('baser', 'データベース処理中にエラーが発生しました。'));
-					}
-				} else {
-					$this->BcMessage->setError(__d('baser', 'データベースに問題があります。メール受信データ保存用テーブルの作成に失敗しました。'));
-				}
-			} else {
-				$this->BcMessage->setError(__d('baser', '入力エラーです。内容を修正してください。'));
-			}
+			$this->render('form');
+			return;
 		}
-		$this->subMenuElements = ['mail_common'];
-		$this->help = 'mail_contents_form';
+
+		/* 登録処理 */
+		if (!$this->request->data['MailContent']['sender_1_']) {
+			$this->request->data['MailContent']['sender_1'] = '';
+		}
+		$this->MailContent->create($this->request->data);
+		if (!$this->MailContent->validates()) {
+			$this->BcMessage->setError(__d('baser', '入力エラーです。内容を修正してください。'));
+			$this->render('form');
+			return;
+		}
+
+		if (!$this->MailMessage->createTable($this->request->data['MailContent']['id'])) {
+			$this->BcMessage->setError(
+				__d('baser', 'データベースに問題があります。メール受信データ保存用テーブルの作成に失敗しました。')
+			);
+			$this->render('form');
+			return;
+		}
+
+		/* データを保存 */
+		if (!$this->MailContent->save(null, false)) {
+			$this->BcMessage->setError(__d('baser', 'データベース処理中にエラーが発生しました。'));
+			$this->render('form');
+			return;
+		}
+
+		$this->BcMessage->setSuccess(
+			sprintf(__d('baser', '新規メールフォーム「%s」を追加しました。'),
+				$this->request->data['MailContent']['title']
+			)
+		);
+		$this->redirect(array('action' => 'edit', $this->MailContent->id));
 		$this->render('form');
 	}
 
@@ -143,25 +161,31 @@ class MailContentsController extends MailAppController {
 
 		if (!$id && empty($this->request->data)) {
 			$this->BcMessage->setError(__d('baser', '無効なIDです。'));
-			$this->redirect(['plugin' => false, 'admin' => true, 'controller' => 'contents', 'action' => 'index']);
+			$this->redirect(
+				['plugin' => false, 'admin' => true, 'controller' => 'contents', 'action' => 'index']
+			);
 		}
 
-		if (empty($this->request->data['MailContent']['id'])) {
-			$this->request->data = $this->MailContent->read(null, $id);
-			if ($this->MailContent->isOverPostSize()) {
-				$this->BcMessage->setError(__d('baser', '送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。', ini_get('post_max_size')));
-			}
-			if(!$this->request->data) {
-				$this->BcMessage->setError(__d('baser', '無効な処理です。'));
-				$this->redirect(['plugin' => false, 'admin' => true, 'controller' => 'contents', 'action' => 'index']);
-			}
-		} else {
+		if (Hash::get($this->request->data, 'MailContent.id')) {
 			if (!$this->request->data['MailContent']['sender_1_']) {
 				$this->request->data['MailContent']['sender_1'] = '';
 			}
 			$this->MailContent->set($this->request->data);
-			if ($this->MailContent->save()) {
-				$this->BcMessage->setSuccess(sprintf(__d('baser', 'メールフォーム「%s」を更新しました。'), $this->request->data['Content']['title']));
+			if (!$this->MailContent->save()) {
+				if ($this->MailContent->validationErrors || $this->MailContent->Content->validationErrors) {
+					$this->BcMessage->setError(__d('baser', '入力エラーです。内容を修正してください。'));
+				} else {
+					$this->BcMessage->setError(__d('baser', 'データベース処理中にエラーが発生しました。'));
+				}
+			} else {
+				$this->BcMessage->setSuccess(
+					sprintf(
+						__d(
+							'baser',
+							'メールフォーム「%s」を更新しました。'),
+						$this->request->data['Content']['title']
+					)
+				);
 				if ($this->request->data['MailContent']['edit_mail_form']) {
 					$this->redirectEditForm($this->request->data['MailContent']['form_template']);
 				} elseif ($this->request->data['MailContent']['edit_mail']) {
@@ -169,19 +193,37 @@ class MailContentsController extends MailAppController {
 				} else {
 					$this->redirect(array('action' => 'edit', $this->request->data['MailContent']['id']));
 				}
-			} else {
-				if ($this->MailContent->validationErrors || $this->MailContent->Content->validationErrors) {
-					$this->BcMessage->setError(__d('baser', '入力エラーです。内容を修正してください。'));
-				} else {
-					$this->BcMessage->setError(__d('baser', 'データベース処理中にエラーが発生しました。'));
-				}
+			}
+		} else {
+			$this->request->data = $this->MailContent->read(null, $id);
+			if ($this->MailContent->isOverPostSize()) {
+				$this->BcMessage->setError(
+					__d(
+						'baser',
+						'送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。',
+						ini_get('post_max_size')
+					)
+				);
+			}
+			if (!$this->request->data) {
+				$this->BcMessage->setError(__d('baser', '無効な処理です。'));
+				$this->redirect(
+					['plugin' => false, 'admin' => true, 'controller' => 'contents', 'action' => 'index']
+				);
 			}
 		}
 
 		$this->request->params['Content'] = $this->BcContents->getContent($id)['Content'];
 		if($this->request->data['Content']['status']) {
 			$site = BcSite::findById($this->request->data['Content']['site_id']);
-			$this->set('publishLink', $this->Content->getUrl($this->request->data['Content']['url'], true, $site->useSubDomain));
+			$this->set(
+				'publishLink',
+				$this->Content->getUrl(
+					$this->request->data['Content']['url'],
+					true,
+					$site->useSubDomain
+				)
+			);
 		}
 		$this->set('mailContent', $this->request->data);
 		$this->subMenuElements = ['mail_fields'];
@@ -189,7 +231,7 @@ class MailContentsController extends MailAppController {
 		$this->help = 'mail_contents_form';
 		$this->render('form');
 	}
-	
+
 /**
  * 削除
  *
@@ -210,7 +252,7 @@ class MailContentsController extends MailAppController {
 
 /**
  * メール編集画面にリダイレクトする
- * 
+ *
  * @param string $template
  * @return void
  */
@@ -222,26 +264,42 @@ class MailContentsController extends MailAppController {
 		if ($this->siteConfigs['theme']) {
 			if (!file_exists($target)) {
 				foreach ($sorces as $source) {
-					if (file_exists($source)) {
-						$folder = new Folder();
-						$folder->create(dirname($target), 0777);
-						copy($source, $target);
-						chmod($target, 0666);
-						break;
+					if (!file_exists($source)) {
+						continue;
 					}
+					$folder = new Folder();
+					$folder->create(dirname($target), 0777);
+					copy($source, $target);
+					chmod($target, 0666);
+					break;
 				}
 			}
 			$path = str_replace(DS, '/', $path);
-			$this->redirect(array_merge(array('plugin' => null, 'mail' => false, 'prefix' => false, 'controller' => 'theme_files', 'action' => 'edit', $this->siteConfigs['theme'], $type), explode('/', $path)));
+			$this->redirect(
+				array_merge(
+					array(
+						'plugin'     => null,
+						'mail'       => false,
+						'prefix'     => false,
+						'controller' => 'theme_files',
+						'action'     => 'edit',
+						$this->siteConfigs['theme'],
+						$type
+					),
+					explode('/', $path)
+				)
+			);
 		} else {
-			$this->BcMessage->setError(__d('baser', '現在、「テーマなし」の場合、管理画面でのテンプレート編集はサポートされていません。'));
+			$this->BcMessage->setError(
+				__d('baser', '現在、「テーマなし」の場合、管理画面でのテンプレート編集はサポートされていません。')
+			);
 			$this->redirect(array('action' => 'index'));
 		}
 	}
 
 /**
  * メールフォーム編集画面にリダイレクトする
- * 
+ *
  * @param string $template
  * @return void
  */
@@ -252,18 +310,36 @@ class MailContentsController extends MailAppController {
 		if ($this->siteConfigs['theme']) {
 			if (!file_exists($target . DS . 'index' . $this->ext)) {
 				foreach ($sorces as $source) {
-					if (is_dir($source)) {
-						$folder = new Folder();
-						$folder->create(dirname($target), 0777);
-						$folder->copy(array('from' => $source, 'to' => $target, 'chmod' => 0777, 'skip' => array('_notes')));
-						break;
+					if (!is_dir($source)) {
+						continue;
 					}
+					$folder = new Folder();
+					$folder->create(dirname($target), 0777);
+					$folder->copy(
+						array('from' => $source, 'to' => $target, 'chmod' => 0777, 'skip' => array('_notes'))
+					);
+					break;
 				}
 			}
 			$path = str_replace(DS, '/', $path);
-			$this->redirect(array_merge(array('plugin' => null, 'mail' => false, 'prefix' => false, 'controller' => 'theme_files', 'action' => 'edit', $this->siteConfigs['theme'], 'etc'), explode('/', $path . '/index' . $this->ext)));
+			$this->redirect(
+				array_merge(
+					array(
+						'plugin'     => null,
+						'mail'       => false,
+						'prefix'     => false,
+						'controller' => 'theme_files',
+						'action'     => 'edit',
+						$this->siteConfigs['theme'],
+						'etc'
+					),
+					explode('/', $path . '/index' . $this->ext)
+				)
+			);
 		} else {
-			$this->BcMessage->setError(__d('baser', '現在、「テーマなし」の場合、管理画面でのテンプレート編集はサポートされていません。'));
+			$this->BcMessage->setError(
+				__d('baser', '現在、「テーマなし」の場合、管理画面でのテンプレート編集はサポートされていません。')
+			);
 			$this->redirect(array('action' => 'index'));
 		}
 	}
@@ -279,15 +355,21 @@ class MailContentsController extends MailAppController {
 			$this->ajaxError(500, __d('baser', '無効な処理です。'));
 		}
 		$user = $this->BcAuth->user();
-		$data = $this->MailContent->copy($this->request->data['entityId'], $this->request->data['parentId'], $this->request->data['title'], $user['id'], $this->request->data['siteId']);
-		if ($data) {
-			$message = sprintf(__d('baser', 'メールフォームのコピー「%s」を追加しました。'), $this->request->data['title']);
-			$this->BcMessage->setSuccess($message, true, false);
-			return json_encode($data['Content']);
-		} else {
+		$data = $this->MailContent->copy(
+			$this->request->data['entityId'],
+			$this->request->data['parentId'],
+			$this->request->data['title'],
+			$user['id'],
+			$this->request->data['siteId']
+		);
+		if (!$data) {
 			$this->ajaxError(500, $this->MailContent->validationErrors);
+			return false;
 		}
-		return false;
-	}
+		$message = sprintf(
+			__d('baser', 'メールフォームのコピー「%s」を追加しました。'), $this->request->data['title']
+		);
+		$this->BcMessage->setSuccess($message, true, false);
+		return json_encode($data['Content']);}
 
 }

--- a/lib/Baser/Plugin/Mail/Controller/MailController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailController.php
@@ -635,7 +635,7 @@ class MailController extends MailAppController {
 					[
 						'fromName' => $mailContent['sender_name'],
 						// カンマ区切りで複数設定されていた場合先頭のアドレスをreplayToに利用
-						'replyTo' => strpos($userMail, ',') === false ? $userMail : current(explode(',', $userMail)),
+						'replyTo' => strpos($userMail, ',') === false ? $userMail : strstr($userMail,',',true),
 						'from' => $fromAdmin,
 						'template' => 'Mail.' . $mailContent['mail_template'],
 						'bcc' => $mailContent['sender_2'],

--- a/lib/Baser/Plugin/Mail/Controller/MailMessagesController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailMessagesController.php
@@ -72,7 +72,15 @@ class MailMessagesController extends MailAppController {
 		$this->MailMessage->setup($this->mailContent['MailContent']['id']);
 		$mailContentId = $this->params['pass'][0];
 		$this->request->params['Content'] = $this->BcContents->getContent($mailContentId)['Content'];
-		$this->crumbs[] = array('name' => sprintf(__d('baser', '%s 管理'), $this->request->params['Content']['title']), 'url' => array('plugin' => 'mail', 'controller' => 'mail_fields', 'action' => 'index', $this->params['pass'][0]));
+		$this->crumbs[] = array(
+			'name' => sprintf(
+				__d('baser', '%s 管理'),
+				$this->request->params['Content']['title']
+			),
+			'url' => array(
+				'plugin' => 'mail', 'controller' => 'mail_fields', 'action' => 'index', $this->params['pass'][0]
+			)
+		);
 	}
 
 /**
@@ -109,7 +117,10 @@ class MailMessagesController extends MailAppController {
 			return;
 		}
 
-		$this->pageTitle = sprintf(__d('baser', '%s｜受信メール一覧'), $this->request->params['Content']['title']);
+		$this->pageTitle = sprintf(
+			__d('baser', '%s｜受信メール一覧'),
+			$this->request->params['Content']['title']
+		);
 		$this->help = 'mail_messages_index';
 	}
 
@@ -131,9 +142,19 @@ class MailMessagesController extends MailAppController {
 		));
 		$mailFields = $this->MailMessage->mailFields;
 
-		$this->crumbs[] = array('name' => __d('baser', '受信メール一覧'), 'url' => array('controller' => 'mail_messages', 'action' => 'index', $this->params['pass'][0]));
+		$this->crumbs[] = array(
+			'name' => __d('baser', '受信メール一覧'),
+			'url'  => array(
+				'controller' => 'mail_messages',
+				'action' => 'index',
+				$this->params['pass'][0]
+			)
+		);
 		$this->set(compact('message', 'mailFields'));
-		$this->pageTitle = sprintf(__d('baser', '%s｜受信メール詳細'), $this->request->params['Content']['title']);
+		$this->pageTitle = sprintf(
+			__d('baser', '%s｜受信メール詳細'),
+			$this->request->params['Content']['title']
+		);
 	}
 
 /**
@@ -141,7 +162,7 @@ class MailMessagesController extends MailAppController {
  *
  * @param int $mailContentId
  * @param int $messageId
- * @return void
+ * @return bool
  */
 	protected function _batch_del($ids) {
 		if ($ids) {
@@ -164,11 +185,11 @@ class MailMessagesController extends MailAppController {
 		if (!$messageId) {
 			$this->ajaxError(500, __d('baser', '無効な処理です。'));
 		}
-		if ($this->_del($messageId)) {
-			exit(true);
-		} else {
-			exit();
+		if (!$this->_del($messageId)) {
+			exit;
 		}
+
+		exit(true);
 	}
 
 /**
@@ -176,16 +197,16 @@ class MailMessagesController extends MailAppController {
  *
  * @param int $mailContentId
  * @param int $messageId
- * @return void
+ * @return bool
  */
 	protected function _del($id = null) {
-		if ($this->MailMessage->delete($id)) {
-			$message = sprintf(__d('baser', '受信データ NO「%s」 を削除しました。'), $id);
-			$this->MailMessage->saveDbLog($message);
-			return true;
-		} else {
+		if (!$this->MailMessage->delete($id)) {
 			return false;
 		}
+
+		$message = sprintf(__d('baser', '受信データ NO「%s」 を削除しました。'), $id);
+		$this->MailMessage->saveDbLog($message);
+		return true;
 	}
 
 /**
@@ -201,10 +222,18 @@ class MailMessagesController extends MailAppController {
 			$this->BcMessage->setError(__d('baser', '無効な処理です。'));
 			$this->notFound();
 		}
-		if ($this->MailMessage->delete($messageId)) {
-			$this->BcMessage->setSuccess(sprintf(__d('baser', '%s への受信データ NO「%s」 を削除しました。'), $this->mailContent['Content']['title'], $messageId));
+		if (!$this->MailMessage->delete($messageId)) {
+			$this->BcMessage->setError(
+				__d('baser', 'データベース処理中にエラーが発生しました。')
+			);
 		} else {
-			$this->BcMessage->setError(__d('baser', 'データベース処理中にエラーが発生しました。'));
+			$this->BcMessage->setSuccess(
+				sprintf(
+					__d('baser', '%s への受信データ NO「%s」 を削除しました。'),
+					$this->mailContent['Content']['title'],
+					$messageId
+				)
+			);
 		}
 		$this->redirect(array('action' => 'index', $mailContentId));
 	}
@@ -220,14 +249,14 @@ class MailMessagesController extends MailAppController {
 		$filePath = WWW_ROOT . 'files' . DS . $settings['saveDir'] . DS . $file;
 		$ext = decodeContent(null, $file);
 		$mineType = 'application/octet-stream';
-		if ($ext != 'gif' && $ext != 'jpg' && $ext != 'png') {
+		if ($ext !== 'gif' && $ext !== 'jpg' && $ext !== 'png') {
 			Header("Content-disposition: attachment; filename=" . $file);
 		} else {
 			$mineType = 'image/' . $ext;
 		}
-		Header("Content-type: " . $mineType . "; name=" . $file);
+		Header(sprintf('Content-type: %s; name=%s', $mineType, $file));
 		echo file_get_contents($filePath);
 		exit();
 	}
-	
+
 }

--- a/lib/Baser/Plugin/Mail/Model/MailAppModel.php
+++ b/lib/Baser/Plugin/Mail/Model/MailAppModel.php
@@ -23,7 +23,15 @@ class MailAppModel extends AppModel {
  * @deprecated 5.0.0 since 4.1.3 htmlspecialchars を利用してください。
  */
 	public function sanitizeData($datas) {
-		trigger_error(deprecatedMessage('メソッド：BcAppModel::sanitizeData()', '4.0.0', '5.0.0', 'htmlspecialchars を利用してください。'), E_USER_DEPRECATED);
+		trigger_error(
+			deprecatedMessage(
+				'メソッド：BcAppModel::sanitizeData()',
+				'4.0.0',
+				'5.0.0',
+				'htmlspecialchars を利用してください。'
+			),
+			E_USER_DEPRECATED
+		);
 		return $this->sanitizeRecord($datas);
 	}
 
@@ -33,17 +41,24 @@ class MailAppModel extends AppModel {
  * @deprecated 5.0.0 since 4.1.3 htmlspecialchars_decode を利用してください。
  */
 	public function restoreData($datas) {
-		trigger_error(deprecatedMessage('メソッド：MailAppModel::restoreData()', '4.1.3', '5.0.0', 'htmlspecialchars_decode を利用してください。'), E_USER_DEPRECATED);
+		trigger_error(
+			deprecatedMessage(
+				'メソッド：MailAppModel::restoreData()',
+				'4.1.3',
+				'5.0.0',
+				'htmlspecialchars_decode を利用してください。'
+			),
+			E_USER_DEPRECATED
+		);
 		foreach ($datas as $key => $data) {
-			if (!is_array($data)) {
-				$data = str_replace("<br />", "", $data);
-				$data = str_replace("<br>", "", $data);
-				$data = str_replace('&lt;', '<', $data);
-				$data = str_replace('&gt;', '>', $data);
-				$data = str_replace('&amp;', '&', $data);
-				$data = str_replace('&quot;', '"', $data);
-				$datas[$key] = $data;
+			if (is_array($data)) {
+				continue;
 			}
+			$datas[$key] = str_replace(
+				array('<br />', '<br>', '&lt;', '&gt;', '&amp;', '&quot;'),
+				array('', '', '<', '>', '&', '"'),
+				$data
+			);
 		}
 		return $datas;
 	}

--- a/lib/Baser/Plugin/Mail/Model/MailContent.php
+++ b/lib/Baser/Plugin/Mail/Model/MailContent.php
@@ -150,7 +150,7 @@ class MailContent extends MailAppModel {
  * @return boolean
  */
 	public function checkSslUrl($check) {
-		if ($check[key($check)] && empty(Configure::read('BcEnv.sslUrl'))) {
+		if ($check[key($check)] && !Configure::read('BcEnv.sslUrl')) {
 			return false;
 		}
 

--- a/lib/Baser/Plugin/Mail/Model/MailContent.php
+++ b/lib/Baser/Plugin/Mail/Model/MailContent.php
@@ -56,50 +56,105 @@ class MailContent extends MailAppModel {
 		parent::__construct($id, $table, $ds);
 		$this->validate = [
 			'id' => [
-				['rule' => 'numeric', 'on' => 'update', 'message' => __d('baser', 'IDに不正な値が利用されています。')]],
+				[
+					'rule' => 'numeric',
+					'on' => 'update',
+					'message' => __d('baser', 'IDに不正な値が利用されています。')
+				]
+			],
 			'sender_name' => [
-				['rule' => ['notBlank'], 'message' => __d('baser', '送信先名を入力してください。')],
-				['rule' => ['maxLength', 255], 'message' => __d('baser', '送信先名は255文字以内で入力してください。')]],
+				[
+					'rule' => ['notBlank'],
+					'message' => __d('baser', '送信先名を入力してください。')
+				],
+				[
+					'rule' => ['maxLength', 255],
+					'message' => __d('baser', '送信先名は255文字以内で入力してください。')
+				]
+			],
 			'subject_user' => [
-				['rule' => ['notBlank'], 'message' => __d('baser', '自動返信メール件名[ユーザー宛]を入力してください。')],
-				['rule' => ['maxLength', 255], 'message' => __d('baser', '自動返信メール件名[ユーザー宛]は255文字以内で入力してください。')]],
+				[
+					'rule' => ['notBlank'],
+					'message' => __d('baser', '自動返信メール件名[ユーザー宛]を入力してください。')
+				],
+				[
+					'rule' => ['maxLength', 255],
+					'message' => __d('baser', '自動返信メール件名[ユーザー宛]は255文字以内で入力してください。')
+				]
+			],
 			'subject_admin' => [
-				['rule' => ['notBlank'], 'message' => __d('baser', '自動送信メール件名[管理者宛]を入力してください。')],
-				['rule' => ['maxLength', 255], 'message' => __d('baser', '自動返信メール件名[管理者宛]は255文字以内で入力してください。')]],
+				[
+					'rule' => ['notBlank'],
+					'message' => __d('baser', '自動送信メール件名[管理者宛]を入力してください。')
+				],
+				[
+					'rule' => ['maxLength', 255],
+					'message' => __d('baser', '自動返信メール件名[管理者宛]は255文字以内で入力してください。')
+				]
+			],
 			'form_template' => [
-				['rule' => ['halfText'], 'message' => __d('baser', 'メールフォームテンプレート名は半角のみで入力してください。'), 'allowEmpty' => false],
-				['rule' => ['maxLength', 20], 'message' => __d('baser', 'フォームテンプレート名は20文字以内で入力してください。')]],
+				[
+					'rule' => ['halfText'],
+					'message' => __d('baser', 'メールフォームテンプレート名は半角のみで入力してください。'),
+					'allowEmpty' => false
+				],
+				[
+					'rule' => ['maxLength', 20],
+					'message' => __d('baser', 'フォームテンプレート名は20文字以内で入力してください。')
+				]
+			],
 			'mail_template' => [
-				['rule' => ['halfText'], 'message' => __d('baser', '送信メールテンプレートは半角のみで入力してください。'), 'allowEmpty' => false],
-				['rule' => ['maxLength', 20], 'message' => __d('baser', 'メールテンプレート名は20文字以内で入力してください。')]	],
+				[
+					'rule' => ['halfText'],
+					'message' => __d('baser', '送信メールテンプレートは半角のみで入力してください。'),
+					'allowEmpty' => false
+				],
+				[
+					'rule' => ['maxLength', 20],
+					'message' => __d('baser', 'メールテンプレート名は20文字以内で入力してください。')
+				]
+			],
 			'redirect_url' => [
-				['rule' => ['maxLength', 255], 'message' => __d('baser', 'リダイレクトURLは255文字以内で入力してください。')]],
+				[
+					'rule' => ['maxLength', 255],
+					'message' => __d('baser', 'リダイレクトURLは255文字以内で入力してください。')
+				]
+			],
 			'sender_1' => [
-				['rule' => ['emails'], 'allowEmpty' => true, 'message' => __d('baser', '送信先メールアドレスの形式が不正です。')]],
+				[
+					'rule' => ['emails'],
+					'allowEmpty' => true,
+					'message' => __d('baser', '送信先メールアドレスの形式が不正です。')
+				]
+			],
 			'sender_2' => [
-				['rule' => ['emails'], 'allowEmpty' => true, 'message' => __d('baser', '送信先メールアドレスの形式が不正です。')]],
+				[
+					'rule' => ['emails'],
+					'allowEmpty' => true,
+					'message' => __d('baser', '送信先メールアドレスの形式が不正です。')
+				]
+			],
 			'ssl_on' => [
-				['rule' => 'checkSslUrl', "message" => __d('baser', 'SSL通信を利用するには、システム設定で、事前にSSL通信用のWebサイトURLを指定してください。')]]
+				[
+					'rule' => 'checkSslUrl',
+					"message" => __d('baser', 'SSL通信を利用するには、システム設定で、事前にSSL通信用のWebサイトURLを指定してください。')
+				]
+			]
 		];
 	}
 
 /**
  * SSL用のURLが設定されているかチェックする
- * 
+ *
  * @param string $check チェック対象文字列
  * @return boolean
  */
 	public function checkSslUrl($check) {
-		if ($check[key($check)]) {
-			$sslUrl = Configure::read('BcEnv.sslUrl');
-			if (empty($sslUrl)) {
-				return false;
-			} else {
-				return true;
-			}
-		} else {
-			return true;
+		if ($check[key($check)] && empty(Configure::read('BcEnv.sslUrl'))) {
+			return false;
 		}
+
+		return true;
 	}
 
 /**
@@ -109,36 +164,38 @@ class MailContent extends MailAppModel {
  * @return boolean
  */
 	public function alphaNumeric($check) {
-		if (preg_match("/^[a-z0-9]+$/", $check[key($check)])) {
-			return true;
-		} else {
+		if (!preg_match("/^[a-z0-9]+$/", $check[key($check)])) {
 			return false;
 		}
+		return true;
 	}
 
 /**
  * フォームの初期値を取得する
  *
- * @return string
+ * @return array
  */
 	public function getDefaultValue() {
-		$data['MailContent']['sender_name'] = __d('baser', '送信先名を入力してください');
-		$data['MailContent']['subject_user'] = __d('baser', 'お問い合わせ頂きありがとうございます');
-		$data['MailContent']['subject_admin'] = __d('baser', 'お問い合わせを頂きました');
-		$data['MailContent']['layout_template'] = 'default';
-		$data['MailContent']['form_template'] = 'default';
-		$data['MailContent']['mail_template'] = 'mail_default';
-		$data['MailContent']['use_description'] = true;
-		$data['MailContent']['auth_captcha'] = false;
-		$data['MailContent']['ssl_on'] = false;
-		$data['MailContent']['save_info'] = true;
-		return $data;
+		return [
+			'MailContent' => [
+				'sender_name'     => __d('baser', '送信先名を入力してください'),
+				'subject_user'    => __d('baser', 'お問い合わせ頂きありがとうございます'),
+				'subject_admin'   => __d('baser', 'お問い合わせを頂きました'),
+				'layout_template' => 'default',
+				'form_template'   => 'default',
+				'mail_template'   => 'mail_default',
+				'use_description' => true,
+				'auth_captcha'    => false,
+				'ssl_on'          => false,
+				'save_info'       => true
+			]
+		];
 	}
 
 /**
  * afterSave
  *
- * @return boolean
+ * @return void
  */
 	public function afterSave($created, $options = array()) {
 		// 検索用テーブルへの登録・削除
@@ -171,18 +228,21 @@ class MailContent extends MailAppModel {
 		}
 		$mailContent = $data['MailContent'];
 		$content = $data['Content'];
-		return ['SearchIndex' => [
-			'type' => __d('baser', 'メール'),
-			'model_id' => (!empty($mailContent['id'])) ? $mailContent['id'] : $this->id,
-			'content_id' => $content['id'],
-			'site_id' => $content['site_id'],
-			'title' => $content['title'],
-			'detail' => $mailContent['description'],
-			'url' => $content['url'],
-			'status' => $content['status'],
-			'publish_begin' => $content['publish_begin'],
-			'publish_end' => $content['publish_end']
-		]];
+		return [
+			'SearchIndex' =>
+				[
+					'type'        => __d('baser', 'メール'),
+					'model_id'    => (!empty($mailContent['id'])) ? $mailContent['id'] : $this->id,
+					'content_id'  => $content['id'],
+					'site_id'     => $content['site_id'],
+					'title'       => $content['title'],
+					'detail'      => $mailContent['description'],
+					'url'         => $content['url'],
+					'status'      => $content['status'],
+					'publish_begin' => $content['publish_begin'],
+					'publish_end' => $content['publish_end']
+				]
+		];
 	}
 
 /**
@@ -232,7 +292,14 @@ class MailContent extends MailAppModel {
 		if ($result = $this->save($data)) {
 			$result['MailContent']['id'] = $this->id;
 			$data = $result;
-			$mailFields = $this->MailField->find('all', array('conditions' => array('MailField.mail_content_id' => $id), 'order' => 'MailField.sort', 'recursive' => -1));
+			$mailFields = $this->MailField->find(
+				'all',
+				array(
+					'conditions' => array('MailField.mail_content_id' => $id),
+					'order' => 'MailField.sort',
+					'recursive' => -1
+				)
+			);
 			foreach ($mailFields as $mailField) {
 				$mailField['MailField']['mail_content_id'] = $result['MailContent']['id'];
 				$this->MailField->copy(null, $mailField, array('sortUpdateOff' => true));
@@ -275,12 +342,12 @@ class MailContent extends MailAppModel {
  * @return	bool
  */
 	public function isAccepting($publishBegin, $publishEnd) {
-		if ($publishBegin && $publishBegin != '0000-00-00 00:00:00') {
+		if ($publishBegin && $publishBegin !== '0000-00-00 00:00:00') {
 			if ($publishBegin > date('Y-m-d H:i:s')) {
 				return false;
 			}
 		}
-		if ($publishEnd && $publishEnd != '0000-00-00 00:00:00') {
+		if ($publishEnd && $publishEnd !== '0000-00-00 00:00:00') {
 			if ($publishEnd < date('Y-m-d H:i:s')) {
 				return false;
 			}
@@ -323,5 +390,4 @@ class MailContent extends MailAppModel {
 		}
 		return $this->find($type, $query);
 	}
-	
 }

--- a/lib/Baser/Plugin/Mail/Model/MailContent.php
+++ b/lib/Baser/Plugin/Mail/Model/MailContent.php
@@ -146,7 +146,7 @@ class MailContent extends MailAppModel {
 /**
  * SSL用のURLが設定されているかチェックする
  *
- * @param string $check チェック対象文字列
+ * @param array $check チェック対象文字列
  * @return boolean
  */
 	public function checkSslUrl($check) {
@@ -160,7 +160,7 @@ class MailContent extends MailAppModel {
 /**
  * 英数チェック
  *
- * @param string $check チェック対象文字列
+ * @param array $check チェック対象文字列
  * @return boolean
  */
 	public function alphaNumeric($check) {

--- a/lib/Baser/Plugin/Mail/Model/MailField.php
+++ b/lib/Baser/Plugin/Mail/Model/MailField.php
@@ -20,7 +20,7 @@ class MailField extends MailAppModel {
 
 /**
  * ビヘイビア
- * 
+ *
  * @var array
  */
 	public $actsAs = array('BcCache');
@@ -36,43 +36,118 @@ class MailField extends MailAppModel {
 		parent::__construct($id, $table, $ds);
 		$this->validate = [
 			'id' => [
-				['rule' => 'numeric', 'on' => 'update', 'message' => __d('baser', 'IDに不正な値が利用されています。')]],
+				[
+					'rule' => 'numeric',
+					'on' => 'update',
+					'message' => __d('baser', 'IDに不正な値が利用されています。')
+				]
+			],
 			'name' => [
-				['rule' => ['notBlank'], 'message' => __d('baser', '項目名を入力してください。')],
-				['rule' => ['maxLength', 255], 'message' => __d('baser', '項目名は255文字以内で入力してください。')]],
+				[
+					'rule' => ['notBlank'],
+					'message' => __d('baser', '項目名を入力してください。')
+				],
+				[
+					'rule' => ['maxLength', 255],
+					'message' => __d('baser', '項目名は255文字以内で入力してください。')
+				]
+			],
 			'field_name' => [
-				['rule' => ['halfTextMailField'], 'message' => __d('baser', 'フィールド名は半角英数字のみで入力してください。'), 'allowEmpty' => false],
-				['rule' => 'duplicateMailField', 'message' => __d('baser', '入力されたフィールド名は既に登録されています。')],
-				['rule' => ['maxLength', 255], 'message' => __d('baser', 'フィールド名は255文字以内で入力してください。')]],
+				[
+					'rule' => ['halfTextMailField'],
+					'message' => __d('baser', 'フィールド名は半角英数字のみで入力してください。'),
+					'allowEmpty' => false
+				],
+				[
+					'rule' => 'duplicateMailField',
+					'message' => __d('baser', '入力されたフィールド名は既に登録されています。')
+				],
+				[
+					'rule' => ['maxLength', 255],
+					'message' => __d('baser', 'フィールド名は255文字以内で入力してください。')
+				]
+			],
 			'type' => [
-				['rule' => ['notBlank'], 'message' => __d('baser', 'タイプを入力してください。')]],
+				[
+					'rule' => ['notBlank'],
+					'message' => __d('baser', 'タイプを入力してください。')
+				]
+			],
 			'head' => [
-				['rule' => ['maxLength', 255], 'message' => __d('baser', '項目見出しは255文字以内で入力してください。')]],
+				[
+					'rule' => ['maxLength', 255],
+					'message' => __d('baser', '項目見出しは255文字以内で入力してください。')
+				]
+			],
 			'attention' => [
-				['rule' => ['maxLength', 255], 'message' => __d('baser', '注意書きは255文字以内で入力してください。')]],
+				[
+					'rule' => ['maxLength', 255],
+					'message' => __d('baser', '注意書きは255文字以内で入力してください。')
+				]
+			],
 			'before_attachment' => [
-				['rule' => ['maxLength', 255], 'message' => __d('baser', '前見出しは255文字以内で入力してください。')]],
+				[
+					'rule' => ['maxLength', 255],
+					'message' => __d('baser', '前見出しは255文字以内で入力してください。')
+				]
+			],
 			'after_attachment' => [
-				['rule' => ['maxLength', 255], 'message' => __d('baser', '後見出しは255文字以内で入力してください。')]],
+				[
+					'rule' => ['maxLength', 255],
+					'message' => __d('baser', '後見出しは255文字以内で入力してください。')
+				]
+			],
 			'source' => [
-				['rule' => ['sourceMailField'], 'message' => __d('baser', '選択リストを入力してください。')]],
+				[
+					'rule' => ['sourceMailField'],
+					'message' => __d('baser', '選択リストを入力してください。')
+				]
+			],
 			'options' => [
-				['rule' => ['maxLength', 255], 'message' => __d('baser', 'オプションは255文字以内で入力してください。')]],
+				[
+					'rule' => ['maxLength', 255],
+					'message' => __d('baser', 'オプションは255文字以内で入力してください。')
+				]
+			],
 			'class' => [
-				['rule' => ['maxLength', 255], 'message' => __d('baser', 'クラス名は255文字以内で入力してください。')]],
+				[
+					'rule' => ['maxLength', 255],
+					'message' => __d('baser', 'クラス名は255文字以内で入力してください。')
+				]
+			],
 			'separator' => [
-				['rule' => ['maxLength', 20], 'message' => __d('baser', '区切り文字は20文字以内で入力してください。')]],
+				[
+					'rule' => ['maxLength', 20],
+					'message' => __d('baser', '区切り文字は20文字以内で入力してください。')
+				]
+			],
 			'default_value' => [
-				['rule' => ['maxLength', 255], 'message' => __d('baser', '初期値は255文字以内で入力してください。')]],
+				[
+					'rule' => ['maxLength', 255],
+					'message' => __d('baser', '初期値は255文字以内で入力してください。')
+				]
+			],
 			'description' => [
-				['rule' => ['maxLength', 255], 'message' => __d('baser', '説明文は255文字以内で入力してください。')]],
+				[
+					'rule' => ['maxLength', 255],
+					'message' => __d('baser', '説明文は255文字以内で入力してください。')
+				]
+			],
 			'group_field' => [
-				['rule' => ['maxLength', 255], 'message' => __d('baser', 'グループフィールドは255文字以内で入力してください。')]],
+				[
+					'rule' => ['maxLength', 255],
+					'message' => __d('baser', 'グループフィールドは255文字以内で入力してください。')
+				]
+			],
 			'group_valid' => [
-				['rule' => ['maxLength', 255], 'message' => __d('baser', 'グループ入力チェックは255文字以内で入力してください。')]]
+				[
+					'rule' => ['maxLength', 255],
+					'message' => __d('baser', 'グループ入力チェックは255文字以内で入力してください。')
+				]
+			]
 		];
 	}
-	
+
 /**
  * コントロールソースを取得する
  *
@@ -114,11 +189,11 @@ class MailField extends MailAppModel {
 			'VALID_REGEX' 			=> __d('baser', '正規表現チェック'),
 		];
 		$source['auto_convert'] = ['CONVERT_HANKAKU' => __d('baser', '半角変換')];
-		if ($field) {
-			return $source[$field];
-		} else {
+		if (!$field) {
 			return $source;
 		}
+
+		return $source[$field];
 	}
 
 /**
@@ -137,9 +212,9 @@ class MailField extends MailAppModel {
 		$ret = $this->find('first', array('conditions' => $conditions));
 		if ($ret) {
 			return false;
-		} else {
-			return true;
 		}
+
+		return true;
 	}
 
 /**
@@ -157,8 +232,8 @@ class MailField extends MailAppModel {
 
 /**
  * 選択リストの入力チェック
- * 
- * @param type $check
+ *
+ * @param integer $check
  */
 	public function sourceMailField($check) {
 		switch ($this->data['MailField']['type']) {
@@ -167,14 +242,10 @@ class MailField extends MailAppModel {
 			case 'multi_check':	// マルチチェックボックス
 			case 'autozip':		// 自動保管郵便番号
 				// 選択リストのチェックを行う
-				$result = (!empty($check[key($check)]));
-				break;
-			default:
-				// 選択リストが不要のタイプの時はチェックしない
-				$result = true;
-				break;
+				return (!empty($check[key($check)]));
 		}
-		return $result;
+		// 選択リストが不要のタイプの時はチェックしない
+		return true;
 	}
 
 /**
@@ -185,14 +256,25 @@ class MailField extends MailAppModel {
  * @return mixed UserGroup Or false
  */
 	public function copy($id, $data = array(), $options = array()) {
-		$options = array_merge(array(
-			'sortUpdateOff' => false,
-			), $options);
+		$options = array_merge(
+			array(
+				'sortUpdateOff' => false,
+			),
+			$options
+		);
 
 		extract($options);
 
 		if ($id) {
-			$data = $this->find('first', array('conditions' => array('MailField.id' => $id), 'recursive' => -1));
+			$data = $this->find(
+				'first',
+				[
+					'conditions' => [
+						'MailField.id' => $id
+					],
+					'recursive' => -1
+				]
+			);
 		}
 		$oldData = $data;
 
@@ -216,7 +298,12 @@ class MailField extends MailAppModel {
 			}
 		}
 
-		$data['MailField']['no'] = $this->getMax('no', array('MailField.mail_content_id' => $data['MailField']['mail_content_id'])) + 1;
+		$data['MailField']['no'] = $this->getMax(
+				'no',
+				array(
+					'MailField.mail_content_id' => $data['MailField']['mail_content_id']
+				)
+			) + 1;
 		if (!$sortUpdateOff) {
 			$data['MailField']['sort'] = $this->getMax('sort') + 1;
 		}
@@ -228,26 +315,26 @@ class MailField extends MailAppModel {
 
 		$this->create($data);
 		$result = $this->save();
-		if ($result) {
-			$result['MailField']['id'] = $this->getInsertID();
-			$data = $result;
-
-			// EVENT MailField.afterCopy
-			if (!$sortUpdateOff) {
-				$event = $this->dispatchEvent('afterCopy', [
-					'id' => $data['MailField']['id'],
-					'data' => $data,
-					'oldId' => $id,
-					'oldData' => $oldData,
-				]);
-			}
-
-			return $result;
-		} else {
+		if (!$result) {
 			return false;
 		}
+
+		$result['MailField']['id'] = $this->getInsertID();
+		$data = $result;
+
+		// EVENT MailField.afterCopy
+		if (!$sortUpdateOff) {
+			$event = $this->dispatchEvent('afterCopy', [
+				'id' => $data['MailField']['id'],
+				'data' => $data,
+				'oldId' => $id,
+				'oldData' => $oldData,
+			]);
+		}
+
+		return $result;
 	}
-	
+
 /**
  * 選択リストのソースを整形する
  * 空白と \r を除外し、改行で結合する
@@ -266,7 +353,7 @@ class MailField extends MailAppModel {
 	}
 
 /**
- * After Delete 
+ * After Delete
  */
 	public function afterDelete() {
 		parent::afterDelete();
@@ -277,7 +364,7 @@ class MailField extends MailAppModel {
 
 /**
  * After Save
- * 
+ *
  * @param bool $created
  * @param array $options
  */

--- a/lib/Baser/Plugin/Mail/Model/MailMessage.php
+++ b/lib/Baser/Plugin/Mail/Model/MailMessage.php
@@ -38,11 +38,11 @@ class MailMessage extends MailAppModel {
 
 /**
  * メールコンテンツ情報
- * 
+ *
  * @var array
  */
 	public $mailContent = array();
-	
+
 /**
  * ビヘイビア
  *
@@ -53,12 +53,12 @@ class MailMessage extends MailAppModel {
 			'subdirDateFormat' => 'Y/m/'
 		)
 	);
-	
+
 /**
  * モデルのセットアップを行う
- * 
+ *
  * MailMessageモデルは利用前にこのメソッドを呼び出しておく必要あり
- * 
+ *
  * @param int $mailContentId
  * @return boolean
  */
@@ -77,7 +77,7 @@ class MailMessage extends MailAppModel {
 			return false;
 		}
 		$this->mailContent = ['MailContent' => $mailContent['MailContent']];
-		
+
 		$this->mailFields = $MailContent->MailField->find('all', [
 			'conditions' => ['MailField.mail_content_id' => $mailContentId, 'MailField.use_field' => true],
 			'recursive' => -1,
@@ -87,18 +87,18 @@ class MailMessage extends MailAppModel {
 		// アップロード設定
 		$this->setupUpload($mailContentId);
 		return true;
-		
+
 	}
 
 /**
  * テーブル名を設定する
- * 
+ *
  * @param $mailContentId
  */
 	public function setUseTable($mailContentId) {
 		$this->table = $this->useTable = $this->createTableName($mailContentId);
 	}
-	
+
 /**
  * アップロード設定を行う
  */
@@ -108,7 +108,7 @@ class MailMessage extends MailAppModel {
 		$settings['fields'] = array();
 		foreach ($this->mailFields as $mailField) {
 			$mailField = $mailField['MailField'];
-			if($mailField['type'] == 'file') {
+			if($mailField['type'] === 'file') {
 				$settings['fields'][$mailField['field_name']] = array(
 					'type' => 'all',
 					'namefield' => 'id',
@@ -120,9 +120,9 @@ class MailMessage extends MailAppModel {
 			$settings['saveDir'] = "mail" . DS . "limited" . DS . $name . DS . "messages";
 		}
 		$this->Behaviors->load('BcUpload', $settings);
-		
+
 	}
-	
+
 /**
  * beforeSave
  *
@@ -177,8 +177,8 @@ class MailMessage extends MailAppModel {
 			$mailField = $mailField['MailField'];
 			if ($mailField['valid'] && !empty($mailField['use_field'])) {
 				// 必須項目
-				if ($mailField['valid'] == 'VALID_NOT_EMPTY' || $mailField['valid'] == 'VALID_EMAIL') {
-					if($mailField['type'] == 'file') {
+				if ($mailField['valid'] === 'VALID_NOT_EMPTY' || $mailField['valid'] === 'VALID_EMAIL') {
+					if($mailField['type'] === 'file') {
 						if(!isset($this->data['MailMessage'][$mailField['field_name'] . '_tmp'])) {
 							$this->validate[$mailField['field_name']] = array('notBlank' => array(
 									'rule' => array('notFileEmpty'),
@@ -194,13 +194,13 @@ class MailMessage extends MailAppModel {
 						));
 					}
 				// 半角数字
-				} elseif ($mailField['valid'] == '/^(|[0-9]+)$/') {
+				} elseif ($mailField['valid'] === '/^(|[0-9]+)$/') {
 					$this->validate[$mailField['field_name']] = array(
 							'rule' => '/^(|[0-9]+)$/',
 							'message' => '半角数字で入力してください。'
 				);
 				// 半角数字（入力必須）
-				} elseif ($mailField['valid'] == '/^([0-9]+)$/') {
+				} elseif ($mailField['valid'] === '/^([0-9]+)$/') {
 					$this->validate[$mailField['field_name']] = array(
 							'rule' => '/^([0-9]+)$/',
 							'message' => __('半角数字で入力してください。')
@@ -208,7 +208,7 @@ class MailMessage extends MailAppModel {
 				} else {
 					$this->validate[$mailField['field_name']] = $mailField['valid'];
 				}
-				if (!empty($this->data['MailMessage'][$mailField['field_name']]) && $mailField['valid'] == 'VALID_EMAIL') {
+				if (!empty($this->data['MailMessage'][$mailField['field_name']]) && $mailField['valid'] === 'VALID_EMAIL') {
 					$this->validate[$mailField['field_name']] = array('email' => array(
 						'rule' => array('email'),
 						'message' => __('形式が無効です。')
@@ -258,7 +258,7 @@ class MailMessage extends MailAppModel {
 			}
 		}
 	}
-	
+
 /**
  * 拡張バリデートチェック
  *
@@ -269,44 +269,56 @@ class MailMessage extends MailAppModel {
 		$dists = array();
 
 		// 対象フィールドを取得
-		foreach ($this->mailFields as $mailField) {
-			$mailField = $mailField['MailField'];
-			if (!empty($mailField['use_field'])) {
-				$valids = explode(',', $mailField['valid_ex']);
-				// マルチチェックボックスのチェックなしチェック
-				if (in_array('VALID_NOT_UNCHECKED', $valids)) {
-					if (empty($data['MailMessage'][$mailField['field_name']])) {
-						$this->invalidate($mailField['field_name'], __('必須項目です。'));
+		foreach ($this->mailFields as $row) {
+			$mailField = $row['MailField'];
+			if (empty($mailField['use_field'])) {
+				continue;
+			}
+
+			$valids = explode(',', $mailField['valid_ex']);
+			$field_name = $mailField['field_name'];
+			// マルチチェックボックスのチェックなしチェック
+			if (in_array('VALID_NOT_UNCHECKED', $valids)) {
+				if (empty($data['MailMessage'][$field_name])) {
+					$this->invalidate($field_name, __('必須項目です。'));
+				}
+				$dists[$field_name][] = @$data['MailMessage'][$field_name];
+				// datetimeの空チェック
+				continue;
+			}
+
+			if (in_array('VALID_DATETIME', $valids)) {
+				if (is_array($data['MailMessage'][$field_name])) {
+					if (empty($data['MailMessage'][$field_name]['year']) ||
+						empty($data['MailMessage'][$field_name]['month']) ||
+						empty($data['MailMessage'][$field_name]['day'])) {
+						$this->invalidate($field_name, __('日付の形式が無効です。'));
 					}
-					$dists[$mailField['field_name']][] = @$data['MailMessage'][$mailField['field_name']];
-					// datetimeの空チェック
-				} elseif (in_array('VALID_DATETIME', $valids)) {
-					if (is_array($data['MailMessage'][$mailField['field_name']])) {
-						if (empty($data['MailMessage'][$mailField['field_name']]['year']) ||
-							empty($data['MailMessage'][$mailField['field_name']]['month']) ||
-							empty($data['MailMessage'][$mailField['field_name']]['day'])) {
-							$this->invalidate($mailField['field_name'], __('日付の形式が無効です。'));
-						}
+				}
+				if (is_string($data['MailMessage'][$field_name])) {
+					// カレンダー入力利用時は yyyy/mm/dd で入ってくる
+					// yyyy/mm/dd 以外の文字列入力も可能であり、そうした際は日付データとして 1970-01-01 となるため認めない
+					$inputValue = date('Y-m-d', strtotime($data['MailMessage'][$field_name]));
+					if ($inputValue === '1970-01-01') {
+						$this->invalidate($field_name, __('日付の形式が無効です。'));
 					}
-					if (is_string($data['MailMessage'][$mailField['field_name']])) {
-						// カレンダー入力利用時は yyyy/mm/dd で入ってくる
-						// yyyy/mm/dd 以外の文字列入力も可能であり、そうした際は日付データとして 1970-01-01 となるため認めない
-						$inputValue = date('Y-m-d', strtotime($data['MailMessage'][$mailField['field_name']]));
-						if ($inputValue === '1970-01-01') {
-							$this->invalidate($mailField['field_name'], __('日付の形式が無効です。'));
-						}
-						if (!$this->checkDate(array($mailField['field_name'] => $inputValue))) {
-							$this->invalidate($mailField['field_name'], __('日付の形式が無効です。'));
-						}
+					if (!$this->checkDate(array($field_name => $inputValue))) {
+						$this->invalidate($field_name, __('日付の形式が無効です。'));
 					}
-				} elseif (in_array('VALID_ZENKAKU_KATAKANA', $valids)) {
-					if(!preg_match('/^(|[ァ-ヾ 　]+)$/u', $data['MailMessage'][$mailField['field_name']])) {
-						$this->invalidate($mailField['field_name'], __('全て全角カタカナで入力してください。'));
-					}
-				} elseif (in_array('VALID_ZENKAKU_HIRAGANA', $valids)) {
-					if (!preg_match('/^([　 \t\r\n]|[ぁ-ん]|[ー])+$/u', $data['MailMessage'][$mailField['field_name']])) {
-						$this->invalidate($mailField['field_name'], __('全て全角ひらがなで入力してください。'));
-					}
+				}
+				continue;
+			}
+
+			if (in_array('VALID_ZENKAKU_KATAKANA', $valids)) {
+				if (!preg_match('/^(|[ァ-ヾ 　]+)$/u', $data['MailMessage'][$field_name])) {
+					$this->invalidate($field_name, __('全て全角カタカナで入力してください。'));
+				}
+				continue;
+			}
+
+			if (in_array('VALID_ZENKAKU_HIRAGANA', $valids)) {
+				if (!preg_match('/^([　 \t\r\n]|[ぁ-ん]|[ー])+$/u', $data['MailMessage'][$field_name])) {
+					$this->invalidate($field_name, __('全て全角ひらがなで入力してください。'));
 				}
 			}
 		}
@@ -373,9 +385,9 @@ class MailMessage extends MailAppModel {
 			$count = count($dist);
 			if ($i > 0 && $i < $count) {
  				$this->invalidate($key . '_not_complate', __('入力データが不完全です。'));
- 				for ($j = 0; $j < $count; $j++) {
- 					$this->invalidate($dist[$j]['name']);
- 				}
+				foreach ($dist as $jValue) {
+					$this->invalidate($jValue['name']);
+				}
 			}
 		}
 	}
@@ -449,11 +461,11 @@ class MailMessage extends MailAppModel {
 			if ($value !== null) {
 
 				// 半角処理
-				if ($mailField['auto_convert'] == 'CONVERT_HANKAKU') {
+				if ($mailField['auto_convert'] === 'CONVERT_HANKAKU') {
 					$value = mb_convert_kana($value, 'a');
 				}
 				// 全角処理
-				if ($mailField['auto_convert'] == 'CONVERT_ZENKAKU') {
+				if ($mailField['auto_convert'] === 'CONVERT_ZENKAKU') {
 					$value = mb_convert_kana($value, 'AK');
 				}
 				// サニタイズ
@@ -487,7 +499,7 @@ class MailMessage extends MailAppModel {
 				// 対象フィールドがあれば、バリデートグループごとに配列に格納する
 				if (!is_null($mailField['default_value']) && $mailField['default_value'] !== "") {
 
-					if ($mailField['type'] == 'multi_check') {
+					if ($mailField['type'] === 'multi_check') {
 						$_data['MailMessage'][$mailField['field_name']][0] = $mailField['default_value'];
 					} else {
 						$_data['MailMessage'][$mailField['field_name']] = $mailField['default_value'];
@@ -519,7 +531,7 @@ class MailMessage extends MailAppModel {
 		foreach ($this->mailFields as $mailField) {
 			$mailField = $mailField['MailField'];
 			// マルチチェックのデータを｜区切りに変換
-			if ($mailField['type'] == 'multi_check' && $mailField['use_field']) {
+			if ($mailField['type'] === 'multi_check' && $mailField['use_field']) {
 				if (!empty($dbData['MailMessage'][$mailField['field_name']])) {
 					if (is_array($dbData['MailMessage'][$mailField['field_name']])) {
 						$dbData['MailMessage'][$mailField['field_name']] = implode("|", $dbData['MailMessage'][$mailField['field_name']]);
@@ -529,7 +541,7 @@ class MailMessage extends MailAppModel {
 				}
 			}
 			// パスワードのデータをハッシュ化
-			if ($mailField['type'] == 'password') {
+			if ($mailField['type'] === 'password') {
 				if (!empty($dbData['MailMessage'][$mailField['field_name']])) {
 					App::uses('AuthComponent', 'Controller/Component');
 					$dbData['MailMessage'][$mailField['field_name']] = AuthComponent::password($dbData['MailMessage'][$mailField['field_name']]);
@@ -648,12 +660,12 @@ class MailMessage extends MailAppModel {
 			if($mailField['no_send']) {
 				unset($dbData['message'][$mailField['field_name']]);
 			}
-			if ($mailField['type'] == 'multi_check') {
+			if ($mailField['type'] === 'multi_check') {
 				if (!empty($dbData['message'][$mailField['field_name']]) && !is_array($dbData['message'][$mailField['field_name']])) {
 					$dbData['message'][$mailField['field_name']] = explode("|", $dbData['message'][$mailField['field_name']]);
 				}
 			}
-			if($mailField['type'] == 'file' && isset($dbData['message'][$mailField['field_name'] . '_tmp'])) {
+			if($mailField['type'] === 'file' && isset($dbData['message'][$mailField['field_name'] . '_tmp'])) {
 				$dbData['message'][$mailField['field_name']] = $dbData['message'][$mailField['field_name'] . '_tmp'];
 				unset($dbData['message'][$mailField['field_name'] . '_tmp']);
 			}
@@ -670,23 +682,23 @@ class MailMessage extends MailAppModel {
  */
 	public function createTableName($mailContentId) {
 		$mailContentId = (int) $mailContentId;
-		if(is_int($mailContentId)) {
-			return 'mail_message_' . $mailContentId;
-		} else {
+		if(!is_int($mailContentId)) {
 			throw new BcException(__d('baser', 'createTableNameの引数$mailContentIdはint型しか受けつけていません。'));
 		}
+
+		return 'mail_message_' . $mailContentId;
 	}
 
 /**
  * フルテーブル名を生成する
- * 
+ *
  * @param $mailContentId
  * @return string
  */
 	public function createFullTableName($mailContentId) {
 		return $this->tablePrefix . $this->createTableName($mailContentId);
 	}
-	
+
 /**
  * メッセージテーブルを作成する
  *
@@ -736,13 +748,12 @@ class MailMessage extends MailAppModel {
  *
  * @param string $contentName
  * @param string $field
- * @return array
+ * @return array|bool
  */
 	public function addMessageField($mailContentId, $field) {
 		$table = $this->createTableName($mailContentId);
 		$options = array('field' => $field, 'column' => array('type' => 'text'), 'table' => $table);
-		$ret = parent::addField($options);
-		return $ret;
+		return parent::addField($options);
 	}
 
 /**
@@ -750,12 +761,11 @@ class MailMessage extends MailAppModel {
  *
  * @param string $contentName
  * @param string $field
- * @return array
+ * @return array|bool
  */
 	public function delMessageField($mailContentId, $field) {
 		$table = $this->createTableName($mailContentId);
-		$ret = parent::delField(array('field' => $field, 'table' => $table));
-		return $ret;
+		return parent::delField(array('field' => $field, 'table' => $table));
 	}
 
 /**
@@ -764,19 +774,18 @@ class MailMessage extends MailAppModel {
  * @param string $fieldName
  * @param string $oldFieldName
  * @param string $newfieldName
- * @return array
+ * @return array|bool
  */
 	public function renameMessageField($mailContentId, $oldFieldName, $newfieldName) {
 		$table = $this->createTableName($mailContentId);
-		$ret = parent::renameField(array('old' => $oldFieldName, 'new' => $newfieldName, 'table' => $table));
-		return $ret;
+		return parent::renameField(array('old' => $oldFieldName, 'new' => $newfieldName, 'table' => $table));
 	}
 
 /**
  * メッセージ保存用テーブルのフィールドを最適化する
  * 初回の場合、id/created/modifiedを追加する
  * 2回目以降の場合は、最後のカラムに追加する
- * 
+ *
  * @param array $dbConfig
  * @param int $mailContentId
  * @return boolean
@@ -808,7 +817,7 @@ class MailMessage extends MailAppModel {
 
 /**
  * 受信メッセージの内容を表示状態に変換する
- * 
+ *
  * @param int $id
  * @param array $messages
  * @return array
@@ -830,7 +839,7 @@ class MailMessage extends MailAppModel {
 			$inData = array();
 			$inData['NO'] = $message[$this->alias]['id'];
 			foreach ($mailFields as $mailField) {
-				if($mailField['MailField']['type'] == 'file') {
+				if($mailField['MailField']['type'] === 'file') {
 					$inData[$mailField['MailField']['field_name'] . ' (' . $mailField['MailField']['name'] . ')'] = $message[$this->alias][$mailField['MailField']['field_name']];
 				} else {
 					$inData[$mailField['MailField']['field_name'] . ' (' . $mailField['MailField']['name'] . ')'] = $Maildata->toDisplayString(
@@ -847,10 +856,10 @@ class MailMessage extends MailAppModel {
 
 		return $messages;
 	}
-	
+
 /**
  * メール受信テーブルを全て再構築
- * 
+ *
  * @return boolean
  */
 	public function reconstructionAll() {
@@ -873,10 +882,9 @@ class MailMessage extends MailAppModel {
 
 	}
 
-	
 /**
  * find
- * 
+ *
  * @param String $type
  * @param mixed $query
  * @return Array

--- a/lib/Baser/Plugin/Mail/View/Elements/mail_form.php
+++ b/lib/Baser/Plugin/Mail/View/Elements/mail_form.php
@@ -21,8 +21,9 @@ $this->Mail->token();
 <script type="text/javascript">
 $(function(){
 	$(".form-submit").click(function(){
-		let mode = $(this).attr('id').replace('BtnMessage', '');
-		$("#MailMessageMode").val(mode);
+		$("#MailMessageMode").val(
+			$(this).attr('id').replace('BtnMessage', '')
+		);
 		$(this).prop('disabled',true);//ボタンを無効化する
 		$(this).closest('form').submit();//フォームを送信する
 		return true;
@@ -33,14 +34,25 @@ $(function(){
 
 <?php /* フォーム開始タグ */ ?>
 <?php if (!$freezed): ?>
-	<?php echo $this->Mailform->create('MailMessage', array('url' => $this->BcBaser->getContentsUrl(null, false, null, false) . 'confirm', 'type' => 'file')) ?>
+	<?php echo $this->Mailform->create(
+		'MailMessage',
+		array(
+			'url' => $this->BcBaser->getContentsUrl(null, false, null, false) . 'confirm',
+			'type' => 'file'
+		)
+	) ?>
 <?php else: ?>
-	<?php echo $this->Mailform->create('MailMessage', array('url' => $this->BcBaser->getContentsUrl(null, false, null, false)  . 'submit')) ?>
+	<?php echo $this->Mailform->create(
+		'MailMessage',
+		array(
+			'url' => $this->BcBaser->getContentsUrl(null, false, null, false)  . 'submit'
+		)
+	) ?>
 <?php endif; ?>
 <?php /* フォーム本体 */ ?>
 
 <?php $this->Mailform->unlockField('MailMessage.mode') ?>
-<?php echo $this->Mailform->hidden('MailMessage.mode') ?>
+<?=$this->Mailform->hidden('MailMessage.mode')?>
 
 <table cellpadding="0" cellspacing="0" class="row-table-01">
 	<?php $this->BcBaser->element('mail_input', array('blockStart' => 1)) ?>
@@ -49,26 +61,50 @@ $(function(){
 <?php if ($mailContent['MailContent']['auth_captcha']): ?>
 	<?php if (!$freezed): ?>
 		<div class="auth-captcha clearfix">
-			<?php echo $this->Mailform->authCaptcha('MailMessage.auth_captcha') ?>
+			<?=$this->Mailform->authCaptcha('MailMessage.auth_captcha')?>
 			<br />
-			&nbsp;<?php echo __('画像の文字を入力してください') ?><br clear="all" />
-			<?php echo $this->Mailform->error('MailMessage.auth_captcha', __('入力された文字が間違っています。入力をやり直してください。')) ?>
+			&nbsp;<?=__('画像の文字を入力してください')?><br clear="all" />
+			<?php echo $this->Mailform->error(
+				'MailMessage.auth_captcha',
+				__('入力された文字が間違っています。入力をやり直してください。')
+			) ?>
 		</div>
 	<?php else: ?>
-		<?php echo $this->Mailform->hidden('MailMessage.auth_captcha') ?>
-		<?php echo $this->Mailform->hidden('MailMessage.captcha_id') ?>
+		<?=$this->Mailform->hidden('MailMessage.auth_captcha')?>
+		<?=$this->Mailform->hidden('MailMessage.captcha_id')?>
 	<?php endif ?>
 <?php endif ?>
 
 <?php /* 送信ボタン */ ?>
 <div class="submit">
 	<?php if ($freezed): ?>
-		<?php echo $this->Mailform->submit('　' . __('書き直す') . '　', array('div' => false, 'class' => 'btn-red button form-submit', 'id' => 'BtnMessageBack')) ?>
-		<?php echo $this->Mailform->submit('　' . __('送信する') . '　', array('div' => false, 'class' => 'btn-red button form-submit', 'id' => 'BtnMessageSubmit')) ?>
+		<?php echo $this->Mailform->submit(
+			'　' . __('書き直す') . '　',
+			array(
+				'div'   => false,
+				'class' => 'btn-red button form-submit',
+				'id'    => 'BtnMessageBack'
+			)
+		) ?>
+		<?php echo $this->Mailform->submit(
+			'　' . __('送信する') . '　',
+			array(
+				'div'   => false,
+				'class' => 'btn-red button form-submit',
+				'id'    => 'BtnMessageSubmit'
+			)
+		) ?>
 	<?php else: ?>
-		<input name="resetdata" value="　<?php echo __('クリア') ?>　" type="reset" class="btn-gray button" />
-		<?php echo $this->Mailform->submit('　' . __('入力内容を確認する') . '　', array('div' => false, 'class' => 'btn-orange button form-submit', 'id' => 'BtnMessageConfirm')) ?>
+		<input name="resetdata" value="　<?=__('クリア')?>　" type="reset" class="btn-gray button" />
+		<?php echo $this->Mailform->submit(
+			'　' . __('入力内容を確認する') . '　',
+			array(
+				'div'   => false,
+				'class' => 'btn-orange button form-submit',
+				'id'    => 'BtnMessageConfirm'
+			)
+		) ?>
 	<?php endif; ?>
 </div>
 
-<?php echo $this->Mailform->end() ?>
+<?=$this->Mailform->end()?>

--- a/lib/Baser/Plugin/Mail/View/Elements/mail_form.php
+++ b/lib/Baser/Plugin/Mail/View/Elements/mail_form.php
@@ -21,7 +21,7 @@ $this->Mail->token();
 <script type="text/javascript">
 $(function(){
 	$(".form-submit").click(function(){
-		var mode = $(this).attr('id').replace('BtnMessage', '');
+		let mode = $(this).attr('id').replace('BtnMessage', '');
 		$("#MailMessageMode").val(mode);
 		$(this).prop('disabled',true);//ボタンを無効化する
 		$(this).closest('form').submit();//フォームを送信する

--- a/lib/Baser/Plugin/Mail/View/Elements/mail_input.php
+++ b/lib/Baser/Plugin/Mail/View/Elements/mail_input.php
@@ -24,10 +24,21 @@ if (empty($mailFields)) {
 }
 
 $template = [
-	'row' => '<tr id="{%row_id%}"{%display%}><th class="col-head" width="150">{%title%}</th><td class="col-input">{%form%}</td></tr>',
-	'title' => '{%title%}<span class="{%required_class%}">{%required_word%}</span>',
+	'row'    => [
+		'<tr id="{%row_id%}"{%display%}>',
+		'<th class="col-head" width="150">{%title%}</th>',
+		'<td class="col-input">{%form%}</td>',
+		'</tr>'
+	],
+	'row_id' => 'RowMessage{%camelize(field_name)%}',
+	'title'  => '{%title%}<span class="{%required_class%}">{%required_word%}</span>',
 	'form' => [
-		'wrap'        => '<span id="{%row_id%}">{%description%}{%before%}{%form%}{%after%}{%attention%}{%error%}{%group-error%}</span>',
+		'wrap'        => [
+			'<span id="{%row_id%}">',
+			'{%description%}{%before%}{%form%}{%after%}{%attention%}{%error%}{%group-error%}',
+			'</span>'
+		],
+		'row_id'      => 'FieldMessage{%camelize(field_name)%}',
 		'description' => '<span class="mail-description">{%description%}</span>',
 		'before'      => '<span class="mail-before-attachment">{%before%}</span>',
 		'after'       => '<span class="mail-after-attachment">{%after%}</span>',
@@ -125,10 +136,16 @@ foreach ($mailFields as $key => $record) {
 			Hash::get($template, 'form.after'), ['after'=>$field['after_attachment']]
 		);
 	}
+	if (!$isGroupValidComplate) {
+		$tmp['error'] = $this->Mailform->error('MailMessage.' . $field['field_name']);
+	}
 	$form[] = $this->Mail->formatText(
 		Hash::get($template, 'form.wrap'),
 		[
-			'row_id'      => 'FieldMessage' . Inflector::camelize($field['field_name']),
+			'row_id'      => $this->Mail->formatText(
+				Hash::get($template, 'form.row_id'),
+				['camelize(field_name)'=>Inflector::camelize($field['field_name'])]
+			),
 			'description' => Hash::get($tmp, 'description', ''),
 			'before'      => Hash::get($tmp, 'before', ''),
 			'form' => $this->Mailform->control(
@@ -139,7 +156,7 @@ foreach ($mailFields as $key => $record) {
 			),
 			'after'       => Hash::get($tmp, 'after', ''),
 			'attention'   => !$freezed ? $this->Mailform->error(Hash::get($template, 'form.attention'), $field) : '',
-			'error'       => !$isGroupValidComplate ? $this->Mailform->error('MailMessage.' . $field['field_name']) : '',
+			'error'       => Hash::get($tmp, 'error', ''),
 			'group-error' => implode("\n", $errors)
 
 		]

--- a/lib/Baser/Plugin/Mail/View/Elements/mail_input.php
+++ b/lib/Baser/Plugin/Mail/View/Elements/mail_input.php
@@ -27,11 +27,11 @@ $template = [
 	'row' => '<tr id="{%row_id%}"{%display%}><th class="col-head" width="150">{%title%}</th><td class="col-input">{%form%}</td></tr>',
 	'title' => '{%title%}<span class="{%required_class%}">{%required_word%}</span>',
 	'form' => [
-		'wrap'          => '<span id="{%row_id%}">{%description%}{%before%}{%form%}{%after%}{%attention%}{%error%}{%group-error%}</span>',
-		'description'   => '<span class="mail-description">{%description%}</span>',
-		'before' => '<span class="mail-before-attachment">{%before%}</span>',
-		'after'  => '<span class="mail-after-attachment">{%after%}</span>',
-		'attention'     => '<span class="mail-attention">{%attention%}</span>'
+		'wrap'        => '<span id="{%row_id%}">{%description%}{%before%}{%form%}{%after%}{%attention%}{%error%}{%group-error%}</span>',
+		'description' => '<span class="mail-description">{%description%}</span>',
+		'before'      => '<span class="mail-before-attachment">{%before%}</span>',
+		'after'       => '<span class="mail-after-attachment">{%after%}</span>',
+		'attention'   => '<span class="mail-attention">{%attention%}</span>'
 	]
 ];
 

--- a/lib/Baser/Plugin/Mail/View/Elements/mail_input.php
+++ b/lib/Baser/Plugin/Mail/View/Elements/mail_input.php
@@ -70,28 +70,6 @@ foreach ($records as $key => $record) {
 	$field = $record['MailField'];
 	$next_key = $key + 1;
 
-	/* 項目名 */
-	if ($group_field != $field['group_field'] || (!$group_field && !$field['group_field'])) {
-		$row = $this->mail->formatText(
-			Hash::get($template, 'row'),
-			[
-				'row_id'  => $this->Mail->formatText(
-					Hash::get($template, 'row_id'),
-					['camelize(field_name)'=>Inflector::camelize($field['field_name'])]
-				),
-				'display' => $field['type'] === 'hidden' ? ' style="display:none"' : '',
-				'label'   =>$this->Mailform->label(
-					sprintf('MailMessage.%s', $field['field_name']),
-					$field['head']
-				),
-				'mark'    => Hash::get(
-					$template,
-					$field['not_empty'] ? 'mark.required' : 'mark.optional'
-				)
-			]
-		);
-	}
-
 	// =========================================================================================================
 	// 2018/02/06 ryuring
 	// no_send オプションは、確認画面に表示しないようにするために利用されている可能性が高い
@@ -100,6 +78,23 @@ foreach ($records as $key => $record) {
 	// 後方互換のため残す
 	// =========================================================================================================
 	$isGroupValidComplate = in_array('VALID_GROUP_COMPLATE', explode(',', $field['valid_ex']));
+	$tmp = [];
+	if(!$this->get('freezed') && $field['description']) {
+		$tmp['description'] = $this->Mail->formatText(
+			Hash::get($template, 'input.description'), $field
+		);
+	}
+	if(!$this->get('freezed') || $this->Mailform->value('MailMessage.' . $field['field_name']) !== '') {
+		$tmp['before'] = $this->Mail->formatText(
+			Hash::get($template, 'input.before'), ['before'=>$field['before_attachment']]
+		);
+		$tmp['after']  = $this->Mail->formatText(
+			Hash::get($template, 'input.after'), ['after'=>$field['after_attachment']]
+		);
+	}
+	if (!$isGroupValidComplate) {
+		$tmp['error'] = $this->Mailform->error('MailMessage.' . $field['field_name']);
+	}
 	$errors = [];
 	if ($this->Mailform->isGroupLastField($this->get('mailFields'), $field)) {
 		if ($isGroupValidComplate) {
@@ -121,23 +116,6 @@ foreach ($records as $key => $record) {
 			'MailMessage.' . $field['group_valid'] . '_not_complate',
 			__('入力データが不完全です。')
 		);
-	}
-	$tmp = [];
-	if(!$this->get('freezed') && $field['description']) {
-		$tmp['description'] = $this->Mail->formatText(
-			Hash::get($template, 'input.description'), $field
-		);
-	}
-	if(!$this->get('freezed') || $this->Mailform->value('MailMessage.' . $field['field_name']) !== '') {
-		$tmp['before'] = $this->Mail->formatText(
-			Hash::get($template, 'input.before'), ['before'=>$field['before_attachment']]
-		);
-		$tmp['after']  = $this->Mail->formatText(
-			Hash::get($template, 'input.after'), ['after'=>$field['after_attachment']]
-		);
-	}
-	if (!$isGroupValidComplate) {
-		$tmp['error'] = $this->Mailform->error('MailMessage.' . $field['field_name']);
 	}
 	$input[] = $this->Mail->formatText(
 		Hash::get($template, 'input.wrap'),
@@ -161,6 +139,28 @@ foreach ($records as $key => $record) {
 
 		]
 	);
+
+	/* 項目名 */
+	if ($group_field != $field['group_field'] || (!$group_field && !$field['group_field'])) {
+		$row = $this->mail->formatText(
+			Hash::get($template, 'row'),
+			[
+				'row_id'  => $this->Mail->formatText(
+					Hash::get($template, 'row_id'),
+					['camelize(field_name)'=>Inflector::camelize($field['field_name'])]
+				),
+				'display' => $field['type'] === 'hidden' ? ' style="display:none"' : '',
+				'label'   =>$this->Mailform->label(
+					sprintf('MailMessage.%s', $field['field_name']),
+					$field['head']
+				),
+				'mark'    => Hash::get(
+					$template,
+					$field['not_empty'] ? 'mark.required' : 'mark.optional'
+				)
+			]
+		);
+	}
 
 	if ($this->Mailform->isGroupLastField($this->get('mailFields'), $field) || empty($field['group_field'])) {
 		$rows[] = $this->Mail->formatText($row,['input'=>implode("\n", $input)]);

--- a/lib/Baser/Plugin/Mail/View/Elements/mail_input.php
+++ b/lib/Baser/Plugin/Mail/View/Elements/mail_input.php
@@ -26,19 +26,22 @@ if (!$this->get('mailFields')) {
 $template = [
 	'row'    => [
 		'<tr id="{%row_id%}"{%display%}>',
-		'<th class="col-head" width="150">{%label%}</th>',
+		'<th class="col-head" width="150">{%label%}{%mark%}</th>',
 		'<td class="col-input">{%input%}</td>',
 		'</tr>'
 	],
 	'row_id' => 'RowMessage{%camelize(field_name)%}',
-	'label'  => '{%label%}<span class="{%required_class%}">{%required_word%}</span>',
+	'mark'   => [
+		'required' => sprintf('<span class="required">%s</span>', __('必須')),
+		'optional' => sprintf('<span class="normal">%s</span>', __('任意'))
+	],
 	'input' => [
 		'wrap'        => [
 			'<span id="{%field_id%}">',
 			'{%description%}{%before%}{%input%}{%after%}{%attention%}{%error%}{%group-error%}',
 			'</span>'
 		],
-		'field_id'      => 'FieldMessage{%camelize(field_name)%}',
+		'field_id'    => 'FieldMessage{%camelize(field_name)%}',
 		'description' => '<span class="mail-description">{%description%}</span>',
 		'before'      => '<span class="mail-before-attachment">{%before%}</span>',
 		'after'       => '<span class="mail-after-attachment">{%after%}</span>',
@@ -72,18 +75,18 @@ foreach ($records as $key => $record) {
 		$row = $this->mail->formatText(
 			Hash::get($template, 'row'),
 			[
-				'row_id'  => 'RowMessage' . Inflector::camelize($field['field_name']),
+				'row_id'  => $this->Mail->formatText(
+					Hash::get($template, 'row_id'),
+					['camelize(field_name)'=>Inflector::camelize($field['field_name'])]
+				),
 				'display' => $field['type'] === 'hidden' ? ' style="display:none"' : '',
-				'label'   => $this->mail->formatText(
-					Hash::get($template, 'label'),
-					[
-						'label'   =>$this->Mailform->label(
-							sprintf('MailMessage.%s', $field['field_name']),
-							$field['head']
-						),
-						'required_class' => $field['not_empty'] ? 'required' : 'normal',
-						'required_word'  => $field['not_empty'] ? __('必須') : __('任意')
-					]
+				'label'   =>$this->Mailform->label(
+					sprintf('MailMessage.%s', $field['field_name']),
+					$field['head']
+				),
+				'mark'    => Hash::get(
+					$template,
+					$field['not_empty'] ? 'mark.required' : 'mark.optional'
 				)
 			]
 		);

--- a/lib/Baser/Plugin/Mail/View/Elements/mail_input.php
+++ b/lib/Baser/Plugin/Mail/View/Elements/mail_input.php
@@ -22,6 +22,10 @@
 if (empty($mailFields)) {
 	return;
 }
+
+$tpl_row = '<tr id="{%row_id%}"{%display%}><th class="col-head" width="150">{%title%}<span class="{%required_class%}">{%required_word%}</span></th><td class="col-input">{%form%}</td></tr>';
+$tpl_form = '<span id="{%id%}">{%description%}{%before-attach%}{%form%}{%after-attach%}{%attention%}{%error%}{%lastErrors%}</span>';
+
 $group_field = null;
 $iteration = 0;
 if (!isset($blockEnd)) {
@@ -48,7 +52,7 @@ foreach ($mailFields as $key => $record) {
 	/* 項目名 */
 	if ($group_field != $field['group_field'] || (!$group_field && !$field['group_field'])) {
 		$title = $this->mail->formatText(
-			'<tr id="{%row_id%}"{%display%}><th class="col-head" width="150">{%title%}<span class="{%required_class%}">{%required_word%}</span></th><td class="col-input">{%form%}</td></tr>',
+			$tpl_row,
 			[
 				'row_id'  => 'RowMessage' . Inflector::camelize($field['field_name']),
 				'display' => $field['type'] === 'hidden' ? ' style="display:none"' : '',
@@ -72,6 +76,7 @@ foreach ($mailFields as $key => $record) {
 	// 本来であれば、not_display_confirm 等のオプションを別途準備し、そちらを利用するべきだが、
 	// 後方互換のため残す
 	// =========================================================================================================
+	$isGroupValidComplate = in_array('VALID_GROUP_COMPLATE', explode(',', $field['valid_ex']));
 	$errors = [];
 	if ($this->Mailform->isGroupLastField($mailFields, $field)) {
 		if ($isGroupValidComplate) {
@@ -96,12 +101,11 @@ foreach ($mailFields as $key => $record) {
 	}
 	$hasDescription = (!$freezed && $field['description']);
 	$hasAttachment = (!$freezed || $this->Mailform->value('MailMessage.' . $field['field_name']) !== '');
-	$isGroupValidComplate = in_array('VALID_GROUP_COMPLATE', explode(',', $field['valid_ex']));
 	$form[] = $this->Mail->formatText(
-		'<span id="{%id%}">{%description%}{%before-attach%}{%form%}{%after-attach%}{%attention%}{%error%}{%lastErrors%}</span>',
+		$tpl_form,
 		[
-			'id'=>'FieldMessage' . Inflector::camelize($field['field_name']),
-			'description' => $hasDescription ? sprintf('<span class="mail-description">%s</span>', $field['description']) : '',
+			'id'            => 'FieldMessage' . Inflector::camelize($field['field_name']),
+			'description'   => $hasDescription ? sprintf('<span class="mail-description">%s</span>', $field['description']) : '',
 			'before-attach' => $hasAttachment  ? sprintf('<span class="mail-before-attachment">%s</span>', $field['before_attachment']) : '',
 			'form' => $this->Mailform->control(
 				($freezed && $field['no_send']) ? 'hidden' : $field['type'],
@@ -110,8 +114,8 @@ foreach ($mailFields as $key => $record) {
 				$this->Mailfield->getAttributes($record)
 			),
 			'after-attach'=>$hasAttachment ? sprintf('<span class="mail-after-attachment">%s</span>', $field['after_attachment']) : '',
-			'attention'=>!$freezed ? sprintf('<span class="mail-attention">%s</span>', $field['attention']) : '',
-			'error'=>!$isGroupValidComplate ? $this->Mailform->error('MailMessage.' . $field['field_name']) : '',
+			'attention'  => !$freezed ? sprintf('<span class="mail-attention">%s</span>', $field['attention']) : '',
+			'error'      => !$isGroupValidComplate ? $this->Mailform->error('MailMessage.' . $field['field_name']) : '',
 			'lastErrors' => implode("\n", $errors)
 
 		]

--- a/lib/Baser/Plugin/Mail/View/Elements/mail_input.php
+++ b/lib/Baser/Plugin/Mail/View/Elements/mail_input.php
@@ -26,19 +26,19 @@ if (empty($mailFields)) {
 $template = [
 	'row'    => [
 		'<tr id="{%row_id%}"{%display%}>',
-		'<th class="col-head" width="150">{%title%}</th>',
-		'<td class="col-input">{%form%}</td>',
+		'<th class="col-head" width="150">{%label%}</th>',
+		'<td class="col-input">{%input%}</td>',
 		'</tr>'
 	],
 	'row_id' => 'RowMessage{%camelize(field_name)%}',
-	'title'  => '{%title%}<span class="{%required_class%}">{%required_word%}</span>',
-	'form' => [
+	'label'  => '{%label%}<span class="{%required_class%}">{%required_word%}</span>',
+	'input' => [
 		'wrap'        => [
-			'<span id="{%row_id%}">',
-			'{%description%}{%before%}{%form%}{%after%}{%attention%}{%error%}{%group-error%}',
+			'<span id="{%field_id%}">',
+			'{%description%}{%before%}{%input%}{%after%}{%attention%}{%error%}{%group-error%}',
 			'</span>'
 		],
-		'row_id'      => 'FieldMessage{%camelize(field_name)%}',
+		'field_id'      => 'FieldMessage{%camelize(field_name)%}',
 		'description' => '<span class="mail-description">{%description%}</span>',
 		'before'      => '<span class="mail-before-attachment">{%before%}</span>',
 		'after'       => '<span class="mail-after-attachment">{%after%}</span>',
@@ -53,7 +53,7 @@ if (!isset($blockEnd)) {
 }
 
 $row  = null;
-$form = [];
+$input = [];
 $rows = [];
 foreach ($mailFields as $key => $record) {
 
@@ -77,10 +77,10 @@ foreach ($mailFields as $key => $record) {
 			[
 				'row_id'  => 'RowMessage' . Inflector::camelize($field['field_name']),
 				'display' => $field['type'] === 'hidden' ? ' style="display:none"' : '',
-				'title'   => $this->mail->formatText(
-					Hash::get($template, 'title'),
+				'label'   => $this->mail->formatText(
+					Hash::get($template, 'label'),
 					[
-						'title'   =>$this->Mailform->label(
+						'label'   =>$this->Mailform->label(
 							sprintf('MailMessage.%s', $field['field_name']),
 							$field['head']
 						),
@@ -125,37 +125,37 @@ foreach ($mailFields as $key => $record) {
 	$tmp = [];
 	if(!$freezed && $field['description']) {
 		$tmp['description'] = $this->Mail->formatText(
-			Hash::get($template, 'form.description'), $field
+			Hash::get($template, 'input.description'), $field
 		);
 	}
 	if(!$freezed || $this->Mailform->value('MailMessage.' . $field['field_name']) !== '') {
 		$tmp['before'] = $this->Mail->formatText(
-			Hash::get($template, 'form.before'), ['before'=>$field['before_attachment']]
+			Hash::get($template, 'input.before'), ['before'=>$field['before_attachment']]
 		);
 		$tmp['after']  = $this->Mail->formatText(
-			Hash::get($template, 'form.after'), ['after'=>$field['after_attachment']]
+			Hash::get($template, 'input.after'), ['after'=>$field['after_attachment']]
 		);
 	}
 	if (!$isGroupValidComplate) {
 		$tmp['error'] = $this->Mailform->error('MailMessage.' . $field['field_name']);
 	}
-	$form[] = $this->Mail->formatText(
-		Hash::get($template, 'form.wrap'),
+	$input[] = $this->Mail->formatText(
+		Hash::get($template, 'input.wrap'),
 		[
-			'row_id'      => $this->Mail->formatText(
-				Hash::get($template, 'form.row_id'),
+			'field_id'      => $this->Mail->formatText(
+				Hash::get($template, 'input.field_id'),
 				['camelize(field_name)'=>Inflector::camelize($field['field_name'])]
 			),
 			'description' => Hash::get($tmp, 'description', ''),
 			'before'      => Hash::get($tmp, 'before', ''),
-			'form' => $this->Mailform->control(
+			'input' => $this->Mailform->control(
 				($freezed && $field['no_send']) ? 'hidden' : $field['type'],
 				'MailMessage.' . $field['field_name'],
 				$this->Mailfield->getOptions($record),
 				$this->Mailfield->getAttributes($record)
 			),
 			'after'       => Hash::get($tmp, 'after', ''),
-			'attention'   => !$freezed ? $this->Mailform->error(Hash::get($template, 'form.attention'), $field) : '',
+			'attention'   => !$freezed ? $this->Mailform->error(Hash::get($template, 'input.attention'), $field) : '',
 			'error'       => Hash::get($tmp, 'error', ''),
 			'group-error' => implode("\n", $errors)
 
@@ -163,9 +163,9 @@ foreach ($mailFields as $key => $record) {
 	);
 
 	if ($this->Mailform->isGroupLastField($mailFields, $field) || empty($field['group_field'])) {
-		$rows[] = $this->Mail->formatText($row,['form'=>implode("\n", $form)]);
+		$rows[] = $this->Mail->formatText($row,['input'=>implode("\n", $input)]);
 		$row = false;
-		$form = [];
+		$input = [];
 	}
 	$group_field = $field['group_field'];
 }

--- a/lib/Baser/Plugin/Mail/View/Elements/mail_input.php
+++ b/lib/Baser/Plugin/Mail/View/Elements/mail_input.php
@@ -22,90 +22,105 @@
 if (empty($mailFields)) {
 	return;
 }
-
 $group_field = null;
 $iteration = 0;
 if (!isset($blockEnd)) {
 	$blockEnd = 0;
 }
 
+$title = null;
+$form = [];
 foreach ($mailFields as $key => $record) {
 
-	$field = $record['MailField'];
 	$iteration++;
-	if ($field['use_field'] && ($blockStart && $iteration >= $blockStart) && (!$blockEnd || $iteration <= $blockEnd)) {
+	if (!$record['MailField']['use_field']) {
+		continue;
+	}
+	if (!$blockStart || $iteration < $blockStart) {
+		continue;
+	}
+	if ($blockEnd && $iteration > $blockEnd) {
+		continue;
+	}
+	$field = $record['MailField'];
+	$next_key = $key + 1;
 
-		$next_key = $key + 1;
-		$description = $field['description'];
+	/* 項目名 */
+	if ($group_field != $field['group_field'] || (!$group_field && !$field['group_field'])) {
+		$title = $this->mail->formatText(
+			'<tr id="{%row_id%}"{%display%}><th class="col-head" width="150">{%title%}<span class="{%required_class%}">{%required_word%}</span></th><td class="col-input">{%form%}</td></tr>',
+			[
+				'row_id'  => 'RowMessage' . Inflector::camelize($field['field_name']),
+				'display' => $field['type'] === 'hidden' ? ' style="display:none"' : '',
+				'title'   =>$this->Mailform->label(
+					sprintf(
+						'MailMessage.%s',
+						$field['field_name']
+					),
+					$field['head']
+				),
+				'required_class' => $field['not_empty'] ? 'required' : 'normal',
+				'required_word'  => $field['not_empty'] ? __('必須') : __('任意')
+			]
+		);
+	}
 
-		/* 項目名 */
-		if ($group_field != $field['group_field'] || (!$group_field && !$field['group_field'])) {
-			echo '    <tr id="RowMessage' . Inflector::camelize($record['MailField']['field_name']) . '"';
-			if ($field['type'] === 'hidden') {
-				echo ' style="display:none"';
-			}
-			echo '>' . "\n" . '        <th class="col-head" width="150">' . $this->Mailform->label("MailMessage." . $field['field_name'] . "", $field['head']);
-			if ($field['not_empty']) {
-				echo '<span class="required">' . __('必須') . '</span>';
-			} else {
-				echo '<span class="normal">' . __('任意') . '</span>';
-			}
-			echo '</th>' . "\n" . '        <td class="col-input">';
-		}
-
-		echo '<span id="FieldMessage' . Inflector::camelize($record['MailField']['field_name']) . '">';
-		if (!$freezed && $description) {
-			echo '<span class="mail-description">' . $description . '</span>';
-		}
-		/* 入力欄 */
-		if (!$freezed || $this->Mailform->value("MailMessage." . $field['field_name']) !== '') {
-			echo '<span class="mail-before-attachment">' . $field['before_attachment'] . '</span>';
-		}
-
-		// =========================================================================================================
-		// 2018/02/06 ryuring
-		// no_send オプションは、確認画面に表示しないようにするために利用されている可能性が高い
-		//（メールアドレスのダブル入力、プライバシーポリシーへの同意に利用されている）
-		// 本来であれば、not_display_confirm 等のオプションを別途準備し、そちらを利用するべきだが、
-		// 後方互換のため残す
-		// =========================================================================================================
-		if ($freezed && $field['no_send']) {
-			echo $this->Mailform->control('hidden', "MailMessage." . $field['field_name'] . "", $this->Mailfield->getOptions($record), $this->Mailfield->getAttributes($record));
-		} else {
-			echo $this->Mailform->control($field['type'], "MailMessage." . $field['field_name'] . "", $this->Mailfield->getOptions($record), $this->Mailfield->getAttributes($record));
-		}
-
-		if (!$freezed || $this->Mailform->value("MailMessage." . $field['field_name']) !== '') {
-			echo '<span class="mail-after-attachment">' . $field['after_attachment'] . '</span>';
-		}
-		if (!$freezed) {
-			echo '<span class="mail-attention">' . $field['attention'] . '</span>';
-		}
-
-		/* 説明欄 */
-		$isGroupValidComplate = in_array('VALID_GROUP_COMPLATE', explode(',', $field['valid_ex']));
-		if (!$isGroupValidComplate) {
-			echo $this->Mailform->error("MailMessage." . $field['field_name']);
-		}
-		$isRequiredToClose = true;
-		if ($this->Mailform->isGroupLastField($mailFields, $field)) {
-			if ($isGroupValidComplate) {
-				$groupValidErrors = $this->Mailform->getGroupValidErrors($mailFields, $field['group_valid']);
-				if ($groupValidErrors) {
-					foreach ($groupValidErrors as $groupValidError) {
-						echo $groupValidError;
-					}
+	// =========================================================================================================
+	// 2018/02/06 ryuring
+	// no_send オプションは、確認画面に表示しないようにするために利用されている可能性が高い
+	//（メールアドレスのダブル入力、プライバシーポリシーへの同意に利用されている）
+	// 本来であれば、not_display_confirm 等のオプションを別途準備し、そちらを利用するべきだが、
+	// 後方互換のため残す
+	// =========================================================================================================
+	$errors = [];
+	if ($this->Mailform->isGroupLastField($mailFields, $field)) {
+		if ($isGroupValidComplate) {
+			$groupValidErrors = $this->Mailform->getGroupValidErrors(
+				$mailFields,
+				$field['group_valid']
+			);
+			if ($groupValidErrors) {
+				foreach ($groupValidErrors as $groupValidError) {
+					$errors[] = $groupValidError;
 				}
 			}
-			echo $this->Mailform->error("MailMessage." . $field['group_valid'] . "_not_same", __("入力データが一致していません。"));
-			echo $this->Mailform->error("MailMessage." . $field['group_valid'] . "_not_complate", __("入力データが不完全です。"));
-		} elseif (!empty($field['group_field'])) {
-			$isRequiredToClose = false;
 		}
-		echo '</span>';
-		if ($isRequiredToClose) {
-			echo "</td>\n    </tr>\n";
-		}
-		$group_field = $field['group_field'];
+		$errors[] = $this->Mailform->error(
+			'MailMessage.' . $field['group_valid'] . "_not_same",
+			__('入力データが一致していません。')
+		);
+		$errors[] = $this->Mailform->error(
+			'MailMessage.' . $field['group_valid'] . '_not_complate',
+			__('入力データが不完全です。')
+		);
 	}
+	$hasDescription = (!$freezed && $field['description']);
+	$hasAttachment = (!$freezed || $this->Mailform->value('MailMessage.' . $field['field_name']) !== '');
+	$isGroupValidComplate = in_array('VALID_GROUP_COMPLATE', explode(',', $field['valid_ex']));
+	$form[] = $this->Mail->formatText(
+		'<span id="{%id%}">{%description%}{%before-attach%}{%form%}{%after-attach%}{%attention%}{%error%}{%lastErrors%}</span>',
+		[
+			'id'=>'FieldMessage' . Inflector::camelize($field['field_name']),
+			'description' => $hasDescription ? sprintf('<span class="mail-description">%s</span>', $field['description']) : '',
+			'before-attach' => $hasAttachment  ? sprintf('<span class="mail-before-attachment">%s</span>', $field['before_attachment']) : '',
+			'form' => $this->Mailform->control(
+				($freezed && $field['no_send']) ? 'hidden' : $field['type'],
+				'MailMessage.' . $field['field_name'],
+				$this->Mailfield->getOptions($record),
+				$this->Mailfield->getAttributes($record)
+			),
+			'after-attach'=>$hasAttachment ? sprintf('<span class="mail-after-attachment">%s</span>', $field['after_attachment']) : '',
+			'attention'=>!$freezed ? sprintf('<span class="mail-attention">%s</span>', $field['attention']) : '',
+			'error'=>!$isGroupValidComplate ? $this->Mailform->error('MailMessage.' . $field['field_name']) : '',
+			'lastErrors' => implode("\n", $errors)
+
+		]
+	);
+
+	if ($this->Mailform->isGroupLastField($mailFields, $field) || empty($field['group_field'])) {
+		echo $this->Mail->formatText($title,['form'=>implode("\n", $form)]);
+		$title = null;
+		$form = [];
+	}
+	$group_field = $field['group_field'];
 }

--- a/lib/Baser/Plugin/Mail/View/Elements/mail_input.php
+++ b/lib/Baser/Plugin/Mail/View/Elements/mail_input.php
@@ -13,97 +13,99 @@
 /**
  * メールフォーム入力欄
  * 呼出箇所：メールフォーム入力ページ、メールフォーム入力内容確認ページ
- * 
+ *
  * @var int $blockStart 表示するフィールドの開始NO
  * @var int $blockEnd 表示するフィールドの終了NO
  * @var bool $freezed 確認画面かどうか
  */
+
+if (empty($mailFields)) {
+	return;
+}
+
 $group_field = null;
 $iteration = 0;
 if (!isset($blockEnd)) {
 	$blockEnd = 0;
 }
 
-if (!empty($mailFields)) {
+foreach ($mailFields as $key => $record) {
 
-	foreach ($mailFields as $key => $record) {
+	$field = $record['MailField'];
+	$iteration++;
+	if ($field['use_field'] && ($blockStart && $iteration >= $blockStart) && (!$blockEnd || $iteration <= $blockEnd)) {
 
-		$field = $record['MailField'];
-		$iteration++;
-		if ($field['use_field'] && ($blockStart && $iteration >= $blockStart) && (!$blockEnd || $iteration <= $blockEnd)) {
+		$next_key = $key + 1;
+		$description = $field['description'];
 
-			$next_key = $key + 1;
-			$description = $field['description'];
-
-			/* 項目名 */
-			if ($group_field != $field['group_field'] || (!$group_field && !$field['group_field'])) {
-				echo '    <tr id="RowMessage' . Inflector::camelize($record['MailField']['field_name']) . '"';
-				if ($field['type'] == 'hidden') {
-					echo ' style="display:none"';
-				}
-				echo '>' . "\n" . '        <th class="col-head" width="150">' . $this->Mailform->label("MailMessage." . $field['field_name'] . "", $field['head']);
-				if ($field['not_empty']) {
-					echo '<span class="required">' . __('必須') . '</span>';
-				} else {
-					echo '<span class="normal">' . __('任意') . '</span>';
-				}
-				echo '</th>' . "\n" . '        <td class="col-input">';
+		/* 項目名 */
+		if ($group_field != $field['group_field'] || (!$group_field && !$field['group_field'])) {
+			echo '    <tr id="RowMessage' . Inflector::camelize($record['MailField']['field_name']) . '"';
+			if ($field['type'] === 'hidden') {
+				echo ' style="display:none"';
 			}
-
-			echo '<span id="FieldMessage' . Inflector::camelize($record['MailField']['field_name']) . '">';
-			if (!$freezed && $description) {
-				echo '<span class="mail-description">' . $description . '</span>';
-			}
-			/* 入力欄 */
-			if (!$freezed || $this->Mailform->value("MailMessage." . $field['field_name']) !== '') {
-				echo '<span class="mail-before-attachment">' . $field['before_attachment'] . '</span>';
-			}
-
-			// =========================================================================================================
-			// 2018/02/06 ryuring
-			// no_send オプションは、確認画面に表示しないようにするために利用されている可能性が高い
-			//（メールアドレスのダブル入力、プライバシーポリシーへの同意に利用されている）
-			// 本来であれば、not_display_confirm 等のオプションを別途準備し、そちらを利用するべきだが、
-			// 後方互換のため残す
-			// =========================================================================================================
-			if ($freezed && $field['no_send']) {
-				echo $this->Mailform->control('hidden', "MailMessage." . $field['field_name'] . "", $this->Mailfield->getOptions($record), $this->Mailfield->getAttributes($record));
+			echo '>' . "\n" . '        <th class="col-head" width="150">' . $this->Mailform->label("MailMessage." . $field['field_name'] . "", $field['head']);
+			if ($field['not_empty']) {
+				echo '<span class="required">' . __('必須') . '</span>';
 			} else {
-				echo $this->Mailform->control($field['type'], "MailMessage." . $field['field_name'] . "", $this->Mailfield->getOptions($record), $this->Mailfield->getAttributes($record));
+				echo '<span class="normal">' . __('任意') . '</span>';
 			}
+			echo '</th>' . "\n" . '        <td class="col-input">';
+		}
 
-			if (!$freezed || $this->Mailform->value("MailMessage." . $field['field_name']) !== '') {
-				echo '<span class="mail-after-attachment">' . $field['after_attachment'] . '</span>';
-			}
-			if (!$freezed) {
-				echo '<span class="mail-attention">' . $field['attention'] . '</span>';
-			}
+		echo '<span id="FieldMessage' . Inflector::camelize($record['MailField']['field_name']) . '">';
+		if (!$freezed && $description) {
+			echo '<span class="mail-description">' . $description . '</span>';
+		}
+		/* 入力欄 */
+		if (!$freezed || $this->Mailform->value("MailMessage." . $field['field_name']) !== '') {
+			echo '<span class="mail-before-attachment">' . $field['before_attachment'] . '</span>';
+		}
 
-			/* 説明欄 */
-			$isGroupValidComplate = in_array('VALID_GROUP_COMPLATE', explode(',', $field['valid_ex']));
-			if(!$isGroupValidComplate) {
-				echo $this->Mailform->error("MailMessage." . $field['field_name']);
-			}
-			$isRequiredToClose = true;
-			if ($this->Mailform->isGroupLastField($mailFields, $field)) {
-				if($isGroupValidComplate) {
-					$groupValidErrors = $this->Mailform->getGroupValidErrors($mailFields, $field['group_valid']);
-					if ($groupValidErrors) {
-						foreach($groupValidErrors as $groupValidError) {
-							echo $groupValidError;
-						}
+		// =========================================================================================================
+		// 2018/02/06 ryuring
+		// no_send オプションは、確認画面に表示しないようにするために利用されている可能性が高い
+		//（メールアドレスのダブル入力、プライバシーポリシーへの同意に利用されている）
+		// 本来であれば、not_display_confirm 等のオプションを別途準備し、そちらを利用するべきだが、
+		// 後方互換のため残す
+		// =========================================================================================================
+		if ($freezed && $field['no_send']) {
+			echo $this->Mailform->control('hidden', "MailMessage." . $field['field_name'] . "", $this->Mailfield->getOptions($record), $this->Mailfield->getAttributes($record));
+		} else {
+			echo $this->Mailform->control($field['type'], "MailMessage." . $field['field_name'] . "", $this->Mailfield->getOptions($record), $this->Mailfield->getAttributes($record));
+		}
+
+		if (!$freezed || $this->Mailform->value("MailMessage." . $field['field_name']) !== '') {
+			echo '<span class="mail-after-attachment">' . $field['after_attachment'] . '</span>';
+		}
+		if (!$freezed) {
+			echo '<span class="mail-attention">' . $field['attention'] . '</span>';
+		}
+
+		/* 説明欄 */
+		$isGroupValidComplate = in_array('VALID_GROUP_COMPLATE', explode(',', $field['valid_ex']));
+		if (!$isGroupValidComplate) {
+			echo $this->Mailform->error("MailMessage." . $field['field_name']);
+		}
+		$isRequiredToClose = true;
+		if ($this->Mailform->isGroupLastField($mailFields, $field)) {
+			if ($isGroupValidComplate) {
+				$groupValidErrors = $this->Mailform->getGroupValidErrors($mailFields, $field['group_valid']);
+				if ($groupValidErrors) {
+					foreach ($groupValidErrors as $groupValidError) {
+						echo $groupValidError;
 					}
 				}
-				echo $this->Mailform->error("MailMessage." . $field['group_valid'] . "_not_same", __("入力データが一致していません。"));
-				echo $this->Mailform->error("MailMessage." . $field['group_valid'] . "_not_complate", __("入力データが不完全です。"));
-			} elseif(!empty($field['group_field'])) {
-				$isRequiredToClose = false;
 			}
-			echo '</span>';
-			if($isRequiredToClose) {
-				echo "</td>\n    </tr>\n";
-			}
-			$group_field = $field['group_field'];
+			echo $this->Mailform->error("MailMessage." . $field['group_valid'] . "_not_same", __("入力データが一致していません。"));
+			echo $this->Mailform->error("MailMessage." . $field['group_valid'] . "_not_complate", __("入力データが不完全です。"));
+		} elseif (!empty($field['group_field'])) {
+			$isRequiredToClose = false;
 		}
+		echo '</span>';
+		if ($isRequiredToClose) {
+			echo "</td>\n    </tr>\n";
+		}
+		$group_field = $field['group_field'];
 	}
 }

--- a/lib/Baser/Plugin/Mail/View/Elements/mail_input.php
+++ b/lib/Baser/Plugin/Mail/View/Elements/mail_input.php
@@ -14,12 +14,12 @@
  * メールフォーム入力欄
  * 呼出箇所：メールフォーム入力ページ、メールフォーム入力内容確認ページ
  *
- * @var int $blockStart 表示するフィールドの開始NO
- * @var int $blockEnd 表示するフィールドの終了NO
- * @var bool $freezed 確認画面かどうか
+ * @var int  $this->get('blockStart') 表示するフィールドの開始NO
+ * @var int  $this->get('blockEnd') 表示するフィールドの終了NO
+ * @var bool $this->get('freezed') 確認画面かどうか
  */
 
-if (empty($mailFields)) {
+if (!$this->get('mailFields')) {
 	return;
 }
 
@@ -48,15 +48,12 @@ $template = [
 
 $group_field = null;
 $iteration = 0;
-if (!isset($blockEnd)) {
-	$blockEnd = 0;
-}
 
 $row  = null;
 $input = [];
 $rows = [];
-foreach ($mailFields as $key => $record) {
-
+$records = $this->get('mailFields');
+foreach ($records as $key => $record) {
 	$iteration++;
 	if (!$record['MailField']['use_field']) {
 		continue;
@@ -64,7 +61,7 @@ foreach ($mailFields as $key => $record) {
 	if (!$blockStart || $iteration < $blockStart) {
 		continue;
 	}
-	if ($blockEnd && $iteration > $blockEnd) {
+	if ($this->get('blockEnd') && $iteration > $this->get('blockEnd')) {
 		continue;
 	}
 	$field = $record['MailField'];
@@ -101,10 +98,10 @@ foreach ($mailFields as $key => $record) {
 	// =========================================================================================================
 	$isGroupValidComplate = in_array('VALID_GROUP_COMPLATE', explode(',', $field['valid_ex']));
 	$errors = [];
-	if ($this->Mailform->isGroupLastField($mailFields, $field)) {
+	if ($this->Mailform->isGroupLastField($this->get('mailFields'), $field)) {
 		if ($isGroupValidComplate) {
 			$groupValidErrors = $this->Mailform->getGroupValidErrors(
-				$mailFields,
+				$this->get('mailFields'),
 				$field['group_valid']
 			);
 			if ($groupValidErrors) {
@@ -123,12 +120,12 @@ foreach ($mailFields as $key => $record) {
 		);
 	}
 	$tmp = [];
-	if(!$freezed && $field['description']) {
+	if(!$this->get('freezed') && $field['description']) {
 		$tmp['description'] = $this->Mail->formatText(
 			Hash::get($template, 'input.description'), $field
 		);
 	}
-	if(!$freezed || $this->Mailform->value('MailMessage.' . $field['field_name']) !== '') {
+	if(!$this->get('freezed') || $this->Mailform->value('MailMessage.' . $field['field_name']) !== '') {
 		$tmp['before'] = $this->Mail->formatText(
 			Hash::get($template, 'input.before'), ['before'=>$field['before_attachment']]
 		);
@@ -149,20 +146,20 @@ foreach ($mailFields as $key => $record) {
 			'description' => Hash::get($tmp, 'description', ''),
 			'before'      => Hash::get($tmp, 'before', ''),
 			'input' => $this->Mailform->control(
-				($freezed && $field['no_send']) ? 'hidden' : $field['type'],
+				($this->get('freezed') && $field['no_send']) ? 'hidden' : $field['type'],
 				'MailMessage.' . $field['field_name'],
 				$this->Mailfield->getOptions($record),
 				$this->Mailfield->getAttributes($record)
 			),
 			'after'       => Hash::get($tmp, 'after', ''),
-			'attention'   => !$freezed ? $this->Mailform->error(Hash::get($template, 'input.attention'), $field) : '',
+			'attention'   => !$this->get('freezed') ? $this->Mailform->error(Hash::get($template, 'input.attention'), $field) : '',
 			'error'       => Hash::get($tmp, 'error', ''),
 			'group-error' => implode("\n", $errors)
 
 		]
 	);
 
-	if ($this->Mailform->isGroupLastField($mailFields, $field) || empty($field['group_field'])) {
+	if ($this->Mailform->isGroupLastField($this->get('mailFields'), $field) || empty($field['group_field'])) {
 		$rows[] = $this->Mail->formatText($row,['input'=>implode("\n", $input)]);
 		$row = false;
 		$input = [];

--- a/lib/Baser/Plugin/Mail/View/Elements/mail_token.php
+++ b/lib/Baser/Plugin/Mail/View/Elements/mail_token.php
@@ -21,7 +21,7 @@ $(function(){
 <?php else: ?>
 $(window).on('load', function() {
 <?php endif ?>
-	var getTokenUrl = '<?php echo $this->BcBaser->getUrl('/bc_form/ajax_get_token?requestview=false') ?>';
+	let getTokenUrl = '<?php echo $this->BcBaser->getUrl('/bc_form/ajax_get_token?requestview=false') ?>';
 	$.ajaxSetup({cache: false});
 	$.get(getTokenUrl, function(result) {
 		$('input[name="data[_Token][key]"]').val(result);

--- a/lib/Baser/Plugin/Mail/View/Elements/mail_token.php
+++ b/lib/Baser/Plugin/Mail/View/Elements/mail_token.php
@@ -13,11 +13,11 @@
 
 
 <script type="text/javascript">
-$(document).ready(function(){
+$(function(){
 	$('input[type="submit"]').prop('disabled', true);
 });
 <?php if($this->request->is('ajax')): ?>
-$(document).ready(function(){
+$(function(){
 <?php else: ?>
 $(window).on('load', function() {
 <?php endif ?>

--- a/lib/Baser/Plugin/Mail/View/Helper/MailBaserHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MailBaserHelper.php
@@ -26,7 +26,13 @@ class MailBaserHelper extends AppHelper {
  * @return bool
  */
 	public function isMail() {
-		return (!empty($this->request->params['Content']['plugin']) && $this->request->params['Content']['plugin'] == 'Mail');
+		if (!Hash::get($this->request->params, 'Content.plugin')) {
+			return false;
+		}
+		if (Hash::get($this->request->params, 'Content.plugin') !== 'Mail') {
+			return false;
+		}
+		return true;
 	}
-	
+
 }

--- a/lib/Baser/Plugin/Mail/View/Helper/MailHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MailHelper.php
@@ -170,11 +170,11 @@ class MailHelper extends AppHelper {
  * @return boolean 設定されている場合 true を返す
  */
 	public function descriptionExists() {
-		if (!empty($this->mailContent['description'])) {
-			return true;
-		} else {
+		if (empty($this->mailContent['description'])) {
 			return false;
 		}
+
+		return true;
 	}
 
 /**
@@ -243,7 +243,7 @@ class MailHelper extends AppHelper {
  * @param string $viewFile
  */
 	public function beforeRender($viewFile) {
-		if($this->request->params['controller'] == 'mail' && in_array($this->request->params['action'], ['index', 'confirm', 'submit'])) {
+		if($this->request->params['controller'] === 'mail' && in_array($this->request->params['action'], ['index', 'confirm', 'submit'])) {
 			// メールフォームをショートコードを利用する際、ショートコードの利用先でキャッシュを利用している場合、
 			// セキュリティコンポーネントで発行するトークンが更新されない為、強制的にキャッシュをオフにする
 			if (!empty($this->request->params['requested'])) {

--- a/lib/Baser/Plugin/Mail/View/Helper/MailHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MailHelper.php
@@ -252,5 +252,15 @@ class MailHelper extends AppHelper {
 			$this->_View->BcForm->request->params['_Token']['unlockedFields'] = $this->_View->get('unlockedFields');
 		}
 	}
-
+	/**
+	 * 簡易テンプレート
+	 *
+	 * @return string
+	 */
+	public function formatText($text, $values=[], $left='{%', $right='%}') {
+		foreach ($values as $k=>$v) {
+			$text = str_replace($left.$k.$right, $v, $text);
+		}
+		return $text;
+	}
 }

--- a/lib/Baser/Plugin/Mail/View/Helper/MailHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MailHelper.php
@@ -258,6 +258,9 @@ class MailHelper extends AppHelper {
 	 * @return string
 	 */
 	public function formatText($text, $values=[], $left='{%', $right='%}') {
+		if(is_array($text)) {
+			$text = implode("\n", $text);
+		}
 		foreach ($values as $k=>$v) {
 			$text = str_replace($left.$k.$right, $v, $text);
 		}

--- a/lib/Baser/Plugin/Mail/View/Helper/MaildataHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MaildataHelper.php
@@ -48,16 +48,6 @@ class MaildataHelper extends BcTextHelper {
  */
 	public function toDisplayString($type, $value) {
 		switch ($type) {
-			case 'text':
-			case 'tel':
-			case 'textarea':
-			case 'email':
-			case 'hidden':
-			case 'check':
-			case 'radio':
-			case 'select':
-				return $value;
-
 			case 'pref':
 				$prefs = $this->prefList();
 				$options = array();

--- a/lib/Baser/Plugin/Mail/View/Helper/MaildataHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MaildataHelper.php
@@ -86,9 +86,19 @@ class MaildataHelper extends BcTextHelper {
 				$aryFile = explode('/', $value);
 				$file = $aryFile[count($aryFile) - 1];
 				$ext = decodeContent(null, $file);
-				$link = array_merge(array('admin' => true, 'controller' => 'mail_messages', 'action' => 'attachment', $mailContent['MailContent']['id']), $aryFile);
+				$link = array_merge(
+					array(
+						'admin' => true,
+						'controller' => 'mail_messages',
+						'action' => 'attachment',
+						$mailContent['MailContent']['id']
+					),
+					$aryFile
+				);
 				if (in_array($ext, array('gif', 'jpg', 'png'))) {
-					return $this->BcBaser->getLink($this->BcBaser->getImg($link, array('width' => 400)), $link, array('target' => '_blank'));
+					return $this->BcBaser->getLink(
+						$this->BcBaser->getImg($link, array('width' => 400)), $link, array('target' => '_blank')
+					);
 				}
 
 				return $this->BcBaser->getLink($file, $link);

--- a/lib/Baser/Plugin/Mail/View/Helper/MailfieldHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MailfieldHelper.php
@@ -34,9 +34,9 @@ class MailfieldHelper extends AppHelper {
 		$attributes['maxlength'] = $data['maxlength'];
 		$attributes['separator'] = $data['separator'];
 		$attributes['class'] = $data['class'];
-		if($data['type'] == 'multi_check') {
+		if($data['type'] === 'multi_check') {
 			$attributes['multiple'] = true;
-		} elseif ($data['type'] == 'tel') {
+		} elseif ($data['type'] === 'tel') {
 			$attributes['type'] = 'tel';
 		}
 		if (!empty($data['options'])) {
@@ -58,7 +58,7 @@ class MailfieldHelper extends AppHelper {
 			$data = $data['MailField'];
 		}
 		if (!empty($data['source'])) {
-			if ($data['type'] != "check") {
+			if ($data['type'] !== "check") {
 				$values = explode("\n", str_replace('|', "\n", $data['source']));
 				$source = [];
 				foreach ($values as $value) {

--- a/lib/Baser/Plugin/Mail/View/Helper/MailformHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MailformHelper.php
@@ -24,7 +24,7 @@ class MailformHelper extends BcFreezeHelper {
 
 /**
  * ヘルパー
- * 
+ *
  * @var array
  */
 	public $helpers = ['Html', 'BcTime', 'BcText', 'Js', 'BcUpload', 'BcCkeditor', 'BcBaser', 'BcContents', 'BcArray'];
@@ -73,7 +73,7 @@ class MailformHelper extends BcFreezeHelper {
 				// フィールド自身が送信されないため、validatePost に引っかかってしまう
 				// hiddenタグを強制的に出すため、falseを明示的に指定
 				$attributes['hiddenField'] = false;
-				$out = $this->hidden($fieldName, array(['value' => '']));
+				$out = $this->hidden($fieldName, ['value' => '']);
 				$out .= $this->radio($fieldName, $options, $attributes);
 				break;
 
@@ -83,8 +83,8 @@ class MailformHelper extends BcFreezeHelper {
 				unset($attributes['maxlength']);
 				unset($attributes['separator']);
 				if (isset($attributes['empty'])) {
-					if (strtolower($attributes['empty']) == 'false' || 
-						strtolower($attributes['empty']) == 'null') {
+					if (strtolower($attributes['empty']) === 'false' ||
+						strtolower($attributes['empty']) === 'null') {
 						$showEmpty = false;
 					} else {
 						$showEmpty = $attributes['empty'];
@@ -174,7 +174,7 @@ class MailformHelper extends BcFreezeHelper {
 				$out .= $this->file($fieldName, $attributes);
 
 				break;
-			
+
 			case 'date_time_calender':
 				unset($attributes['size']);
 				unset($attributes['rows']);
@@ -190,11 +190,11 @@ class MailformHelper extends BcFreezeHelper {
 				unset($attributes['empty']);
 				$attributes['monthNames'] = false;
 				$attributes['separator'] = '&nbsp;';
-				if (isset($attributes['minYear']) && $attributes['minYear'] == 'today') {
-					$attributes['minYear'] = intval(date('Y'));
+				if (isset($attributes['minYear']) && $attributes['minYear'] === 'today') {
+					$attributes['minYear'] = (int)date('Y');
 				}
-				if (isset($attributes['maxYear']) && $attributes['maxYear'] == 'today') {
-					$attributes['maxYear'] = intval(date('Y'));
+				if (isset($attributes['maxYear']) && $attributes['maxYear'] === 'today') {
+					$attributes['maxYear'] = (int)date('Y');
 				}
 				$out = $this->dateTime($fieldName, 'WMD', null, $attributes);
 				break;
@@ -255,7 +255,7 @@ class MailformHelper extends BcFreezeHelper {
 
 /**
  * 認証キャプチャを表示する
- * 
+ *
  * @param array $options オプション（初期値 : []）
  * 	- `separate` : 画像と入力欄の区切り（初期値：''）
  * 	- `class` : CSSクラス名（初期値：auth-captcha-image）

--- a/lib/Baser/Plugin/Mail/View/Helper/MailformHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MailformHelper.php
@@ -288,7 +288,10 @@ class MailformHelper extends BcFreezeHelper {
 	public function getGroupValidErrors($mailFields, $groupValid, $options = [], $distinct = true) {
 		$errors = [];
 		foreach ($mailFields as $mailField) {
-			if ($mailField['MailField']['group_valid'] !== $groupValid || !in_array('VALID_GROUP_COMPLATE', explode(',', $mailField['MailField']['valid_ex']))) {
+			if ($mailField['MailField']['group_valid'] !== $groupValid) {
+				continue;
+			}
+			if (!in_array('VALID_GROUP_COMPLATE', explode(',', $mailField['MailField']['valid_ex']))) {
 				continue;
 			}
 			if(!empty($this->validationErrors['MailMessage'][$mailField['MailField']['field_name']])) {


### PR DESCRIPTION
とりあえず今回はリファクタリング中心に進め、defer対応は改めて取り組みたいと思います。
今回はメンテナンス性を高めるためのコード整理を主に行ない、動作は今までどおり変わらない
ようにしています。
改修量が多いため、メール関係の他のコミットがあった場合はコンフリクトすると思いますが、
その時は当プルリクをいったん破棄して、他のコミットのほうを優先して採用いただければと
思います。（プルリクのまとめ直しはすぐできるようにしてあるので）

```
row = [
    <tr id="{%row_id%}"{%display%}>
    <th class="col-head" width="150">{%label%}</th>
    <td class="col-input">{%input%}</td>
    </tr>
]
row_id = 'RowMessage{%camelize(field_name)%}'
label  = '{%label%}<span class="{%required_class%}">{%required_word%}</span>'

input = [
    wrap = [
        <span id="{%field_id%}">
        {%description%}{%before%}{%input%}{%after%}{%attention%}{%error%}{%group-error%}
        </span>
    ]
    field_id    = 'FieldMessage{%camelize(field_name)%}'
    description = '<span class="mail-description">{%description%}</span>'
    before      = '<span class="mail-before-attachment">{%before%}</span>'
    after       = '<span class="mail-after-attachment">{%after%}</span>'
    attention   = '<span class="mail-attention">{%attention%}</span>'
]
```

https://github.com/baserproject/basercms/blob/fb05fa6f40d1514e81dba937db46f4925648d973/lib/Baser/Plugin/Mail/View/Elements/mail_input.php

htmlの構成は処理と分離し、上記のような感じにしました。
`row` がひとつの大きなまとまりで、その内側に `{%label%}` と `{%wrap%}` が
それぞれ左・右(tableでいうところのthとtd)に振り分ける形でネストされます。
さらに `{%label%}` の内側には `{%row_id%}` と `{%label%}` がネストされ、
`{%wrap%}` の内側には `{%field_id%}` から `{%attention%}` まで 5つの
htmlコードがネストされます。
今回の改修により、tableではなくdiv要素やdl要素を使って組み替えたりなどが
簡単にできるようになると思います。

分かりにくければさらに改善します。