### PR TITLE
fix #1607 admin-third利用時「最近の動き」の表示テキストが折り返して表示されない点を修正

### DIFF
--- a/app/webroot/theme/admin-third/__assets/css/components/_update-log.scss
+++ b/app/webroot/theme/admin-third/__assets/css/components/_update-log.scss
@@ -8,6 +8,7 @@
       margin-bottom: 8px;
       line-height: 1.5;
       border-bottom: 1px solid $color_border;
+      word-break: break-word;
       .date {
         font-size:80%;
       }

--- a/app/webroot/theme/admin-third/css/admin/style.css
+++ b/app/webroot/theme/admin-third/css/admin/style.css
@@ -7310,7 +7310,8 @@ body {
     padding-bottom: 9px;
     margin-bottom: 8px;
     line-height: 1.5;
-    border-bottom: 1px solid #eeeeea; }
+    border-bottom: 1px solid #eeeeea;
+    word-break: break-word; }
     .bca-update-log__list-item .date {
       font-size: 80%; }
 


### PR DESCRIPTION
issueはこちらです。 https://github.com/baserproject/basercms/issues/1607  
可能な際に取込み検討お願いします。
