### PR TITLE
fix #1616 削除した（ゴミ箱に入れた）メールフォームの設定画面や受信一覧が閲覧できる

### DIFF
--- a/lib/Baser/Plugin/Mail/Controller/MailMessagesController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailMessagesController.php
@@ -66,6 +66,10 @@ class MailMessagesController extends MailAppController {
  */
 	public function beforeFilter() {
 		parent::beforeFilter();
+		$content = $this->BcContents->getContent($this->request->params['pass'][0]);
+		if(!$content) {
+			$this->notFound();
+		}
 		$this->mailContent = $this->MailContent->read(null, $this->params['pass'][0]);
 		App::uses('MailMessage', 'Mail.Model');
 		$this->MailMessage = new MailMessage();


### PR DESCRIPTION
可能な際に取込み検討お願いします。
ゴミ箱に入っているメールフォームの受信一覧にアクセスすると404になるよう変更しております。