### PR TITLE
fix : #1609 BlogHelper::getPostContentで、文字数をカットした際に最後に「・・・」等の文字列を挿入できるよう修正

### DIFF
--- a/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
+++ b/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
@@ -319,8 +319,8 @@ class BlogHelper extends AppHelper {
  * @param mixed $cut 文字をカットするかどうかを真偽値で指定。カットする場合、文字数を数値で入力（初期値 : false）
  * @return void
  */
-	public function postContent($post, $moreText = true, $moreLink = false, $cut = false) {
-		echo $this->getPostContent($post, $moreText, $moreLink, $cut);
+	public function postContent($post, $moreText = true, $moreLink = false, $cut = false, $lastText = false) {
+		echo $this->getPostContent($post, $moreText, $moreLink, $cut, $lastText);
 	}
 
 /**
@@ -332,9 +332,10 @@ class BlogHelper extends AppHelper {
  *	「≫ 続きを読む」という文字列がリンクとして表示される。（初期値 : false）
  * また、文字列を指定するとその文字列がリンクとなる
  * @param mixed $cut 文字をカットするかどうかを真偽値で指定。カットする場合、文字数を数値で入力（初期値 : false）
+ * @param mixed $lastText 本文後に文字列を挿入するかを真偽値で指定。挿入する場合、テキストを入力（初期値 : false）
  * @return string 記事本文
  */
-	public function getPostContent($post, $moreText = true, $moreLink = false, $cut = false) {
+	public function getPostContent($post, $moreText = true, $moreLink = false, $cut = false, $lastText = false) {
 		if ($moreLink === true) {
 			$moreLink = __d('baser', '≫ 続きを読む');
 		}
@@ -348,7 +349,12 @@ class BlogHelper extends AppHelper {
 		if ($cut) {
 			$out = str_replace(["\r\n", "\r", "\n"], '', $out);
 			$out = html_entity_decode($out, ENT_QUOTES, 'UTF-8');
-			$out = mb_substr(strip_tags($out), 0, $cut, 'UTF-8');
+			if ($lastText && mb_strlen(strip_tags($out)) > $cut) {
+				$out = mb_substr(strip_tags($out), 0, $cut, 'UTF-8') . strip_tags($lastText);
+			}
+			else {
+				$out = mb_substr(strip_tags($out), 0, $cut, 'UTF-8');
+			}
 		}
 		if ($moreLink && trim($post['BlogPost']['detail']) && trim($post['BlogPost']['detail']) != "<br>") {
 			if (!isset($this->Html)) {

--- a/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
+++ b/lib/Baser/Plugin/Blog/View/Helper/BlogHelper.php
@@ -317,6 +317,7 @@ class BlogHelper extends AppHelper {
  *	「≫ 続きを読む」という文字列がリンクとして表示される。（初期値 : false）
  * また、文字列を指定するとその文字列がリンクとなる
  * @param mixed $cut 文字をカットするかどうかを真偽値で指定。カットする場合、文字数を数値で入力（初期値 : false）
+ * @param mixed $lastText 本文後に文字列を挿入するかを真偽値で指定。挿入する場合、テキストを入力（初期値 : false）
  * @return void
  */
 	public function postContent($post, $moreText = true, $moreLink = false, $cut = false, $lastText = false) {


### PR DESCRIPTION
issueはこちらです。 #1609
引数, $lastTextに文字列を設定且つ本文の長さが$cutより大きい際に最後に文字列が追加される仕様となっております。
可能な際に取込み検討お願いします。