### PR TITLE
fix #1577 【メール】リファクタリング

### DIFF
--- a/lib/Baser/Plugin/Mail/Controller/MailContentsController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailContentsController.php
@@ -94,7 +94,7 @@ class MailContentsController extends MailAppController {
 		}
 		return false;
 	}
-	
+
 /**
  * [ADMIN] メールフォーム追加
  *
@@ -181,7 +181,14 @@ class MailContentsController extends MailAppController {
 		$this->request->params['Content'] = $this->BcContents->getContent($id)['Content'];
 		if($this->request->data['Content']['status']) {
 			$site = BcSite::findById($this->request->data['Content']['site_id']);
-			$this->set('publishLink', $this->Content->getUrl($this->request->data['Content']['url'], true, $site->useSubDomain));
+			$this->set(
+				'publishLink',
+				$this->Content->getUrl(
+					$this->request->data['Content']['url'],
+					true,
+					$site->useSubDomain
+				)
+			);
 		}
 		$this->set('mailContent', $this->request->data);
 		$this->subMenuElements = ['mail_fields'];
@@ -189,7 +196,7 @@ class MailContentsController extends MailAppController {
 		$this->help = 'mail_contents_form';
 		$this->render('form');
 	}
-	
+
 /**
  * 削除
  *
@@ -210,7 +217,7 @@ class MailContentsController extends MailAppController {
 
 /**
  * メール編集画面にリダイレクトする
- * 
+ *
  * @param string $template
  * @return void
  */
@@ -232,16 +239,31 @@ class MailContentsController extends MailAppController {
 				}
 			}
 			$path = str_replace(DS, '/', $path);
-			$this->redirect(array_merge(array('plugin' => null, 'mail' => false, 'prefix' => false, 'controller' => 'theme_files', 'action' => 'edit', $this->siteConfigs['theme'], $type), explode('/', $path)));
+			$this->redirect(
+				array_merge(
+					array(
+						'plugin'     => null,
+						'mail'       => false,
+						'prefix'     => false,
+						'controller' => 'theme_files',
+						'action'     => 'edit',
+						$this->siteConfigs['theme'],
+						$type
+					),
+					explode('/', $path)
+				)
+			);
 		} else {
-			$this->BcMessage->setError(__d('baser', '現在、「テーマなし」の場合、管理画面でのテンプレート編集はサポートされていません。'));
+			$this->BcMessage->setError(
+				__d('baser', '現在、「テーマなし」の場合、管理画面でのテンプレート編集はサポートされていません。')
+			);
 			$this->redirect(array('action' => 'index'));
 		}
 	}
 
 /**
  * メールフォーム編集画面にリダイレクトする
- * 
+ *
  * @param string $template
  * @return void
  */
@@ -261,9 +283,24 @@ class MailContentsController extends MailAppController {
 				}
 			}
 			$path = str_replace(DS, '/', $path);
-			$this->redirect(array_merge(array('plugin' => null, 'mail' => false, 'prefix' => false, 'controller' => 'theme_files', 'action' => 'edit', $this->siteConfigs['theme'], 'etc'), explode('/', $path . '/index' . $this->ext)));
+			$this->redirect(
+				array_merge(
+					array(
+						'plugin'     => null,
+						'mail'       => false,
+						'prefix'     => false,
+						'controller' => 'theme_files',
+						'action'     => 'edit',
+						$this->siteConfigs['theme'],
+						'etc'
+					),
+					explode('/', $path . '/index' . $this->ext)
+				)
+			);
 		} else {
-			$this->BcMessage->setError(__d('baser', '現在、「テーマなし」の場合、管理画面でのテンプレート編集はサポートされていません。'));
+			$this->BcMessage->setError(
+				__d('baser', '現在、「テーマなし」の場合、管理画面でのテンプレート編集はサポートされていません。')
+			);
 			$this->redirect(array('action' => 'index'));
 		}
 	}

--- a/lib/Baser/Plugin/Mail/Controller/MailContentsController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailContentsController.php
@@ -84,15 +84,20 @@ class MailContentsController extends MailAppController {
 		}
 		$this->request->data['MailContent'] = $this->MailContent->getDefaultValue()['MailContent'];
 		$data = $this->MailContent->save($this->request->data);
-		if ($data) {
-			$this->MailMessage->createTable($data['MailContent']['id']);
-			$message = sprintf(__d('baser', 'メールフォーム「%s」を追加しました。'), $this->request->data['Content']['title']);
-			$this->BcMessage->setSuccess($message, true, false);
-			return json_encode($data['Content']);
-		} else {
+		if (!$data) {
 			$this->ajaxError(500, $this->MailContent->validationErrors);
+			return false;
 		}
-		return false;
+		$this->MailMessage->createTable($data['MailContent']['id']);
+		$this->BcMessage->setSuccess(
+			sprintf(
+				__d('baser', 'メールフォーム「%s」を追加しました。'),
+				$this->request->data['Content']['title']
+			),
+			true,
+			false
+		);
+		return json_encode($data['Content']);
 	}
 
 /**
@@ -102,34 +107,47 @@ class MailContentsController extends MailAppController {
  */
 	public function admin_add() {
 		$this->pageTitle = __d('baser', '新規メールフォーム登録');
+		$this->subMenuElements = ['mail_common'];
+		$this->help = 'mail_contents_form';
 
 		if (!$this->request->data) {
 			$this->request->data = $this->MailContent->getDefaultValue();
-		} else {
-
-			/* 登録処理 */
-			if (!$this->request->data['MailContent']['sender_1_']) {
-				$this->request->data['MailContent']['sender_1'] = '';
-			}
-			$this->MailContent->create($this->request->data);
-			if ($this->MailContent->validates()) {
-				if ($this->MailMessage->createTable($this->request->data['MailContent']['id'])) {
-					/* データを保存 */
-					if ($this->MailContent->save(null, false)) {
-						$this->BcMessage->setSuccess(sprintf(__d('baser', '新規メールフォーム「%s」を追加しました。'), $this->request->data['MailContent']['title']));
-						$this->redirect(array('action' => 'edit', $this->MailContent->id));
-					} else {
-						$this->BcMessage->setError(__d('baser', 'データベース処理中にエラーが発生しました。'));
-					}
-				} else {
-					$this->BcMessage->setError(__d('baser', 'データベースに問題があります。メール受信データ保存用テーブルの作成に失敗しました。'));
-				}
-			} else {
-				$this->BcMessage->setError(__d('baser', '入力エラーです。内容を修正してください。'));
-			}
+			$this->render('form');
+			return;
 		}
-		$this->subMenuElements = ['mail_common'];
-		$this->help = 'mail_contents_form';
+
+		/* 登録処理 */
+		if (!$this->request->data['MailContent']['sender_1_']) {
+			$this->request->data['MailContent']['sender_1'] = '';
+		}
+		$this->MailContent->create($this->request->data);
+		if (!$this->MailContent->validates()) {
+			$this->BcMessage->setError(__d('baser', '入力エラーです。内容を修正してください。'));
+			$this->render('form');
+			return;
+		}
+
+		if (!$this->MailMessage->createTable($this->request->data['MailContent']['id'])) {
+			$this->BcMessage->setError(
+				__d('baser', 'データベースに問題があります。メール受信データ保存用テーブルの作成に失敗しました。')
+			);
+			$this->render('form');
+			return;
+		}
+
+		/* データを保存 */
+		if (!$this->MailContent->save(null, false)) {
+			$this->BcMessage->setError(__d('baser', 'データベース処理中にエラーが発生しました。'));
+			$this->render('form');
+			return;
+		}
+
+		$this->BcMessage->setSuccess(
+			sprintf(__d('baser', '新規メールフォーム「%s」を追加しました。'),
+				$this->request->data['MailContent']['title']
+			)
+		);
+		$this->redirect(array('action' => 'edit', $this->MailContent->id));
 		$this->render('form');
 	}
 
@@ -143,25 +161,31 @@ class MailContentsController extends MailAppController {
 
 		if (!$id && empty($this->request->data)) {
 			$this->BcMessage->setError(__d('baser', '無効なIDです。'));
-			$this->redirect(['plugin' => false, 'admin' => true, 'controller' => 'contents', 'action' => 'index']);
+			$this->redirect(
+				['plugin' => false, 'admin' => true, 'controller' => 'contents', 'action' => 'index']
+			);
 		}
 
-		if (empty($this->request->data['MailContent']['id'])) {
-			$this->request->data = $this->MailContent->read(null, $id);
-			if ($this->MailContent->isOverPostSize()) {
-				$this->BcMessage->setError(__d('baser', '送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。', ini_get('post_max_size')));
-			}
-			if(!$this->request->data) {
-				$this->BcMessage->setError(__d('baser', '無効な処理です。'));
-				$this->redirect(['plugin' => false, 'admin' => true, 'controller' => 'contents', 'action' => 'index']);
-			}
-		} else {
+		if (Hash::get($this->request->data, 'MailContent.id')) {
 			if (!$this->request->data['MailContent']['sender_1_']) {
 				$this->request->data['MailContent']['sender_1'] = '';
 			}
 			$this->MailContent->set($this->request->data);
-			if ($this->MailContent->save()) {
-				$this->BcMessage->setSuccess(sprintf(__d('baser', 'メールフォーム「%s」を更新しました。'), $this->request->data['Content']['title']));
+			if (!$this->MailContent->save()) {
+				if ($this->MailContent->validationErrors || $this->MailContent->Content->validationErrors) {
+					$this->BcMessage->setError(__d('baser', '入力エラーです。内容を修正してください。'));
+				} else {
+					$this->BcMessage->setError(__d('baser', 'データベース処理中にエラーが発生しました。'));
+				}
+			} else {
+				$this->BcMessage->setSuccess(
+					sprintf(
+						__d(
+							'baser',
+							'メールフォーム「%s」を更新しました。'),
+						$this->request->data['Content']['title']
+					)
+				);
 				if ($this->request->data['MailContent']['edit_mail_form']) {
 					$this->redirectEditForm($this->request->data['MailContent']['form_template']);
 				} elseif ($this->request->data['MailContent']['edit_mail']) {
@@ -169,12 +193,23 @@ class MailContentsController extends MailAppController {
 				} else {
 					$this->redirect(array('action' => 'edit', $this->request->data['MailContent']['id']));
 				}
-			} else {
-				if ($this->MailContent->validationErrors || $this->MailContent->Content->validationErrors) {
-					$this->BcMessage->setError(__d('baser', '入力エラーです。内容を修正してください。'));
-				} else {
-					$this->BcMessage->setError(__d('baser', 'データベース処理中にエラーが発生しました。'));
-				}
+			}
+		} else {
+			$this->request->data = $this->MailContent->read(null, $id);
+			if ($this->MailContent->isOverPostSize()) {
+				$this->BcMessage->setError(
+					__d(
+						'baser',
+						'送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。',
+						ini_get('post_max_size')
+					)
+				);
+			}
+			if (!$this->request->data) {
+				$this->BcMessage->setError(__d('baser', '無効な処理です。'));
+				$this->redirect(
+					['plugin' => false, 'admin' => true, 'controller' => 'contents', 'action' => 'index']
+				);
 			}
 		}
 
@@ -229,13 +264,14 @@ class MailContentsController extends MailAppController {
 		if ($this->siteConfigs['theme']) {
 			if (!file_exists($target)) {
 				foreach ($sorces as $source) {
-					if (file_exists($source)) {
-						$folder = new Folder();
-						$folder->create(dirname($target), 0777);
-						copy($source, $target);
-						chmod($target, 0666);
-						break;
+					if (!file_exists($source)) {
+						continue;
 					}
+					$folder = new Folder();
+					$folder->create(dirname($target), 0777);
+					copy($source, $target);
+					chmod($target, 0666);
+					break;
 				}
 			}
 			$path = str_replace(DS, '/', $path);
@@ -274,12 +310,15 @@ class MailContentsController extends MailAppController {
 		if ($this->siteConfigs['theme']) {
 			if (!file_exists($target . DS . 'index' . $this->ext)) {
 				foreach ($sorces as $source) {
-					if (is_dir($source)) {
-						$folder = new Folder();
-						$folder->create(dirname($target), 0777);
-						$folder->copy(array('from' => $source, 'to' => $target, 'chmod' => 0777, 'skip' => array('_notes')));
-						break;
+					if (!is_dir($source)) {
+						continue;
 					}
+					$folder = new Folder();
+					$folder->create(dirname($target), 0777);
+					$folder->copy(
+						array('from' => $source, 'to' => $target, 'chmod' => 0777, 'skip' => array('_notes'))
+					);
+					break;
 				}
 			}
 			$path = str_replace(DS, '/', $path);
@@ -316,15 +355,21 @@ class MailContentsController extends MailAppController {
 			$this->ajaxError(500, __d('baser', '無効な処理です。'));
 		}
 		$user = $this->BcAuth->user();
-		$data = $this->MailContent->copy($this->request->data['entityId'], $this->request->data['parentId'], $this->request->data['title'], $user['id'], $this->request->data['siteId']);
-		if ($data) {
-			$message = sprintf(__d('baser', 'メールフォームのコピー「%s」を追加しました。'), $this->request->data['title']);
-			$this->BcMessage->setSuccess($message, true, false);
-			return json_encode($data['Content']);
-		} else {
+		$data = $this->MailContent->copy(
+			$this->request->data['entityId'],
+			$this->request->data['parentId'],
+			$this->request->data['title'],
+			$user['id'],
+			$this->request->data['siteId']
+		);
+		if (!$data) {
 			$this->ajaxError(500, $this->MailContent->validationErrors);
+			return false;
 		}
-		return false;
-	}
+		$message = sprintf(
+			__d('baser', 'メールフォームのコピー「%s」を追加しました。'), $this->request->data['title']
+		);
+		$this->BcMessage->setSuccess($message, true, false);
+		return json_encode($data['Content']);}
 
 }

--- a/lib/Baser/Plugin/Mail/Controller/MailContentsController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailContentsController.php
@@ -213,7 +213,7 @@ class MailContentsController extends MailAppController {
 			}
 		}
 
-		$this->request->params['Content'] = $this->BcContents->getContent($id)['Content'];
+		$this->request->param('Content', $this->BcContents->getContent($id)['Content']);
 		if($this->request->data['Content']['status']) {
 			$site = BcSite::findById($this->request->data['Content']['site_id']);
 			$this->set(

--- a/lib/Baser/Plugin/Mail/Controller/MailController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailController.php
@@ -517,8 +517,8 @@ class MailController extends MailAppController {
 
 /**
  * メール送信する
- * 
- * @return void
+ *
+ * @return false|void
  */
 	protected function _sendEmail($options) {
 		$options = array_merge(

--- a/lib/Baser/Plugin/Mail/Controller/MailController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailController.php
@@ -127,7 +127,7 @@ class MailController extends MailAppController {
 		$this->dbDatas['mailContent'] = $this->MailMessage->mailContent;
 		$this->dbDatas['mailFields'] = $this->MailMessage->mailFields;
 		$this->dbDatas['mailConfig'] = $this->MailConfig->find();
-		
+
 		// ページタイトルをセット
 		$this->pageTitle = $this->request->params['Content']['title'];
 
@@ -175,7 +175,7 @@ class MailController extends MailAppController {
 		if ($this->dbDatas['mailContent']['MailContent']['widget_area']) {
 			$this->set('widgetArea', $this->dbDatas['mailContent']['MailContent']['widget_area']);
 		}
-		
+
 		// キャッシュ対策
 		if (!isConsole() && empty($this->request->params['requested'])) {
 			header("Cache-Control: no-cache, no-store, must-revalidate");
@@ -198,12 +198,12 @@ class MailController extends MailAppController {
 			return;
 		}
 
-		if($this->BcContents->preview == 'default' && $this->request->data && empty($this->request->params['requested'])) {
+		if($this->BcContents->preview === 'default' && $this->request->data && empty($this->request->params['requested'])) {
 			$this->dbDatas['mailContent']['MailContent'] = $this->request->data['MailContent'];
 			$this->request->data = $this->Content->saveTmpFiles($this->request->data, mt_rand(0, 99999999));
 			$this->request->params['Content']['eyecatch'] = $this->request->data['Content']['eyecatch'];
 		}
-		
+
 		$this->Session->write('Mail.valid', true);
 
 		// 初期値を取得
@@ -243,7 +243,7 @@ class MailController extends MailAppController {
 				$this->BcMessage->setError(__('ファイルのアップロードサイズが上限を超えています。'));
 			}
 		}
-		
+
 		if (!$this->MailContent->isAccepting($this->dbDatas['mailContent']['MailContent']['publish_begin'], $this->dbDatas['mailContent']['MailContent']['publish_end'])) {
 			$this->render($this->dbDatas['mailContent']['MailContent']['form_template'] . DS . 'unpublish');
 			return;
@@ -258,7 +258,7 @@ class MailController extends MailAppController {
 		} else {
 			// 入力データを整形し、モデルに引き渡す
 			$this->request->data = $this->MailMessage->create($this->MailMessage->autoConvert($this->request->data));
-			
+
 			// fileタイプへの送信データ検証
 			if (!$this->_checkDirectoryRraversal()) {
 				$this->redirect($this->request->params['Content']['url'] . '/index');
@@ -290,7 +290,16 @@ class MailController extends MailAppController {
 		}
 		$user = BcUtil::loginUser('admin');
 		if (!empty($user)) {
-			$this->set('editLink', ['admin' => true, 'plugin' => 'mail', 'controller' => 'mail_contents', 'action' => 'edit', $this->dbDatas['mailContent']['MailContent']['id']]);
+			$this->set(
+				'editLink',
+				[
+					'admin'      => true,
+					'plugin'     => 'mail',
+					'controller' => 'mail_contents',
+					'action'     => 'edit',
+					$this->dbDatas['mailContent']['MailContent']['id']
+				]
+			);
 		}
 		$this->set('mailContent', $this->dbDatas['mailContent']);
 		$this->render($this->dbDatas['mailContent']['MailContent']['form_template'] . DS . 'confirm');
@@ -326,12 +335,12 @@ class MailController extends MailAppController {
 					unset($this->request->data['MailMessage']['auth_captcha']);
 				}
 			}
-			
+
 			// fileタイプへの送信データ検証
 			if (!$this->_checkDirectoryRraversal()) {
 				$this->redirect($this->request->params['Content']['url'] . '/index');
 			}
-			
+
 			$this->MailMessage->create($this->request->data);
 
 			// データの入力チェックを行う
@@ -399,11 +408,15 @@ class MailController extends MailAppController {
 							'data' => $this->request->data
 						]);
 					} else {
-						$this->BcMessage->setError(__('エラー : 送信中にエラーが発生しました。しばらくたってから再度送信お願いします。'));
+						$this->BcMessage->setError(
+							__('エラー : 送信中にエラーが発生しました。しばらくたってから再度送信お願いします。')
+						);
 						$this->redirect($this->request->params['Content']['url']);
 					}
 				} else {
-					$this->BcMessage->setError(__('エラー : 送信中にエラーが発生しました。しばらくたってから再度送信お願いします。'));
+					$this->BcMessage->setError(
+						__('エラー : 送信中にエラーが発生しました。しばらくたってから再度送信お願いします。')
+					);
 					$this->redirect($this->request->params['Content']['url']);
 				}
 
@@ -429,7 +442,16 @@ class MailController extends MailAppController {
 		}
 		$user = BcUtil::loginUser('admin');
 		if (!empty($user)) {
-			$this->set('editLink', ['admin' => true, 'plugin' => 'mail', 'controller' => 'mail_contents', 'action' => 'edit', $this->dbDatas['mailContent']['MailContent']['id']]);
+			$this->set(
+				'editLink',
+				[
+					'admin'      => true,
+					'plugin'     => 'mail',
+					'controller' => 'mail_contents',
+					'action'     => 'edit',
+					$this->dbDatas['mailContent']['MailContent']['id']
+				]
+			);
 		}
 	}
 
@@ -478,7 +500,16 @@ class MailController extends MailAppController {
 		// <<<
 		$user = BcUtil::loginUser('admin');
 		if (!empty($user)) {
-			$this->set('editLink', ['admin' => true, 'plugin' => 'mail', 'controller' => 'mail_contents', 'action' => 'edit', $this->dbDatas['mailContent']['MailContent']['id']]);
+			$this->set(
+				'editLink',
+				[
+					'admin' => true,
+					'plugin' => 'mail',
+					'controller' => 'mail_contents',
+					'action' => 'edit',
+					$this->dbDatas['mailContent']['MailContent']['id']
+				]
+			);
 		}
 		$this->set('mailContent', $this->dbDatas['mailContent']);
 		$this->render($this->dbDatas['mailContent']['MailContent']['form_template'] . DS . 'index');
@@ -535,20 +566,28 @@ class MailController extends MailAppController {
 			}
 			$value = $data['message'][$field];
 			// ユーザーメールを取得
-			if ($mailField['MailField']['type'] == 'email' && $value) {
+			if ($mailField['MailField']['type'] === 'email' && $value) {
 				$userMail = $value;
 			}
 			// 件名にフィールドの値を埋め込む
 			// 和暦など配列の場合は無視
 			if (!is_array($value)) {
-				$mailContent['subject_user'] = str_replace('{$' . $field . '}', $value, $mailContent['subject_user']);
-				$mailContent['subject_admin'] = str_replace('{$' . $field . '}', $value, $mailContent['subject_admin']);
+				$mailContent['subject_user'] = str_replace(
+					'{$' . $field . '}',
+					$value,
+					$mailContent['subject_user']
+				);
+				$mailContent['subject_admin'] = str_replace(
+					'{$' . $field . '}',
+					$value,
+					$mailContent['subject_admin']
+				);
 			}
-			if($mailField['MailField']['type'] == 'file' && $value) {
+			if($mailField['MailField']['type'] === 'file' && $value) {
 				$attachments[] = WWW_ROOT . 'files' . DS . $settings['saveDir'] . DS . $value;
 			}
 			// パスワードは入力値をマスクした値を表示
-			if ($mailField['MailField']['type'] == 'password' && $value && !empty($options['maskedPasswords'][$field])) {
+			if ($mailField['MailField']['type'] === 'password' && $value && !empty($options['maskedPasswords'][$field])) {
 				$data['message'][$field] = $options['maskedPasswords'][$field];
 			}
 		}
@@ -616,14 +655,14 @@ class MailController extends MailAppController {
 
 		return true;
 	}
-	
+
 /**
  * ファイルフィールドのデータがアップロードされたファイルパスであることを検証する
- * 
+ *
  * @return boolean
  */
 	private function _checkDirectoryRraversal() {
-		if (!isset($this->dbDatas['mailFields']) 
+		if (!isset($this->dbDatas['mailFields'])
 			|| !is_array($this->dbDatas['mailFields'])
 			|| empty($this->MailMessage->Behaviors->BcUpload->settings['MailMessage'])) {
 			return false;
@@ -644,7 +683,7 @@ class MailController extends MailAppController {
 
 /**
  * 認証用のキャプチャ画像を表示する
- * 
+ *
  * @return void
  */
 	public function captcha($token = null) {

--- a/lib/Baser/Plugin/Mail/Controller/MailFieldsController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailFieldsController.php
@@ -379,7 +379,7 @@ class MailFieldsController extends MailAppController {
 /**
  * フォームの初期値を取得する
  *
- * @return string
+ * @return array
  */
 	protected function _getDefaultValue() {
 		$data['MailField']['type'] = 'text';
@@ -443,7 +443,7 @@ class MailFieldsController extends MailAppController {
  * 並び替えを更新する [AJAX]
  *
  * @param int $mailContentId
- * @return boolean
+ * @return bool|void
  * @access	public
  */
 	public function admin_ajax_update_sort($mailContentId) {
@@ -467,8 +467,8 @@ class MailFieldsController extends MailAppController {
 /**
  * 管理画面ページ一覧の検索条件を取得する
  *
- * @param array $mailContentId
- * @return string
+ * @param integer $mailContentId
+ * @return array
  */
 	protected function _createAdminIndexConditions($mailContentId) {
 		$conditions = array('MailField.mail_content_id' => $mailContentId);

--- a/lib/Baser/Plugin/Mail/Controller/MailFieldsController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailFieldsController.php
@@ -65,11 +65,11 @@ class MailFieldsController extends MailAppController {
 		parent::beforeFilter();
 		$this->_checkEnv();
 		$this->MailContent->recursive = -1;
-		$mailContentId = $this->params['pass'][0];
+		$mailContentId = $this->request->param('pass.0');
 		$this->mailContent = $this->MailContent->read(null, $mailContentId);
-		$this->request->params['Content'] = $this->BcContents->getContent($mailContentId)['Content'];
+		$this->request->param('Content', $this->BcContents->getContent($mailContentId)['Content']);
 		$this->crumbs[] = array(
-			'name' => sprintf('%s 設定', $this->request->params['Content']['title']),
+			'name' => sprintf('%s 設定', $this->request->param('Content.title')),
 			'url' => array(
 				'plugin' => 'mail',
 				'controller' => 'mail_fields',
@@ -77,10 +77,10 @@ class MailFieldsController extends MailAppController {
 				$mailContentId
 			)
 		);
-		if($this->request->params['Content']['status']) {
-			$site = BcSite::findById($this->request->params['Content']['site_id']);
+		if($this->request->param('Content.status')) {
+			$site = BcSite::findById($this->request->param('Content.site_id'));
 			$this->set('publishLink', $this->Content->getUrl(
-				$this->request->params['Content']['url'], true, $site->useSubDomain)
+				$this->request->param('Content.url'), true, $site->useSubDomain)
 			);
 		}
 	}
@@ -150,7 +150,7 @@ class MailFieldsController extends MailAppController {
 		$this->subMenuElements = array('mail_fields');
 		$this->pageTitle = sprintf(
 			__d('baser', '%s｜メールフィールド一覧'),
-			$this->request->params['Content']['title']
+			$this->request->param('Content.title')
 		);
 		$this->help = 'mail_fields_index';
 	}
@@ -236,7 +236,7 @@ class MailFieldsController extends MailAppController {
 
 		$this->subMenuElements = array('mail_fields');
 		$this->pageTitle = sprintf(
-			__d('baser', '%s｜新規メールフィールド登録'), $this->request->params['Content']['title']
+			__d('baser', '%s｜新規メールフィールド登録'), $this->request->param('Content.title')
 		);
 		$this->help = 'mail_fields_form';
 		$this->render('form');
@@ -301,7 +301,7 @@ class MailFieldsController extends MailAppController {
 		/* 表示設定 */
 		$this->subMenuElements = array('mail_fields');
 		$this->pageTitle = sprintf(
-			__d('baser', '%s｜メールフィールド編集'), $this->request->params['Content']['title']
+			__d('baser', '%s｜メールフィールド編集'), $this->request->param('Content.title')
 		);
 		$this->help = 'mail_fields_form';
 		$this->render('form');
@@ -479,7 +479,7 @@ class MailFieldsController extends MailAppController {
 		);
 		$this->set('encoding', $this->request->query['encoding']);
 		$this->set('messages', $messages);
-		$this->set('contentName', $this->request->params['Content']['name']);
+		$this->set('contentName', $this->request->param('Content.name'));
 	}
 
 /**

--- a/lib/Baser/Plugin/Mail/Controller/MailFieldsController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailFieldsController.php
@@ -68,10 +68,20 @@ class MailFieldsController extends MailAppController {
 		$mailContentId = $this->params['pass'][0];
 		$this->mailContent = $this->MailContent->read(null, $mailContentId);
 		$this->request->params['Content'] = $this->BcContents->getContent($mailContentId)['Content'];
-		$this->crumbs[] = array('name' => sprintf('%s 設定', $this->request->params['Content']['title']), 'url' => array('plugin' => 'mail', 'controller' => 'mail_fields', 'action' => 'index', $mailContentId));
+		$this->crumbs[] = array(
+			'name' => sprintf('%s 設定', $this->request->params['Content']['title']),
+			'url' => array(
+				'plugin' => 'mail',
+				'controller' => 'mail_fields',
+				'action' => 'index',
+				$mailContentId
+			)
+		);
 		if($this->request->params['Content']['status']) {
 			$site = BcSite::findById($this->request->params['Content']['site_id']);
-			$this->set('publishLink', $this->Content->getUrl($this->request->params['Content']['url'], true, $site->useSubDomain));
+			$this->set('publishLink', $this->Content->getUrl(
+				$this->request->params['Content']['url'], true, $site->useSubDomain)
+			);
 		}
 	}
 
@@ -84,14 +94,18 @@ class MailFieldsController extends MailAppController {
 			$Folder = new Folder();
 			$Folder->create($savePath, 0777);
 			if(!is_dir($savePath)) {
-				$this->BcMessage->setError('ファイルフィールドを利用している場合、現在、フォームより送信したファイルフィールドのデータは公開された状態となっています。URLを直接閲覧すると参照できてしまいます。参照されないようにする為には、' . WWW_ROOT . 'files/mail/ に書き込み権限を与えてください。');
+				$this->BcMessage->setError(
+					'ファイルフィールドを利用している場合、フォームより送信したファイルフィールドのデータは公開された状態となっています。URLを直接閲覧すると参照できてしまいます。参照されないようにするためには、' . WWW_ROOT . 'files/mail/ に書き込み権限を与えてください。'
+				);
 			}
 			$File = new File($savePath . DS . '.htaccess');
 			$htaccess = "Order allow,deny\nDeny from all";
 			$File->write($htaccess);
 			$File->close();
 			if(!file_exists($savePath . DS . '.htaccess')) {
-				$this->BcMessage->setError('ファイルフィールドを利用している場合、現在、フォームより送信したファイルフィールドのデータは公開された状態となっています。URLを直接閲覧すると参照できてしまいます。参照されないようにする為には、' . WWW_ROOT . 'files/mail/limited/ に書き込み権限を与えてください。');
+				$this->BcMessage->setError(
+					'ファイルフィールドを利用している場合、フォームより送信したファイルフィールドのデータは公開された状態となっています。URLを直接閲覧すると参照できてしまいます。参照されないようにするためには、' . WWW_ROOT . 'files/mail/limited/ に書き込み権限を与えてください。'
+				);
 			}
 		}
 	}
@@ -119,8 +133,13 @@ class MailFieldsController extends MailAppController {
 		}
 
 		$conditions = $this->_createAdminIndexConditions($mailContentId);
-		$datas = $this->MailField->find('all', array('conditions' => $conditions, 'order' => 'MailField.sort'));
-		$this->set('datas', $datas);
+		$this->set(
+			'datas',
+			$this->MailField->find(
+				'all',
+				array('conditions' => $conditions, 'order' => 'MailField.sort')
+			)
+		);
 
 		$this->_setAdminIndexViewData();
 
@@ -129,19 +148,25 @@ class MailFieldsController extends MailAppController {
 			return;
 		}
 		$this->subMenuElements = array('mail_fields');
-		$this->pageTitle = sprintf(__d('baser', '%s｜メールフィールド一覧'), $this->request->params['Content']['title']);
+		$this->pageTitle = sprintf(
+			__d('baser', '%s｜メールフィールド一覧'),
+			$this->request->params['Content']['title']
+		);
 		$this->help = 'mail_fields_index';
 	}
 
 /**
  * 一覧の表示用データをセットする
- * 
+ *
  * @return void
  */
 	protected function _setAdminIndexViewData() {
 		/* セッション処理 */
 		if (isset($this->params['named']['sortmode'])) {
-			$this->Session->write('SortMode.MailField', $this->params['named']['sortmode']);
+			$this->Session->write(
+				'SortMode.MailField',
+				$this->params['named']['sortmode']
+			);
 		}
 
 		/* 並び替えモード */
@@ -174,7 +199,9 @@ class MailFieldsController extends MailAppController {
 				$data['MailField']['valid_ex'] = implode(',', $data['MailField']['valid_ex']);
 			}
 			$data['MailField']['mail_content_id'] = $mailContentId;
-			$data['MailField']['no'] = $this->MailField->getMax('no', array('MailField.mail_content_id' => $mailContentId)) + 1;
+			$data['MailField']['no'] = $this->MailField->getMax(
+				'no', array('MailField.mail_content_id' => $mailContentId)
+				) + 1;
 			$data['MailField']['sort'] = $this->MailField->getMax('sort') + 1;
 			$data['MailField']['source'] = $this->MailField->formatSource($data['MailField']['source']);
 			$this->MailField->create($data);
@@ -194,9 +221,11 @@ class MailFieldsController extends MailAppController {
 				$this->BcMessage->setError(__d('baser', '入力エラーです。内容を修正してください。'));
 			}
 		}
-		
+
 		$this->subMenuElements = array('mail_fields');
-		$this->pageTitle = sprintf(__d('baser', '%s｜新規メールフィールド登録'), $this->request->params['Content']['title']);
+		$this->pageTitle = sprintf(
+			__d('baser', '%s｜新規メールフィールド登録'), $this->request->params['Content']['title']
+		);
 		$this->help = 'mail_fields_form';
 		$this->render('form');
 	}
@@ -250,7 +279,9 @@ class MailFieldsController extends MailAppController {
 
 		/* 表示設定 */
 		$this->subMenuElements = array('mail_fields');
-		$this->pageTitle = sprintf(__d('baser', '%s｜メールフィールド編集'), $this->request->params['Content']['title']);
+		$this->pageTitle = sprintf(
+			__d('baser', '%s｜メールフィールド編集'), $this->request->params['Content']['title']
+		);
 		$this->help = 'mail_fields_form';
 		$this->render('form');
 	}
@@ -304,12 +335,19 @@ class MailFieldsController extends MailAppController {
 		/* 削除処理 */
 		if ($this->MailMessage->delMessageField($mailContentId, $mailField['MailField']['field_name'])) {
 			if ($this->MailField->delete($id)) {
-				$this->BcMessage->setSuccess(sprintf(__d('baser', 'メールフィールド「%s」を削除しました。'), $mailField['MailField']['name']));
+				$this->BcMessage->setSuccess(
+					sprintf(
+						__d('baser', 'メールフィールド「%s」を削除しました。'),
+						$mailField['MailField']['name']
+					)
+				);
 			} else {
 				$this->BcMessage->setError(__d('baser', 'データベース処理中にエラーが発生しました。'));
 			}
 		} else {
-			$this->BcMessage->setError(__d('baser', 'データベースに問題があります。メール受信データ保存用テーブルの更新処理に失敗しました。'));
+			$this->BcMessage->setError(
+				__d('baser', 'データベースに問題があります。メール受信データ保存用テーブルの更新処理に失敗しました。')
+			);
 		}
 
 		$this->redirect(array('action' => 'index', $mailContentId));
@@ -317,14 +355,13 @@ class MailFieldsController extends MailAppController {
 
 /**
  * 一括削除
- * 
+ *
  * @param array $ids
  * @return boolean
  */
 	protected function _batch_del($ids) {
 		if ($ids) {
 			foreach ($ids as $id) {
-
 				// メッセージ用にデータを取得
 				$mailField = $this->MailField->read(null, $id);
 				/* 削除処理 */
@@ -376,7 +413,7 @@ class MailFieldsController extends MailAppController {
 
 /**
  * メッセージCSVファイルをダウンロードする
- * 
+ *
  * @param int $mailContentId
  * @return void
  */
@@ -390,7 +427,13 @@ class MailFieldsController extends MailAppController {
 		$this->MailMessage->schema(true);
 		$this->MailMessage->cacheSources = false;
 		$this->MailMessage->setUseTable($mailContentId);
-		$messages = $this->MailMessage->convertMessageToCsv($mailContentId, $this->MailMessage->find('all', array('order' => $this->MailMessage->alias .'.created DESC',)));
+		$messages = $this->MailMessage->convertMessageToCsv(
+			$mailContentId,
+			$this->MailMessage->find(
+				'all',
+				array('order' => $this->MailMessage->alias .'.created DESC')
+			)
+		);
 		$this->set('encoding', $this->request->query['encoding']);
 		$this->set('messages', $messages);
 		$this->set('contentName', $this->request->params['Content']['name']);
@@ -434,7 +477,7 @@ class MailFieldsController extends MailAppController {
 
 /**
  * [ADMIN] 無効状態にする（AJAX）
- * 
+ *
  * @param string $blogContentId
  * @param string $blogPostId beforeFilterで利用
  * @param string $blogCommentId
@@ -455,7 +498,7 @@ class MailFieldsController extends MailAppController {
 
 /**
  * [ADMIN] 有効状態にする（AJAX）
- * 
+ *
  * @param string $blogContentId
  * @param string $blogPostId beforeFilterで利用
  * @param string $blogCommentId
@@ -476,10 +519,10 @@ class MailFieldsController extends MailAppController {
 
 /**
  * 一括公開
- * 
+ *
  * @param array $ids
  * @return boolean
- * @access protected 
+ * @access protected
  */
 	protected function _batch_publish($ids) {
 		if ($ids) {
@@ -492,10 +535,10 @@ class MailFieldsController extends MailAppController {
 
 /**
  * 一括非公開
- * 
+ *
  * @param array $ids
  * @return boolean
- * @access protected 
+ * @access protected
  */
 	protected function _batch_unpublish($ids) {
 		if ($ids) {
@@ -508,14 +551,17 @@ class MailFieldsController extends MailAppController {
 
 /**
  * ステータスを変更する
- * 
+ *
  * @param int $id
  * @param boolean $status
- * @return boolean 
+ * @return boolean
  */
 	protected function _changeStatus($id, $status) {
 		$statusTexts = array(0 => __d('baser', '無効'), 1 => __d('baser', '有効'));
-		$data = $this->MailField->find('first', array('conditions' => array('MailField.id' => $id), 'recursive' => -1));
+		$data = $this->MailField->find(
+			'first',
+			array('conditions' => array('MailField.id' => $id), 'recursive' => -1)
+		);
 		$data['MailField']['use_field'] = $status;
 		$this->MailField->set($data);
 

--- a/lib/Baser/Plugin/Mail/Controller/MailMessagesController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailMessagesController.php
@@ -189,11 +189,11 @@ class MailMessagesController extends MailAppController {
 		if (!$messageId) {
 			$this->ajaxError(500, __d('baser', '無効な処理です。'));
 		}
-		if ($this->_del($messageId)) {
-			exit(true);
-		} else {
-			exit();
+		if (!$this->_del($messageId)) {
+			exit;
 		}
+
+		exit(true);
 	}
 
 /**
@@ -204,13 +204,13 @@ class MailMessagesController extends MailAppController {
  * @return bool
  */
 	protected function _del($id = null) {
-		if ($this->MailMessage->delete($id)) {
-			$message = sprintf(__d('baser', '受信データ NO「%s」 を削除しました。'), $id);
-			$this->MailMessage->saveDbLog($message);
-			return true;
-		} else {
+		if (!$this->MailMessage->delete($id)) {
 			return false;
 		}
+
+		$message = sprintf(__d('baser', '受信データ NO「%s」 を削除しました。'), $id);
+		$this->MailMessage->saveDbLog($message);
+		return true;
 	}
 
 /**
@@ -226,10 +226,18 @@ class MailMessagesController extends MailAppController {
 			$this->BcMessage->setError(__d('baser', '無効な処理です。'));
 			$this->notFound();
 		}
-		if ($this->MailMessage->delete($messageId)) {
-			$this->BcMessage->setSuccess(sprintf(__d('baser', '%s への受信データ NO「%s」 を削除しました。'), $this->mailContent['Content']['title'], $messageId));
+		if (!$this->MailMessage->delete($messageId)) {
+			$this->BcMessage->setError(
+				__d('baser', 'データベース処理中にエラーが発生しました。')
+			);
 		} else {
-			$this->BcMessage->setError(__d('baser', 'データベース処理中にエラーが発生しました。'));
+			$this->BcMessage->setSuccess(
+				sprintf(
+					__d('baser', '%s への受信データ NO「%s」 を削除しました。'),
+					$this->mailContent['Content']['title'],
+					$messageId
+				)
+			);
 		}
 		$this->redirect(array('action' => 'index', $mailContentId));
 	}

--- a/lib/Baser/Plugin/Mail/Controller/MailMessagesController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailMessagesController.php
@@ -66,23 +66,27 @@ class MailMessagesController extends MailAppController {
  */
 	public function beforeFilter() {
 		parent::beforeFilter();
-		$content = $this->BcContents->getContent($this->request->params['pass'][0]);
+		$content = $this->BcContents->getContent($this->request->param('pass.0'));
 		if(!$content) {
 			$this->notFound();
 		}
-		$this->mailContent = $this->MailContent->read(null, $this->params['pass'][0]);
+		$this->mailContent = $this->MailContent->read(null, $this->request->param('pass.0'));
 		App::uses('MailMessage', 'Mail.Model');
 		$this->MailMessage = new MailMessage();
 		$this->MailMessage->setup($this->mailContent['MailContent']['id']);
-		$mailContentId = $this->params['pass'][0];
-		$this->request->params['Content'] = $this->BcContents->getContent($mailContentId)['Content'];
+		$mailContentId = $this->request->param('pass.0');
+		$content = $this->BcContents->getContent($mailContentId);
+		$this->request->param('Content', $content['Content']);
 		$this->crumbs[] = array(
 			'name' => sprintf(
 				__d('baser', '%s 管理'),
-				$this->request->params['Content']['title']
+				$this->request->param('Content.title')
 			),
 			'url' => array(
-				'plugin' => 'mail', 'controller' => 'mail_fields', 'action' => 'index', $this->params['pass'][0]
+				'plugin' => 'mail',
+				'controller' => 'mail_fields',
+				'action' => 'index',
+				$this->request->param('pass.0')
 			)
 		);
 	}
@@ -123,7 +127,7 @@ class MailMessagesController extends MailAppController {
 
 		$this->pageTitle = sprintf(
 			__d('baser', '%s｜受信メール一覧'),
-			$this->request->params['Content']['title']
+			$this->request->param('Content.title')
 		);
 		$this->help = 'mail_messages_index';
 	}
@@ -157,7 +161,7 @@ class MailMessagesController extends MailAppController {
 		$this->set(compact('message', 'mailFields'));
 		$this->pageTitle = sprintf(
 			__d('baser', '%s｜受信メール詳細'),
-			$this->request->params['Content']['title']
+			$this->request->param('Content.title')
 		);
 	}
 

--- a/lib/Baser/Plugin/Mail/Controller/MailMessagesController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailMessagesController.php
@@ -76,7 +76,15 @@ class MailMessagesController extends MailAppController {
 		$this->MailMessage->setup($this->mailContent['MailContent']['id']);
 		$mailContentId = $this->params['pass'][0];
 		$this->request->params['Content'] = $this->BcContents->getContent($mailContentId)['Content'];
-		$this->crumbs[] = array('name' => sprintf(__d('baser', '%s 管理'), $this->request->params['Content']['title']), 'url' => array('plugin' => 'mail', 'controller' => 'mail_fields', 'action' => 'index', $this->params['pass'][0]));
+		$this->crumbs[] = array(
+			'name' => sprintf(
+				__d('baser', '%s 管理'),
+				$this->request->params['Content']['title']
+			),
+			'url' => array(
+				'plugin' => 'mail', 'controller' => 'mail_fields', 'action' => 'index', $this->params['pass'][0]
+			)
+		);
 	}
 
 /**
@@ -113,7 +121,10 @@ class MailMessagesController extends MailAppController {
 			return;
 		}
 
-		$this->pageTitle = sprintf(__d('baser', '%s｜受信メール一覧'), $this->request->params['Content']['title']);
+		$this->pageTitle = sprintf(
+			__d('baser', '%s｜受信メール一覧'),
+			$this->request->params['Content']['title']
+		);
 		$this->help = 'mail_messages_index';
 	}
 
@@ -135,9 +146,19 @@ class MailMessagesController extends MailAppController {
 		));
 		$mailFields = $this->MailMessage->mailFields;
 
-		$this->crumbs[] = array('name' => __d('baser', '受信メール一覧'), 'url' => array('controller' => 'mail_messages', 'action' => 'index', $this->params['pass'][0]));
+		$this->crumbs[] = array(
+			'name' => __d('baser', '受信メール一覧'),
+			'url'  => array(
+				'controller' => 'mail_messages',
+				'action' => 'index',
+				$this->params['pass'][0]
+			)
+		);
 		$this->set(compact('message', 'mailFields'));
-		$this->pageTitle = sprintf(__d('baser', '%s｜受信メール詳細'), $this->request->params['Content']['title']);
+		$this->pageTitle = sprintf(
+			__d('baser', '%s｜受信メール詳細'),
+			$this->request->params['Content']['title']
+		);
 	}
 
 /**
@@ -224,14 +245,14 @@ class MailMessagesController extends MailAppController {
 		$filePath = WWW_ROOT . 'files' . DS . $settings['saveDir'] . DS . $file;
 		$ext = decodeContent(null, $file);
 		$mineType = 'application/octet-stream';
-		if ($ext != 'gif' && $ext != 'jpg' && $ext != 'png') {
+		if ($ext !== 'gif' && $ext !== 'jpg' && $ext !== 'png') {
 			Header("Content-disposition: attachment; filename=" . $file);
 		} else {
 			$mineType = 'image/' . $ext;
 		}
-		Header("Content-type: " . $mineType . "; name=" . $file);
+		Header(sprintf('Content-type: %s; name=%s', $mineType, $file));
 		echo file_get_contents($filePath);
 		exit();
 	}
-	
+
 }

--- a/lib/Baser/Plugin/Mail/Controller/MailMessagesController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailMessagesController.php
@@ -166,7 +166,7 @@ class MailMessagesController extends MailAppController {
  *
  * @param int $mailContentId
  * @param int $messageId
- * @return void
+ * @return bool
  */
 	protected function _batch_del($ids) {
 		if ($ids) {
@@ -201,7 +201,7 @@ class MailMessagesController extends MailAppController {
  *
  * @param int $mailContentId
  * @param int $messageId
- * @return void
+ * @return bool
  */
 	protected function _del($id = null) {
 		if ($this->MailMessage->delete($id)) {

--- a/lib/Baser/Plugin/Mail/Model/MailAppModel.php
+++ b/lib/Baser/Plugin/Mail/Model/MailAppModel.php
@@ -51,15 +51,14 @@ class MailAppModel extends AppModel {
 			E_USER_DEPRECATED
 		);
 		foreach ($datas as $key => $data) {
-			if (!is_array($data)) {
-				$data = str_replace("<br />", "", $data);
-				$data = str_replace("<br>", "", $data);
-				$data = str_replace('&lt;', '<', $data);
-				$data = str_replace('&gt;', '>', $data);
-				$data = str_replace('&amp;', '&', $data);
-				$data = str_replace('&quot;', '"', $data);
-				$datas[$key] = $data;
+			if (is_array($data)) {
+				continue;
 			}
+			$datas[$key] = str_replace(
+				array('<br />', '<br>', '&lt;', '&gt;', '&amp;', '&quot;'),
+				array('', '', '<', '>', '&', '"'),
+				$data
+			);
 		}
 		return $datas;
 	}

--- a/lib/Baser/Plugin/Mail/Model/MailAppModel.php
+++ b/lib/Baser/Plugin/Mail/Model/MailAppModel.php
@@ -23,7 +23,15 @@ class MailAppModel extends AppModel {
  * @deprecated 5.0.0 since 4.1.3 htmlspecialchars を利用してください。
  */
 	public function sanitizeData($datas) {
-		trigger_error(deprecatedMessage('メソッド：BcAppModel::sanitizeData()', '4.0.0', '5.0.0', 'htmlspecialchars を利用してください。'), E_USER_DEPRECATED);
+		trigger_error(
+			deprecatedMessage(
+				'メソッド：BcAppModel::sanitizeData()',
+				'4.0.0',
+				'5.0.0',
+				'htmlspecialchars を利用してください。'
+			),
+			E_USER_DEPRECATED
+		);
 		return $this->sanitizeRecord($datas);
 	}
 
@@ -33,7 +41,15 @@ class MailAppModel extends AppModel {
  * @deprecated 5.0.0 since 4.1.3 htmlspecialchars_decode を利用してください。
  */
 	public function restoreData($datas) {
-		trigger_error(deprecatedMessage('メソッド：MailAppModel::restoreData()', '4.1.3', '5.0.0', 'htmlspecialchars_decode を利用してください。'), E_USER_DEPRECATED);
+		trigger_error(
+			deprecatedMessage(
+				'メソッド：MailAppModel::restoreData()',
+				'4.1.3',
+				'5.0.0',
+				'htmlspecialchars_decode を利用してください。'
+			),
+			E_USER_DEPRECATED
+		);
 		foreach ($datas as $key => $data) {
 			if (!is_array($data)) {
 				$data = str_replace("<br />", "", $data);

--- a/lib/Baser/Plugin/Mail/Model/MailContent.php
+++ b/lib/Baser/Plugin/Mail/Model/MailContent.php
@@ -145,8 +145,8 @@ class MailContent extends MailAppModel {
 
 /**
  * SSL用のURLが設定されているかチェックする
- * 
- * @param string $check チェック対象文字列
+ *
+ * @param array $check チェック対象文字列
  * @return boolean
  */
 	public function checkSslUrl($check) {
@@ -165,7 +165,7 @@ class MailContent extends MailAppModel {
 /**
  * 英数チェック
  *
- * @param string $check チェック対象文字列
+ * @param array $check チェック対象文字列
  * @return boolean
  */
 	public function alphaNumeric($check) {
@@ -179,7 +179,7 @@ class MailContent extends MailAppModel {
 /**
  * フォームの初期値を取得する
  *
- * @return string
+ * @return array
  */
 	public function getDefaultValue() {
 		return [
@@ -201,7 +201,7 @@ class MailContent extends MailAppModel {
 /**
  * afterSave
  *
- * @return boolean
+ * @return void
  */
 	public function afterSave($created, $options = array()) {
 		// 検索用テーブルへの登録・削除

--- a/lib/Baser/Plugin/Mail/Model/MailContent.php
+++ b/lib/Baser/Plugin/Mail/Model/MailContent.php
@@ -150,16 +150,11 @@ class MailContent extends MailAppModel {
  * @return boolean
  */
 	public function checkSslUrl($check) {
-		if ($check[key($check)]) {
-			$sslUrl = Configure::read('BcEnv.sslUrl');
-			if (empty($sslUrl)) {
-				return false;
-			} else {
-				return true;
-			}
-		} else {
-			return true;
+		if ($check[key($check)] && !Configure::read('BcEnv.sslUrl')) {
+			return false;
 		}
+
+		return true;
 	}
 
 /**
@@ -169,11 +164,10 @@ class MailContent extends MailAppModel {
  * @return boolean
  */
 	public function alphaNumeric($check) {
-		if (preg_match("/^[a-z0-9]+$/", $check[key($check)])) {
-			return true;
-		} else {
+		if (!preg_match("/^[a-z0-9]+$/", $check[key($check)])) {
 			return false;
 		}
+		return true;
 	}
 
 /**

--- a/lib/Baser/Plugin/Mail/Model/MailContent.php
+++ b/lib/Baser/Plugin/Mail/Model/MailContent.php
@@ -56,30 +56,90 @@ class MailContent extends MailAppModel {
 		parent::__construct($id, $table, $ds);
 		$this->validate = [
 			'id' => [
-				['rule' => 'numeric', 'on' => 'update', 'message' => __d('baser', 'IDに不正な値が利用されています。')]],
+				[
+					'rule' => 'numeric',
+					'on' => 'update',
+					'message' => __d('baser', 'IDに不正な値が利用されています。')
+				]
+			],
 			'sender_name' => [
-				['rule' => ['notBlank'], 'message' => __d('baser', '送信先名を入力してください。')],
-				['rule' => ['maxLength', 255], 'message' => __d('baser', '送信先名は255文字以内で入力してください。')]],
+				[
+					'rule' => ['notBlank'],
+					'message' => __d('baser', '送信先名を入力してください。')
+				],
+				[
+					'rule' => ['maxLength', 255],
+					'message' => __d('baser', '送信先名は255文字以内で入力してください。')
+				]
+			],
 			'subject_user' => [
-				['rule' => ['notBlank'], 'message' => __d('baser', '自動返信メール件名[ユーザー宛]を入力してください。')],
-				['rule' => ['maxLength', 255], 'message' => __d('baser', '自動返信メール件名[ユーザー宛]は255文字以内で入力してください。')]],
+				[
+					'rule' => ['notBlank'],
+					'message' => __d('baser', '自動返信メール件名[ユーザー宛]を入力してください。')
+				],
+				[
+					'rule' => ['maxLength', 255],
+					'message' => __d('baser', '自動返信メール件名[ユーザー宛]は255文字以内で入力してください。')
+				]
+			],
 			'subject_admin' => [
-				['rule' => ['notBlank'], 'message' => __d('baser', '自動送信メール件名[管理者宛]を入力してください。')],
-				['rule' => ['maxLength', 255], 'message' => __d('baser', '自動返信メール件名[管理者宛]は255文字以内で入力してください。')]],
+				[
+					'rule' => ['notBlank'],
+					'message' => __d('baser', '自動送信メール件名[管理者宛]を入力してください。')
+				],
+				[
+					'rule' => ['maxLength', 255],
+					'message' => __d('baser', '自動返信メール件名[管理者宛]は255文字以内で入力してください。')
+				]
+			],
 			'form_template' => [
-				['rule' => ['halfText'], 'message' => __d('baser', 'メールフォームテンプレート名は半角のみで入力してください。'), 'allowEmpty' => false],
-				['rule' => ['maxLength', 20], 'message' => __d('baser', 'フォームテンプレート名は20文字以内で入力してください。')]],
+				[
+					'rule' => ['halfText'],
+					'message' => __d('baser', 'メールフォームテンプレート名は半角のみで入力してください。'),
+					'allowEmpty' => false
+				],
+				[
+					'rule' => ['maxLength', 20],
+					'message' => __d('baser', 'フォームテンプレート名は20文字以内で入力してください。')
+				]
+			],
 			'mail_template' => [
-				['rule' => ['halfText'], 'message' => __d('baser', '送信メールテンプレートは半角のみで入力してください。'), 'allowEmpty' => false],
-				['rule' => ['maxLength', 20], 'message' => __d('baser', 'メールテンプレート名は20文字以内で入力してください。')]	],
+				[
+					'rule' => ['halfText'],
+					'message' => __d('baser', '送信メールテンプレートは半角のみで入力してください。'),
+					'allowEmpty' => false
+				],
+				[
+					'rule' => ['maxLength', 20],
+					'message' => __d('baser', 'メールテンプレート名は20文字以内で入力してください。')
+				]
+			],
 			'redirect_url' => [
-				['rule' => ['maxLength', 255], 'message' => __d('baser', 'リダイレクトURLは255文字以内で入力してください。')]],
+				[
+					'rule' => ['maxLength', 255],
+					'message' => __d('baser', 'リダイレクトURLは255文字以内で入力してください。')
+				]
+			],
 			'sender_1' => [
-				['rule' => ['emails'], 'allowEmpty' => true, 'message' => __d('baser', '送信先メールアドレスの形式が不正です。')]],
+				[
+					'rule' => ['emails'],
+					'allowEmpty' => true,
+					'message' => __d('baser', '送信先メールアドレスの形式が不正です。')
+				]
+			],
 			'sender_2' => [
-				['rule' => ['emails'], 'allowEmpty' => true, 'message' => __d('baser', '送信先メールアドレスの形式が不正です。')]],
+				[
+					'rule' => ['emails'],
+					'allowEmpty' => true,
+					'message' => __d('baser', '送信先メールアドレスの形式が不正です。')
+				]
+			],
 			'ssl_on' => [
-				['rule' => 'checkSslUrl', "message" => __d('baser', 'SSL通信を利用するには、システム設定で、事前にSSL通信用のWebサイトURLを指定してください。')]]
+				[
+					'rule' => 'checkSslUrl',
+					"message" => __d('baser', 'SSL通信を利用するには、システム設定で、事前にSSL通信用のWebサイトURLを指定してください。')
+				]
+			]
 		];
 	}
 
@@ -122,17 +182,20 @@ class MailContent extends MailAppModel {
  * @return string
  */
 	public function getDefaultValue() {
-		$data['MailContent']['sender_name'] = __d('baser', '送信先名を入力してください');
-		$data['MailContent']['subject_user'] = __d('baser', 'お問い合わせ頂きありがとうございます');
-		$data['MailContent']['subject_admin'] = __d('baser', 'お問い合わせを頂きました');
-		$data['MailContent']['layout_template'] = 'default';
-		$data['MailContent']['form_template'] = 'default';
-		$data['MailContent']['mail_template'] = 'mail_default';
-		$data['MailContent']['use_description'] = true;
-		$data['MailContent']['auth_captcha'] = false;
-		$data['MailContent']['ssl_on'] = false;
-		$data['MailContent']['save_info'] = true;
-		return $data;
+		return [
+			'MailContent' => [
+				'sender_name'     => __d('baser', '送信先名を入力してください'),
+				'subject_user'    => __d('baser', 'お問い合わせ頂きありがとうございます'),
+				'subject_admin'   => __d('baser', 'お問い合わせを頂きました'),
+				'layout_template' => 'default',
+				'form_template'   => 'default',
+				'mail_template'   => 'mail_default',
+				'use_description' => true,
+				'auth_captcha'    => false,
+				'ssl_on'          => false,
+				'save_info'       => true
+			]
+		];
 	}
 
 /**
@@ -171,18 +234,21 @@ class MailContent extends MailAppModel {
 		}
 		$mailContent = $data['MailContent'];
 		$content = $data['Content'];
-		return ['SearchIndex' => [
-			'type' => __d('baser', 'メール'),
-			'model_id' => (!empty($mailContent['id'])) ? $mailContent['id'] : $this->id,
-			'content_id' => $content['id'],
-			'site_id' => $content['site_id'],
-			'title' => $content['title'],
-			'detail' => $mailContent['description'],
-			'url' => $content['url'],
-			'status' => $content['status'],
-			'publish_begin' => $content['publish_begin'],
-			'publish_end' => $content['publish_end']
-		]];
+		return [
+			'SearchIndex' =>
+				[
+					'type'        => __d('baser', 'メール'),
+					'model_id'    => (!empty($mailContent['id'])) ? $mailContent['id'] : $this->id,
+					'content_id'  => $content['id'],
+					'site_id'     => $content['site_id'],
+					'title'       => $content['title'],
+					'detail'      => $mailContent['description'],
+					'url'         => $content['url'],
+					'status'      => $content['status'],
+					'publish_begin' => $content['publish_begin'],
+					'publish_end' => $content['publish_end']
+				]
+		];
 	}
 
 /**
@@ -232,7 +298,14 @@ class MailContent extends MailAppModel {
 		if ($result = $this->save($data)) {
 			$result['MailContent']['id'] = $this->id;
 			$data = $result;
-			$mailFields = $this->MailField->find('all', array('conditions' => array('MailField.mail_content_id' => $id), 'order' => 'MailField.sort', 'recursive' => -1));
+			$mailFields = $this->MailField->find(
+				'all',
+				array(
+					'conditions' => array('MailField.mail_content_id' => $id),
+					'order' => 'MailField.sort',
+					'recursive' => -1
+				)
+			);
 			foreach ($mailFields as $mailField) {
 				$mailField['MailField']['mail_content_id'] = $result['MailContent']['id'];
 				$this->MailField->copy(null, $mailField, array('sortUpdateOff' => true));
@@ -275,12 +348,12 @@ class MailContent extends MailAppModel {
  * @return	bool
  */
 	public function isAccepting($publishBegin, $publishEnd) {
-		if ($publishBegin && $publishBegin != '0000-00-00 00:00:00') {
+		if ($publishBegin && $publishBegin !== '0000-00-00 00:00:00') {
 			if ($publishBegin > date('Y-m-d H:i:s')) {
 				return false;
 			}
 		}
-		if ($publishEnd && $publishEnd != '0000-00-00 00:00:00') {
+		if ($publishEnd && $publishEnd !== '0000-00-00 00:00:00') {
 			if ($publishEnd < date('Y-m-d H:i:s')) {
 				return false;
 			}
@@ -323,5 +396,4 @@ class MailContent extends MailAppModel {
 		}
 		return $this->find($type, $query);
 	}
-	
 }

--- a/lib/Baser/Plugin/Mail/Model/MailField.php
+++ b/lib/Baser/Plugin/Mail/Model/MailField.php
@@ -189,11 +189,11 @@ class MailField extends MailAppModel {
 			'VALID_REGEX' 			=> __d('baser', '正規表現チェック'),
 		];
 		$source['auto_convert'] = ['CONVERT_HANKAKU' => __d('baser', '半角変換')];
-		if ($field) {
-			return $source[$field];
-		} else {
+		if (!$field) {
 			return $source;
 		}
+
+		return $source[$field];
 	}
 
 /**
@@ -212,9 +212,9 @@ class MailField extends MailAppModel {
 		$ret = $this->find('first', array('conditions' => $conditions));
 		if ($ret) {
 			return false;
-		} else {
-			return true;
 		}
+
+		return true;
 	}
 
 /**
@@ -242,14 +242,10 @@ class MailField extends MailAppModel {
 			case 'multi_check':	// マルチチェックボックス
 			case 'autozip':		// 自動保管郵便番号
 				// 選択リストのチェックを行う
-				$result = (!empty($check[key($check)]));
-				break;
-			default:
-				// 選択リストが不要のタイプの時はチェックしない
-				$result = true;
-				break;
+				return (!empty($check[key($check)]));
 		}
-		return $result;
+		// 選択リストが不要のタイプの時はチェックしない
+		return true;
 	}
 
 /**
@@ -319,24 +315,24 @@ class MailField extends MailAppModel {
 
 		$this->create($data);
 		$result = $this->save();
-		if ($result) {
-			$result['MailField']['id'] = $this->getInsertID();
-			$data = $result;
-
-			// EVENT MailField.afterCopy
-			if (!$sortUpdateOff) {
-				$event = $this->dispatchEvent('afterCopy', [
-					'id' => $data['MailField']['id'],
-					'data' => $data,
-					'oldId' => $id,
-					'oldData' => $oldData,
-				]);
-			}
-
-			return $result;
-		} else {
+		if (!$result) {
 			return false;
 		}
+
+		$result['MailField']['id'] = $this->getInsertID();
+		$data = $result;
+
+		// EVENT MailField.afterCopy
+		if (!$sortUpdateOff) {
+			$event = $this->dispatchEvent('afterCopy', [
+				'id' => $data['MailField']['id'],
+				'data' => $data,
+				'oldId' => $id,
+				'oldData' => $oldData,
+			]);
+		}
+
+		return $result;
 	}
 
 /**

--- a/lib/Baser/Plugin/Mail/Model/MailField.php
+++ b/lib/Baser/Plugin/Mail/Model/MailField.php
@@ -20,7 +20,7 @@ class MailField extends MailAppModel {
 
 /**
  * ビヘイビア
- * 
+ *
  * @var array
  */
 	public $actsAs = array('BcCache');
@@ -36,43 +36,118 @@ class MailField extends MailAppModel {
 		parent::__construct($id, $table, $ds);
 		$this->validate = [
 			'id' => [
-				['rule' => 'numeric', 'on' => 'update', 'message' => __d('baser', 'IDに不正な値が利用されています。')]],
+				[
+					'rule' => 'numeric',
+					'on' => 'update',
+					'message' => __d('baser', 'IDに不正な値が利用されています。')
+				]
+			],
 			'name' => [
-				['rule' => ['notBlank'], 'message' => __d('baser', '項目名を入力してください。')],
-				['rule' => ['maxLength', 255], 'message' => __d('baser', '項目名は255文字以内で入力してください。')]],
+				[
+					'rule' => ['notBlank'],
+					'message' => __d('baser', '項目名を入力してください。')
+				],
+				[
+					'rule' => ['maxLength', 255],
+					'message' => __d('baser', '項目名は255文字以内で入力してください。')
+				]
+			],
 			'field_name' => [
-				['rule' => ['halfTextMailField'], 'message' => __d('baser', 'フィールド名は半角英数字のみで入力してください。'), 'allowEmpty' => false],
-				['rule' => 'duplicateMailField', 'message' => __d('baser', '入力されたフィールド名は既に登録されています。')],
-				['rule' => ['maxLength', 255], 'message' => __d('baser', 'フィールド名は255文字以内で入力してください。')]],
+				[
+					'rule' => ['halfTextMailField'],
+					'message' => __d('baser', 'フィールド名は半角英数字のみで入力してください。'),
+					'allowEmpty' => false
+				],
+				[
+					'rule' => 'duplicateMailField',
+					'message' => __d('baser', '入力されたフィールド名は既に登録されています。')
+				],
+				[
+					'rule' => ['maxLength', 255],
+					'message' => __d('baser', 'フィールド名は255文字以内で入力してください。')
+				]
+			],
 			'type' => [
-				['rule' => ['notBlank'], 'message' => __d('baser', 'タイプを入力してください。')]],
+				[
+					'rule' => ['notBlank'],
+					'message' => __d('baser', 'タイプを入力してください。')
+				]
+			],
 			'head' => [
-				['rule' => ['maxLength', 255], 'message' => __d('baser', '項目見出しは255文字以内で入力してください。')]],
+				[
+					'rule' => ['maxLength', 255],
+					'message' => __d('baser', '項目見出しは255文字以内で入力してください。')
+				]
+			],
 			'attention' => [
-				['rule' => ['maxLength', 255], 'message' => __d('baser', '注意書きは255文字以内で入力してください。')]],
+				[
+					'rule' => ['maxLength', 255],
+					'message' => __d('baser', '注意書きは255文字以内で入力してください。')
+				]
+			],
 			'before_attachment' => [
-				['rule' => ['maxLength', 255], 'message' => __d('baser', '前見出しは255文字以内で入力してください。')]],
+				[
+					'rule' => ['maxLength', 255],
+					'message' => __d('baser', '前見出しは255文字以内で入力してください。')
+				]
+			],
 			'after_attachment' => [
-				['rule' => ['maxLength', 255], 'message' => __d('baser', '後見出しは255文字以内で入力してください。')]],
+				[
+					'rule' => ['maxLength', 255],
+					'message' => __d('baser', '後見出しは255文字以内で入力してください。')
+				]
+			],
 			'source' => [
-				['rule' => ['sourceMailField'], 'message' => __d('baser', '選択リストを入力してください。')]],
+				[
+					'rule' => ['sourceMailField'],
+					'message' => __d('baser', '選択リストを入力してください。')
+				]
+			],
 			'options' => [
-				['rule' => ['maxLength', 255], 'message' => __d('baser', 'オプションは255文字以内で入力してください。')]],
+				[
+					'rule' => ['maxLength', 255],
+					'message' => __d('baser', 'オプションは255文字以内で入力してください。')
+				]
+			],
 			'class' => [
-				['rule' => ['maxLength', 255], 'message' => __d('baser', 'クラス名は255文字以内で入力してください。')]],
+				[
+					'rule' => ['maxLength', 255],
+					'message' => __d('baser', 'クラス名は255文字以内で入力してください。')
+				]
+			],
 			'separator' => [
-				['rule' => ['maxLength', 20], 'message' => __d('baser', '区切り文字は20文字以内で入力してください。')]],
+				[
+					'rule' => ['maxLength', 20],
+					'message' => __d('baser', '区切り文字は20文字以内で入力してください。')
+				]
+			],
 			'default_value' => [
-				['rule' => ['maxLength', 255], 'message' => __d('baser', '初期値は255文字以内で入力してください。')]],
+				[
+					'rule' => ['maxLength', 255],
+					'message' => __d('baser', '初期値は255文字以内で入力してください。')
+				]
+			],
 			'description' => [
-				['rule' => ['maxLength', 255], 'message' => __d('baser', '説明文は255文字以内で入力してください。')]],
+				[
+					'rule' => ['maxLength', 255],
+					'message' => __d('baser', '説明文は255文字以内で入力してください。')
+				]
+			],
 			'group_field' => [
-				['rule' => ['maxLength', 255], 'message' => __d('baser', 'グループフィールドは255文字以内で入力してください。')]],
+				[
+					'rule' => ['maxLength', 255],
+					'message' => __d('baser', 'グループフィールドは255文字以内で入力してください。')
+				]
+			],
 			'group_valid' => [
-				['rule' => ['maxLength', 255], 'message' => __d('baser', 'グループ入力チェックは255文字以内で入力してください。')]]
+				[
+					'rule' => ['maxLength', 255],
+					'message' => __d('baser', 'グループ入力チェックは255文字以内で入力してください。')
+				]
+			]
 		];
 	}
-	
+
 /**
  * コントロールソースを取得する
  *
@@ -185,14 +260,25 @@ class MailField extends MailAppModel {
  * @return mixed UserGroup Or false
  */
 	public function copy($id, $data = array(), $options = array()) {
-		$options = array_merge(array(
-			'sortUpdateOff' => false,
-			), $options);
+		$options = array_merge(
+			array(
+				'sortUpdateOff' => false,
+			),
+			$options
+		);
 
 		extract($options);
 
 		if ($id) {
-			$data = $this->find('first', array('conditions' => array('MailField.id' => $id), 'recursive' => -1));
+			$data = $this->find(
+				'first',
+				[
+					'conditions' => [
+						'MailField.id' => $id
+					],
+					'recursive' => -1
+				]
+			);
 		}
 		$oldData = $data;
 
@@ -216,7 +302,12 @@ class MailField extends MailAppModel {
 			}
 		}
 
-		$data['MailField']['no'] = $this->getMax('no', array('MailField.mail_content_id' => $data['MailField']['mail_content_id'])) + 1;
+		$data['MailField']['no'] = $this->getMax(
+				'no',
+				array(
+					'MailField.mail_content_id' => $data['MailField']['mail_content_id']
+				)
+			) + 1;
 		if (!$sortUpdateOff) {
 			$data['MailField']['sort'] = $this->getMax('sort') + 1;
 		}
@@ -247,7 +338,7 @@ class MailField extends MailAppModel {
 			return false;
 		}
 	}
-	
+
 /**
  * 選択リストのソースを整形する
  * 空白と \r を除外し、改行で結合する
@@ -266,7 +357,7 @@ class MailField extends MailAppModel {
 	}
 
 /**
- * After Delete 
+ * After Delete
  */
 	public function afterDelete() {
 		parent::afterDelete();
@@ -277,7 +368,7 @@ class MailField extends MailAppModel {
 
 /**
  * After Save
- * 
+ *
  * @param bool $created
  * @param array $options
  */

--- a/lib/Baser/Plugin/Mail/Model/MailField.php
+++ b/lib/Baser/Plugin/Mail/Model/MailField.php
@@ -232,8 +232,8 @@ class MailField extends MailAppModel {
 
 /**
  * 選択リストの入力チェック
- * 
- * @param type $check
+ *
+ * @param integer $check
  */
 	public function sourceMailField($check) {
 		switch ($this->data['MailField']['type']) {

--- a/lib/Baser/Plugin/Mail/Model/MailMessage.php
+++ b/lib/Baser/Plugin/Mail/Model/MailMessage.php
@@ -38,11 +38,11 @@ class MailMessage extends MailAppModel {
 
 /**
  * メールコンテンツ情報
- * 
+ *
  * @var array
  */
 	public $mailContent = array();
-	
+
 /**
  * ビヘイビア
  *
@@ -53,12 +53,12 @@ class MailMessage extends MailAppModel {
 			'subdirDateFormat' => 'Y/m/'
 		)
 	);
-	
+
 /**
  * モデルのセットアップを行う
- * 
+ *
  * MailMessageモデルは利用前にこのメソッドを呼び出しておく必要あり
- * 
+ *
  * @param int $mailContentId
  * @return boolean
  */
@@ -77,7 +77,7 @@ class MailMessage extends MailAppModel {
 			return false;
 		}
 		$this->mailContent = ['MailContent' => $mailContent['MailContent']];
-		
+
 		$this->mailFields = $MailContent->MailField->find('all', [
 			'conditions' => ['MailField.mail_content_id' => $mailContentId, 'MailField.use_field' => true],
 			'recursive' => -1,
@@ -87,18 +87,18 @@ class MailMessage extends MailAppModel {
 		// アップロード設定
 		$this->setupUpload($mailContentId);
 		return true;
-		
+
 	}
 
 /**
  * テーブル名を設定する
- * 
+ *
  * @param $mailContentId
  */
 	public function setUseTable($mailContentId) {
 		$this->table = $this->useTable = $this->createTableName($mailContentId);
 	}
-	
+
 /**
  * アップロード設定を行う
  */
@@ -108,7 +108,7 @@ class MailMessage extends MailAppModel {
 		$settings['fields'] = array();
 		foreach ($this->mailFields as $mailField) {
 			$mailField = $mailField['MailField'];
-			if($mailField['type'] == 'file') {
+			if($mailField['type'] === 'file') {
 				$settings['fields'][$mailField['field_name']] = array(
 					'type' => 'all',
 					'namefield' => 'id',
@@ -120,9 +120,9 @@ class MailMessage extends MailAppModel {
 			$settings['saveDir'] = "mail" . DS . "limited" . DS . $name . DS . "messages";
 		}
 		$this->Behaviors->load('BcUpload', $settings);
-		
+
 	}
-	
+
 /**
  * beforeSave
  *
@@ -177,8 +177,8 @@ class MailMessage extends MailAppModel {
 			$mailField = $mailField['MailField'];
 			if ($mailField['valid'] && !empty($mailField['use_field'])) {
 				// 必須項目
-				if ($mailField['valid'] == 'VALID_NOT_EMPTY' || $mailField['valid'] == 'VALID_EMAIL') {
-					if($mailField['type'] == 'file') {
+				if ($mailField['valid'] === 'VALID_NOT_EMPTY' || $mailField['valid'] === 'VALID_EMAIL') {
+					if($mailField['type'] === 'file') {
 						if(!isset($this->data['MailMessage'][$mailField['field_name'] . '_tmp'])) {
 							$this->validate[$mailField['field_name']] = array('notBlank' => array(
 									'rule' => array('notFileEmpty'),
@@ -194,13 +194,13 @@ class MailMessage extends MailAppModel {
 						));
 					}
 				// 半角数字
-				} elseif ($mailField['valid'] == '/^(|[0-9]+)$/') {
+				} elseif ($mailField['valid'] === '/^(|[0-9]+)$/') {
 					$this->validate[$mailField['field_name']] = array(
 							'rule' => '/^(|[0-9]+)$/',
 							'message' => '半角数字で入力してください。'
 				);
 				// 半角数字（入力必須）
-				} elseif ($mailField['valid'] == '/^([0-9]+)$/') {
+				} elseif ($mailField['valid'] === '/^([0-9]+)$/') {
 					$this->validate[$mailField['field_name']] = array(
 							'rule' => '/^([0-9]+)$/',
 							'message' => __('半角数字で入力してください。')
@@ -208,7 +208,7 @@ class MailMessage extends MailAppModel {
 				} else {
 					$this->validate[$mailField['field_name']] = $mailField['valid'];
 				}
-				if (!empty($this->data['MailMessage'][$mailField['field_name']]) && $mailField['valid'] == 'VALID_EMAIL') {
+				if (!empty($this->data['MailMessage'][$mailField['field_name']]) && $mailField['valid'] === 'VALID_EMAIL') {
 					$this->validate[$mailField['field_name']] = array('email' => array(
 						'rule' => array('email'),
 						'message' => __('形式が無効です。')
@@ -258,7 +258,7 @@ class MailMessage extends MailAppModel {
 			}
 		}
 	}
-	
+
 /**
  * 拡張バリデートチェック
  *
@@ -449,11 +449,11 @@ class MailMessage extends MailAppModel {
 			if ($value !== null) {
 
 				// 半角処理
-				if ($mailField['auto_convert'] == 'CONVERT_HANKAKU') {
+				if ($mailField['auto_convert'] === 'CONVERT_HANKAKU') {
 					$value = mb_convert_kana($value, 'a');
 				}
 				// 全角処理
-				if ($mailField['auto_convert'] == 'CONVERT_ZENKAKU') {
+				if ($mailField['auto_convert'] === 'CONVERT_ZENKAKU') {
 					$value = mb_convert_kana($value, 'AK');
 				}
 				// サニタイズ
@@ -487,7 +487,7 @@ class MailMessage extends MailAppModel {
 				// 対象フィールドがあれば、バリデートグループごとに配列に格納する
 				if (!is_null($mailField['default_value']) && $mailField['default_value'] !== "") {
 
-					if ($mailField['type'] == 'multi_check') {
+					if ($mailField['type'] === 'multi_check') {
 						$_data['MailMessage'][$mailField['field_name']][0] = $mailField['default_value'];
 					} else {
 						$_data['MailMessage'][$mailField['field_name']] = $mailField['default_value'];
@@ -519,7 +519,7 @@ class MailMessage extends MailAppModel {
 		foreach ($this->mailFields as $mailField) {
 			$mailField = $mailField['MailField'];
 			// マルチチェックのデータを｜区切りに変換
-			if ($mailField['type'] == 'multi_check' && $mailField['use_field']) {
+			if ($mailField['type'] === 'multi_check' && $mailField['use_field']) {
 				if (!empty($dbData['MailMessage'][$mailField['field_name']])) {
 					if (is_array($dbData['MailMessage'][$mailField['field_name']])) {
 						$dbData['MailMessage'][$mailField['field_name']] = implode("|", $dbData['MailMessage'][$mailField['field_name']]);
@@ -529,7 +529,7 @@ class MailMessage extends MailAppModel {
 				}
 			}
 			// パスワードのデータをハッシュ化
-			if ($mailField['type'] == 'password') {
+			if ($mailField['type'] === 'password') {
 				if (!empty($dbData['MailMessage'][$mailField['field_name']])) {
 					App::uses('AuthComponent', 'Controller/Component');
 					$dbData['MailMessage'][$mailField['field_name']] = AuthComponent::password($dbData['MailMessage'][$mailField['field_name']]);
@@ -648,12 +648,12 @@ class MailMessage extends MailAppModel {
 			if($mailField['no_send']) {
 				unset($dbData['message'][$mailField['field_name']]);
 			}
-			if ($mailField['type'] == 'multi_check') {
+			if ($mailField['type'] === 'multi_check') {
 				if (!empty($dbData['message'][$mailField['field_name']]) && !is_array($dbData['message'][$mailField['field_name']])) {
 					$dbData['message'][$mailField['field_name']] = explode("|", $dbData['message'][$mailField['field_name']]);
 				}
 			}
-			if($mailField['type'] == 'file' && isset($dbData['message'][$mailField['field_name'] . '_tmp'])) {
+			if($mailField['type'] === 'file' && isset($dbData['message'][$mailField['field_name'] . '_tmp'])) {
 				$dbData['message'][$mailField['field_name']] = $dbData['message'][$mailField['field_name'] . '_tmp'];
 				unset($dbData['message'][$mailField['field_name'] . '_tmp']);
 			}
@@ -679,14 +679,14 @@ class MailMessage extends MailAppModel {
 
 /**
  * フルテーブル名を生成する
- * 
+ *
  * @param $mailContentId
  * @return string
  */
 	public function createFullTableName($mailContentId) {
 		return $this->tablePrefix . $this->createTableName($mailContentId);
 	}
-	
+
 /**
  * メッセージテーブルを作成する
  *
@@ -776,7 +776,7 @@ class MailMessage extends MailAppModel {
  * メッセージ保存用テーブルのフィールドを最適化する
  * 初回の場合、id/created/modifiedを追加する
  * 2回目以降の場合は、最後のカラムに追加する
- * 
+ *
  * @param array $dbConfig
  * @param int $mailContentId
  * @return boolean
@@ -808,7 +808,7 @@ class MailMessage extends MailAppModel {
 
 /**
  * 受信メッセージの内容を表示状態に変換する
- * 
+ *
  * @param int $id
  * @param array $messages
  * @return array
@@ -830,7 +830,7 @@ class MailMessage extends MailAppModel {
 			$inData = array();
 			$inData['NO'] = $message[$this->alias]['id'];
 			foreach ($mailFields as $mailField) {
-				if($mailField['MailField']['type'] == 'file') {
+				if($mailField['MailField']['type'] === 'file') {
 					$inData[$mailField['MailField']['field_name'] . ' (' . $mailField['MailField']['name'] . ')'] = $message[$this->alias][$mailField['MailField']['field_name']];
 				} else {
 					$inData[$mailField['MailField']['field_name'] . ' (' . $mailField['MailField']['name'] . ')'] = $Maildata->toDisplayString(
@@ -847,10 +847,10 @@ class MailMessage extends MailAppModel {
 
 		return $messages;
 	}
-	
+
 /**
  * メール受信テーブルを全て再構築
- * 
+ *
  * @return boolean
  */
 	public function reconstructionAll() {
@@ -873,10 +873,9 @@ class MailMessage extends MailAppModel {
 
 	}
 
-	
 /**
  * find
- * 
+ *
  * @param String $type
  * @param mixed $query
  * @return Array

--- a/lib/Baser/Plugin/Mail/Model/MailMessage.php
+++ b/lib/Baser/Plugin/Mail/Model/MailMessage.php
@@ -736,7 +736,7 @@ class MailMessage extends MailAppModel {
  *
  * @param string $contentName
  * @param string $field
- * @return array
+ * @return array|bool
  */
 	public function addMessageField($mailContentId, $field) {
 		$table = $this->createTableName($mailContentId);
@@ -750,7 +750,7 @@ class MailMessage extends MailAppModel {
  *
  * @param string $contentName
  * @param string $field
- * @return array
+ * @return array|bool
  */
 	public function delMessageField($mailContentId, $field) {
 		$table = $this->createTableName($mailContentId);
@@ -764,7 +764,7 @@ class MailMessage extends MailAppModel {
  * @param string $fieldName
  * @param string $oldFieldName
  * @param string $newfieldName
- * @return array
+ * @return array|bool
  */
 	public function renameMessageField($mailContentId, $oldFieldName, $newfieldName) {
 		$table = $this->createTableName($mailContentId);

--- a/lib/Baser/Plugin/Mail/View/Elements/admin/submenus/mail_fields.php
+++ b/lib/Baser/Plugin/Mail/View/Elements/admin/submenus/mail_fields.php
@@ -20,11 +20,57 @@
 	<th><?php echo __d('baser', 'メールフォーム管理メニュー')?></th>
 	<td>
 		<ul class="cleafix">
-			<li><?php $this->BcBaser->link(sprintf(__d('baser', '%s 設定'), $this->request->params['Content']['title']), array('controller' => 'mail_contents', 'action' => 'edit', $mailContent['MailContent']['id'])) ?></li>
-			<li><?php $this->BcBaser->link(__d('baser', 'メールフィールド一覧'), array('controller' => 'mail_fields', 'action' => 'index', $mailContent['MailContent']['id'])) ?></li>
-			<li><?php $this->BcBaser->link(__d('baser', 'メールフィールド新規追加'), array('controller' => 'mail_fields', 'action' => 'add', $mailContent['MailContent']['id'])) ?></li>
-			<li><?php $this->BcBaser->link(__d('baser', '受信メール一覧'), array('controller' => 'mail_messages', 'action' => 'index', $mailContent['MailContent']['id'])) ?></li>
-			<li><?php $this->BcBaser->link(__d('baser', 'メールプラグイン基本設定'), array('controller' => 'mail_configs', 'action' => 'form')) ?></li>
+			<li><?php
+			$this->BcBaser->link(
+				sprintf(
+					__d('baser', '%s 設定'), $this->request->params['Content']['title']
+				),
+				array(
+					'controller' => 'mail_contents',
+					'action' => 'edit',
+					$mailContent['MailContent']['id']
+				)
+			) ?>
+			</li>
+			<li><?php
+			$this->BcBaser->link(
+				__d('baser', 'メールフィールド一覧'),
+				array(
+					'controller' => 'mail_fields',
+					'action' => 'index',
+					$mailContent['MailContent']['id']
+				)
+			) ?>
+			</li>
+			<li><?php
+			$this->BcBaser->link(
+				__d('baser', 'メールフィールド新規追加'),
+				array(
+					'controller' => 'mail_fields',
+					'action' => 'add',
+					$mailContent['MailContent']['id']
+				)
+			) ?>
+			</li>
+			<li><?php
+			$this->BcBaser->link(
+				__d('baser', '受信メール一覧'),
+				array(
+					'controller' => 'mail_messages',
+					'action' => 'index',
+					$mailContent['MailContent']['id']
+				)
+			) ?>
+			</li>
+			<li><?php
+			$this->BcBaser->link(
+				__d('baser', 'メールプラグイン基本設定'),
+				array(
+					'controller' => 'mail_configs',
+					'action' => 'form'
+				)
+			) ?>
+			</li>
 		</ul>
 	</td>
 </tr>

--- a/lib/Baser/Plugin/Mail/View/Elements/mail_form.php
+++ b/lib/Baser/Plugin/Mail/View/Elements/mail_form.php
@@ -21,8 +21,9 @@ $this->Mail->token();
 <script type="text/javascript">
 $(function(){
 	$(".form-submit").click(function(){
-		var mode = $(this).attr('id').replace('BtnMessage', '');
-		$("#MailMessageMode").val(mode);
+		$("#MailMessageMode").val(
+			$(this).attr('id').replace('BtnMessage', '')
+		);
 		$(this).prop('disabled',true);//ボタンを無効化する
 		$(this).closest('form').submit();//フォームを送信する
 		return true;

--- a/lib/Baser/Plugin/Mail/View/Elements/mail_form.php
+++ b/lib/Baser/Plugin/Mail/View/Elements/mail_form.php
@@ -33,14 +33,25 @@ $(function(){
 
 <?php /* フォーム開始タグ */ ?>
 <?php if (!$freezed): ?>
-	<?php echo $this->Mailform->create('MailMessage', array('url' => $this->BcBaser->getContentsUrl(null, false, null, false) . 'confirm', 'type' => 'file')) ?>
+	<?php echo $this->Mailform->create(
+		'MailMessage',
+		array(
+			'url' => $this->BcBaser->getContentsUrl(null, false, null, false) . 'confirm',
+			'type' => 'file'
+		)
+	) ?>
 <?php else: ?>
-	<?php echo $this->Mailform->create('MailMessage', array('url' => $this->BcBaser->getContentsUrl(null, false, null, false)  . 'submit')) ?>
+	<?php echo $this->Mailform->create(
+		'MailMessage',
+		array(
+			'url' => $this->BcBaser->getContentsUrl(null, false, null, false)  . 'submit'
+		)
+	) ?>
 <?php endif; ?>
 <?php /* フォーム本体 */ ?>
 
 <?php $this->Mailform->unlockField('MailMessage.mode') ?>
-<?php echo $this->Mailform->hidden('MailMessage.mode') ?>
+<?= $this->Mailform->hidden('MailMessage.mode') ?>
 
 <table cellpadding="0" cellspacing="0" class="row-table-01">
 	<?php $this->BcBaser->element('mail_input', array('blockStart' => 1)) ?>
@@ -49,26 +60,50 @@ $(function(){
 <?php if ($mailContent['MailContent']['auth_captcha']): ?>
 	<?php if (!$freezed): ?>
 		<div class="auth-captcha clearfix">
-			<?php echo $this->Mailform->authCaptcha('MailMessage.auth_captcha') ?>
+			<?= $this->Mailform->authCaptcha('MailMessage.auth_captcha') ?>
 			<br />
-			&nbsp;<?php echo __('画像の文字を入力してください') ?><br clear="all" />
-			<?php echo $this->Mailform->error('MailMessage.auth_captcha', __('入力された文字が間違っています。入力をやり直してください。')) ?>
+			&nbsp;<?= __('画像の文字を入力してください')?><br clear="all" />
+			<?php echo $this->Mailform->error(
+				'MailMessage.auth_captcha',
+				__('入力された文字が間違っています。入力をやり直してください。')
+			) ?>
 		</div>
 	<?php else: ?>
-		<?php echo $this->Mailform->hidden('MailMessage.auth_captcha') ?>
-		<?php echo $this->Mailform->hidden('MailMessage.captcha_id') ?>
+		<?= $this->Mailform->hidden('MailMessage.auth_captcha') ?>
+		<?= $this->Mailform->hidden('MailMessage.captcha_id') ?>
 	<?php endif ?>
 <?php endif ?>
 
 <?php /* 送信ボタン */ ?>
 <div class="submit">
 	<?php if ($freezed): ?>
-		<?php echo $this->Mailform->submit('　' . __('書き直す') . '　', array('div' => false, 'class' => 'btn-red button form-submit', 'id' => 'BtnMessageBack')) ?>
-		<?php echo $this->Mailform->submit('　' . __('送信する') . '　', array('div' => false, 'class' => 'btn-red button form-submit', 'id' => 'BtnMessageSubmit')) ?>
+		<?php echo $this->Mailform->submit(
+			'　' . __('書き直す') . '　',
+			array(
+				'div'   => false,
+				'class' => 'btn-red button form-submit',
+				'id'    => 'BtnMessageBack'
+			)
+		) ?>
+		<?php echo $this->Mailform->submit(
+			'　' . __('送信する') . '　',
+			array(
+				'div'   => false,
+				'class' => 'btn-red button form-submit',
+				'id'    => 'BtnMessageSubmit'
+			)
+		) ?>
 	<?php else: ?>
-		<input name="resetdata" value="　<?php echo __('クリア') ?>　" type="reset" class="btn-gray button" />
-		<?php echo $this->Mailform->submit('　' . __('入力内容を確認する') . '　', array('div' => false, 'class' => 'btn-orange button form-submit', 'id' => 'BtnMessageConfirm')) ?>
+		<input name="resetdata" value="　<?= __('クリア') ?>　" type="reset" class="btn-gray button" />
+		<?php echo $this->Mailform->submit(
+			'　' . __('入力内容を確認する') . '　',
+			array(
+				'div'   => false,
+				'class' => 'btn-orange button form-submit',
+				'id'    => 'BtnMessageConfirm'
+			)
+		) ?>
 	<?php endif; ?>
 </div>
 
-<?php echo $this->Mailform->end() ?>
+<?= $this->Mailform->end() ?>

--- a/lib/Baser/Plugin/Mail/View/Elements/mail_input.php
+++ b/lib/Baser/Plugin/Mail/View/Elements/mail_input.php
@@ -13,97 +13,161 @@
 /**
  * メールフォーム入力欄
  * 呼出箇所：メールフォーム入力ページ、メールフォーム入力内容確認ページ
- * 
- * @var int $blockStart 表示するフィールドの開始NO
- * @var int $blockEnd 表示するフィールドの終了NO
- * @var bool $freezed 確認画面かどうか
+ *
+ * @var int  $this->get('blockStart') 表示するフィールドの開始NO
+ * @var int  $this->get('blockEnd') 表示するフィールドの終了NO
+ * @var bool $this->get('freezed') 確認画面かどうか
  */
+
+if (!$this->get('mailFields')) {
+	return;
+}
+
+$template = [
+	'row'    => [
+		'<tr id="{%row_id%}"{%display%}>',
+		'<th class="col-head" width="150">{%label%}{%mark%}</th>',
+		'<td class="col-input">{%input%}</td>',
+		'</tr>'
+	],
+	'row_id' => 'RowMessage{%camelize(field_name)%}',
+	'mark'   => [
+		'required' => sprintf('<span class="required">%s</span>', __('必須')),
+		'optional' => sprintf('<span class="normal">%s</span>', __('任意'))
+	],
+	'input' => [
+		'wrap'        => [
+			'<span id="{%field_id%}">',
+			'{%description%}{%before%}{%input%}{%after%}{%attention%}{%error%}{%group-error%}',
+			'</span>'
+		],
+		'field_id'    => 'FieldMessage{%camelize(field_name)%}',
+		'description' => '<span class="mail-description">{%description%}</span>',
+		'before'      => '<span class="mail-before-attachment">{%before%}</span>',
+		'after'       => '<span class="mail-after-attachment">{%after%}</span>',
+		'attention'   => '<span class="mail-attention">{%attention%}</span>'
+	]
+];
+
 $group_field = null;
 $iteration = 0;
-if (!isset($blockEnd)) {
-	$blockEnd = 0;
-}
 
-if (!empty($mailFields)) {
-
-	foreach ($mailFields as $key => $record) {
-
-		$field = $record['MailField'];
-		$iteration++;
-		if ($field['use_field'] && ($blockStart && $iteration >= $blockStart) && (!$blockEnd || $iteration <= $blockEnd)) {
-
-			$next_key = $key + 1;
-			$description = $field['description'];
-
-			/* 項目名 */
-			if ($group_field != $field['group_field'] || (!$group_field && !$field['group_field'])) {
-				echo '    <tr id="RowMessage' . Inflector::camelize($record['MailField']['field_name']) . '"';
-				if ($field['type'] == 'hidden') {
-					echo ' style="display:none"';
-				}
-				echo '>' . "\n" . '        <th class="col-head" width="150">' . $this->Mailform->label("MailMessage." . $field['field_name'] . "", $field['head']);
-				if ($field['not_empty']) {
-					echo '<span class="required">' . __('必須') . '</span>';
-				} else {
-					echo '<span class="normal">' . __('任意') . '</span>';
-				}
-				echo '</th>' . "\n" . '        <td class="col-input">';
-			}
-
-			echo '<span id="FieldMessage' . Inflector::camelize($record['MailField']['field_name']) . '">';
-			if (!$freezed && $description) {
-				echo '<span class="mail-description">' . $description . '</span>';
-			}
-			/* 入力欄 */
-			if (!$freezed || $this->Mailform->value("MailMessage." . $field['field_name']) !== '') {
-				echo '<span class="mail-before-attachment">' . $field['before_attachment'] . '</span>';
-			}
-
-			// =========================================================================================================
-			// 2018/02/06 ryuring
-			// no_send オプションは、確認画面に表示しないようにするために利用されている可能性が高い
-			//（メールアドレスのダブル入力、プライバシーポリシーへの同意に利用されている）
-			// 本来であれば、not_display_confirm 等のオプションを別途準備し、そちらを利用するべきだが、
-			// 後方互換のため残す
-			// =========================================================================================================
-			if ($freezed && $field['no_send']) {
-				echo $this->Mailform->control('hidden', "MailMessage." . $field['field_name'] . "", $this->Mailfield->getOptions($record), $this->Mailfield->getAttributes($record));
-			} else {
-				echo $this->Mailform->control($field['type'], "MailMessage." . $field['field_name'] . "", $this->Mailfield->getOptions($record), $this->Mailfield->getAttributes($record));
-			}
-
-			if (!$freezed || $this->Mailform->value("MailMessage." . $field['field_name']) !== '') {
-				echo '<span class="mail-after-attachment">' . $field['after_attachment'] . '</span>';
-			}
-			if (!$freezed) {
-				echo '<span class="mail-attention">' . $field['attention'] . '</span>';
-			}
-
-			/* 説明欄 */
-			$isGroupValidComplate = in_array('VALID_GROUP_COMPLATE', explode(',', $field['valid_ex']));
-			if(!$isGroupValidComplate) {
-				echo $this->Mailform->error("MailMessage." . $field['field_name']);
-			}
-			$isRequiredToClose = true;
-			if ($this->Mailform->isGroupLastField($mailFields, $field)) {
-				if($isGroupValidComplate) {
-					$groupValidErrors = $this->Mailform->getGroupValidErrors($mailFields, $field['group_valid']);
-					if ($groupValidErrors) {
-						foreach($groupValidErrors as $groupValidError) {
-							echo $groupValidError;
-						}
-					}
-				}
-				echo $this->Mailform->error("MailMessage." . $field['group_valid'] . "_not_same", __("入力データが一致していません。"));
-				echo $this->Mailform->error("MailMessage." . $field['group_valid'] . "_not_complate", __("入力データが不完全です。"));
-			} elseif(!empty($field['group_field'])) {
-				$isRequiredToClose = false;
-			}
-			echo '</span>';
-			if($isRequiredToClose) {
-				echo "</td>\n    </tr>\n";
-			}
-			$group_field = $field['group_field'];
-		}
+$row  = null;
+$input = [];
+$rows = [];
+$records = $this->get('mailFields');
+foreach ($records as $key => $record) {
+	$iteration++;
+	if (!$record['MailField']['use_field']) {
+		continue;
 	}
+	if (!$blockStart || $iteration < $blockStart) {
+		continue;
+	}
+	if ($this->get('blockEnd') && $iteration > $this->get('blockEnd')) {
+		continue;
+	}
+	$field = $record['MailField'];
+	$next_key = $key + 1;
+
+	// =========================================================================================================
+	// 2018/02/06 ryuring
+	// no_send オプションは、確認画面に表示しないようにするために利用されている可能性が高い
+	//（メールアドレスのダブル入力、プライバシーポリシーへの同意に利用されている）
+	// 本来であれば、not_display_confirm 等のオプションを別途準備し、そちらを利用するべきだが、
+	// 後方互換のため残す
+	// =========================================================================================================
+	$isGroupValidComplate = in_array('VALID_GROUP_COMPLATE', explode(',', $field['valid_ex']));
+	$tmp = [];
+	if(!$this->get('freezed') && $field['description']) {
+		$tmp['description'] = $this->Mail->formatText(
+			Hash::get($template, 'input.description'), $field
+		);
+	}
+	if(!$this->get('freezed') || $this->Mailform->value('MailMessage.' . $field['field_name']) !== '') {
+		$tmp['before'] = $this->Mail->formatText(
+			Hash::get($template, 'input.before'), ['before'=>$field['before_attachment']]
+		);
+		$tmp['after']  = $this->Mail->formatText(
+			Hash::get($template, 'input.after'), ['after'=>$field['after_attachment']]
+		);
+	}
+	if (!$isGroupValidComplate) {
+		$tmp['error'] = $this->Mailform->error('MailMessage.' . $field['field_name']);
+	}
+	$errors = [];
+	if ($this->Mailform->isGroupLastField($this->get('mailFields'), $field)) {
+		if ($isGroupValidComplate) {
+			$groupValidErrors = $this->Mailform->getGroupValidErrors(
+				$this->get('mailFields'),
+				$field['group_valid']
+			);
+			if ($groupValidErrors) {
+				foreach ($groupValidErrors as $groupValidError) {
+					$errors[] = $groupValidError;
+				}
+			}
+		}
+		$errors[] = $this->Mailform->error(
+			'MailMessage.' . $field['group_valid'] . "_not_same",
+			__('入力データが一致していません。')
+		);
+		$errors[] = $this->Mailform->error(
+			'MailMessage.' . $field['group_valid'] . '_not_complate',
+			__('入力データが不完全です。')
+		);
+	}
+	$input[] = $this->Mail->formatText(
+		Hash::get($template, 'input.wrap'),
+		[
+			'field_id'      => $this->Mail->formatText(
+				Hash::get($template, 'input.field_id'),
+				['camelize(field_name)'=>Inflector::camelize($field['field_name'])]
+			),
+			'description' => Hash::get($tmp, 'description', ''),
+			'before'      => Hash::get($tmp, 'before', ''),
+			'input' => $this->Mailform->control(
+				($this->get('freezed') && $field['no_send']) ? 'hidden' : $field['type'],
+				'MailMessage.' . $field['field_name'],
+				$this->Mailfield->getOptions($record),
+				$this->Mailfield->getAttributes($record)
+			),
+			'after'       => Hash::get($tmp, 'after', ''),
+			'attention'   => !$this->get('freezed') ? $this->Mailform->error(Hash::get($template, 'input.attention'), $field) : '',
+			'error'       => Hash::get($tmp, 'error', ''),
+			'group-error' => implode("\n", $errors)
+
+		]
+	);
+
+	/* 項目名 */
+	if ($group_field != $field['group_field'] || (!$group_field && !$field['group_field'])) {
+		$row = $this->mail->formatText(
+			Hash::get($template, 'row'),
+			[
+				'row_id'  => $this->Mail->formatText(
+					Hash::get($template, 'row_id'),
+					['camelize(field_name)'=>Inflector::camelize($field['field_name'])]
+				),
+				'display' => $field['type'] === 'hidden' ? ' style="display:none"' : '',
+				'label'   =>$this->Mailform->label(
+					sprintf('MailMessage.%s', $field['field_name']),
+					$field['head']
+				),
+				'mark'    => Hash::get(
+					$template,
+					$field['not_empty'] ? 'mark.required' : 'mark.optional'
+				)
+			]
+		);
+	}
+
+	if ($this->Mailform->isGroupLastField($this->get('mailFields'), $field) || empty($field['group_field'])) {
+		$rows[] = $this->Mail->formatText($row,['input'=>implode("\n", $input)]);
+		$row = false;
+		$input = [];
+	}
+	$group_field = $field['group_field'];
 }
+
+echo implode("\n", $rows);

--- a/lib/Baser/Plugin/Mail/View/Elements/mail_token.php
+++ b/lib/Baser/Plugin/Mail/View/Elements/mail_token.php
@@ -13,15 +13,15 @@
 
 
 <script type="text/javascript">
-$(document).ready(function(){
+$(function(){
 	$('input[type="submit"]').prop('disabled', true);
 });
 <?php if($this->request->is('ajax')): ?>
-$(document).ready(function(){
+$(function(){
 <?php else: ?>
 $(window).on('load', function() {
 <?php endif ?>
-	var getTokenUrl = '<?php echo $this->BcBaser->getUrl('/bc_form/ajax_get_token?requestview=false') ?>';
+	let getTokenUrl = '<?php echo $this->BcBaser->getUrl('/bc_form/ajax_get_token?requestview=false') ?>';
 	$.ajaxSetup({cache: false});
 	$.get(getTokenUrl, function(result) {
 		$('input[name="data[_Token][key]"]').val(result);

--- a/lib/Baser/Plugin/Mail/View/Helper/MailBaserHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MailBaserHelper.php
@@ -26,7 +26,13 @@ class MailBaserHelper extends AppHelper {
  * @return bool
  */
 	public function isMail() {
-		return (!empty($this->request->params['Content']['plugin']) && $this->request->params['Content']['plugin'] == 'Mail');
+		if (!Hash::get($this->request->params, 'Content.plugin')) {
+			return false;
+		}
+		if (Hash::get($this->request->params, 'Content.plugin') !== 'Mail') {
+			return false;
+		}
+		return true;
 	}
 
 }

--- a/lib/Baser/Plugin/Mail/View/Helper/MailBaserHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MailBaserHelper.php
@@ -28,5 +28,5 @@ class MailBaserHelper extends AppHelper {
 	public function isMail() {
 		return (!empty($this->request->params['Content']['plugin']) && $this->request->params['Content']['plugin'] == 'Mail');
 	}
-	
+
 }

--- a/lib/Baser/Plugin/Mail/View/Helper/MailHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MailHelper.php
@@ -243,7 +243,7 @@ class MailHelper extends AppHelper {
  * @param string $viewFile
  */
 	public function beforeRender($viewFile) {
-		if($this->request->params['controller'] == 'mail' && in_array($this->request->params['action'], ['index', 'confirm', 'submit'])) {
+		if($this->request->params['controller'] === 'mail' && in_array($this->request->params['action'], ['index', 'confirm', 'submit'])) {
 			// メールフォームをショートコードを利用する際、ショートコードの利用先でキャッシュを利用している場合、
 			// セキュリティコンポーネントで発行するトークンが更新されない為、強制的にキャッシュをオフにする
 			if (!empty($this->request->params['requested'])) {

--- a/lib/Baser/Plugin/Mail/View/Helper/MailHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MailHelper.php
@@ -252,5 +252,18 @@ class MailHelper extends AppHelper {
 			$this->_View->BcForm->request->params['_Token']['unlockedFields'] = $this->_View->get('unlockedFields');
 		}
 	}
-
+	/**
+	 * 簡易テンプレート
+	 *
+	 * @return string
+	 */
+	public function formatText($text, $values=[], $left='{%', $right='%}') {
+		if(is_array($text)) {
+			$text = implode("\n", $text);
+		}
+		foreach ($values as $k=>$v) {
+			$text = str_replace($left.$k.$right, $v, $text);
+		}
+		return $text;
+	}
 }

--- a/lib/Baser/Plugin/Mail/View/Helper/MailHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MailHelper.php
@@ -170,11 +170,11 @@ class MailHelper extends AppHelper {
  * @return boolean 設定されている場合 true を返す
  */
 	public function descriptionExists() {
-		if (!empty($this->mailContent['description'])) {
-			return true;
-		} else {
+		if (empty($this->mailContent['description'])) {
 			return false;
 		}
+
+		return true;
 	}
 
 /**

--- a/lib/Baser/Plugin/Mail/View/Helper/MaildataHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MaildataHelper.php
@@ -48,16 +48,6 @@ class MaildataHelper extends BcTextHelper {
  */
 	public function toDisplayString($type, $value) {
 		switch ($type) {
-			case 'text':
-			case 'tel':
-			case 'textarea':
-			case 'email':
-			case 'hidden':
-			case 'check':
-			case 'radio':
-			case 'select':
-				return $value;
-
 			case 'pref':
 				$prefs = $this->prefList();
 				$options = array();

--- a/lib/Baser/Plugin/Mail/View/Helper/MaildataHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MaildataHelper.php
@@ -96,9 +96,19 @@ class MaildataHelper extends BcTextHelper {
 				$aryFile = explode('/', $value);
 				$file = $aryFile[count($aryFile) - 1];
 				$ext = decodeContent(null, $file);
-				$link = array_merge(array('admin' => true, 'controller' => 'mail_messages', 'action' => 'attachment', $mailContent['MailContent']['id']), $aryFile);
+				$link = array_merge(
+					array(
+						'admin' => true,
+						'controller' => 'mail_messages',
+						'action' => 'attachment',
+						$mailContent['MailContent']['id']
+					),
+					$aryFile
+				);
 				if (in_array($ext, array('gif', 'jpg', 'png'))) {
-					return $this->BcBaser->getLink($this->BcBaser->getImg($link, array('width' => 400)), $link, array('target' => '_blank'));
+					return $this->BcBaser->getLink(
+						$this->BcBaser->getImg($link, array('width' => 400)), $link, array('target' => '_blank')
+					);
 				}
 
 				return $this->BcBaser->getLink($file, $link);

--- a/lib/Baser/Plugin/Mail/View/Helper/MailfieldHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MailfieldHelper.php
@@ -34,9 +34,9 @@ class MailfieldHelper extends AppHelper {
 		$attributes['maxlength'] = $data['maxlength'];
 		$attributes['separator'] = $data['separator'];
 		$attributes['class'] = $data['class'];
-		if($data['type'] == 'multi_check') {
+		if($data['type'] === 'multi_check') {
 			$attributes['multiple'] = true;
-		} elseif ($data['type'] == 'tel') {
+		} elseif ($data['type'] === 'tel') {
 			$attributes['type'] = 'tel';
 		}
 		if (!empty($data['options'])) {
@@ -58,7 +58,7 @@ class MailfieldHelper extends AppHelper {
 			$data = $data['MailField'];
 		}
 		if (!empty($data['source'])) {
-			if ($data['type'] != "check") {
+			if ($data['type'] !== "check") {
 				$values = explode("\n", str_replace('|', "\n", $data['source']));
 				$source = [];
 				foreach ($values as $value) {

--- a/lib/Baser/Plugin/Mail/View/Helper/MailformHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MailformHelper.php
@@ -24,7 +24,7 @@ class MailformHelper extends BcFreezeHelper {
 
 /**
  * ヘルパー
- * 
+ *
  * @var array
  */
 	public $helpers = ['Html', 'BcTime', 'BcText', 'Js', 'BcUpload', 'BcCkeditor', 'BcBaser', 'BcContents', 'BcArray'];
@@ -73,7 +73,7 @@ class MailformHelper extends BcFreezeHelper {
 				// フィールド自身が送信されないため、validatePost に引っかかってしまう
 				// hiddenタグを強制的に出すため、falseを明示的に指定
 				$attributes['hiddenField'] = false;
-				$out = $this->hidden($fieldName, array(['value' => '']));
+				$out = $this->hidden($fieldName, ['value' => '']);
 				$out .= $this->radio($fieldName, $options, $attributes);
 				break;
 
@@ -83,8 +83,8 @@ class MailformHelper extends BcFreezeHelper {
 				unset($attributes['maxlength']);
 				unset($attributes['separator']);
 				if (isset($attributes['empty'])) {
-					if (strtolower($attributes['empty']) == 'false' || 
-						strtolower($attributes['empty']) == 'null') {
+					if (strtolower($attributes['empty']) === 'false' ||
+						strtolower($attributes['empty']) === 'null') {
 						$showEmpty = false;
 					} else {
 						$showEmpty = $attributes['empty'];
@@ -174,7 +174,7 @@ class MailformHelper extends BcFreezeHelper {
 				$out .= $this->file($fieldName, $attributes);
 
 				break;
-			
+
 			case 'date_time_calender':
 				unset($attributes['size']);
 				unset($attributes['rows']);
@@ -190,11 +190,11 @@ class MailformHelper extends BcFreezeHelper {
 				unset($attributes['empty']);
 				$attributes['monthNames'] = false;
 				$attributes['separator'] = '&nbsp;';
-				if (isset($attributes['minYear']) && $attributes['minYear'] == 'today') {
-					$attributes['minYear'] = intval(date('Y'));
+				if (isset($attributes['minYear']) && $attributes['minYear'] === 'today') {
+					$attributes['minYear'] = (int)date('Y');
 				}
-				if (isset($attributes['maxYear']) && $attributes['maxYear'] == 'today') {
-					$attributes['maxYear'] = intval(date('Y'));
+				if (isset($attributes['maxYear']) && $attributes['maxYear'] === 'today') {
+					$attributes['maxYear'] = (int)date('Y');
 				}
 				$out = $this->dateTime($fieldName, 'WMD', null, $attributes);
 				break;
@@ -255,7 +255,7 @@ class MailformHelper extends BcFreezeHelper {
 
 /**
  * 認証キャプチャを表示する
- * 
+ *
  * @param array $options オプション（初期値 : []）
  * 	- `separate` : 画像と入力欄の区切り（初期値：''）
  * 	- `class` : CSSクラス名（初期値：auth-captcha-image）

--- a/lib/Baser/Plugin/Mail/View/Helper/MailformHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MailformHelper.php
@@ -288,7 +288,10 @@ class MailformHelper extends BcFreezeHelper {
 	public function getGroupValidErrors($mailFields, $groupValid, $options = [], $distinct = true) {
 		$errors = [];
 		foreach ($mailFields as $mailField) {
-			if ($mailField['MailField']['group_valid'] !== $groupValid || !in_array('VALID_GROUP_COMPLATE', explode(',', $mailField['MailField']['valid_ex']))) {
+			if ($mailField['MailField']['group_valid'] !== $groupValid) {
+				continue;
+			}
+			if (!in_array('VALID_GROUP_COMPLATE', explode(',', $mailField['MailField']['valid_ex']))) {
 				continue;
 			}
 			if(!empty($this->validationErrors['MailMessage'][$mailField['MailField']['field_name']])) {


### PR DESCRIPTION
https://github.com/baserproject/basercms/issues/1577

上記の件、コミット内容が散らかっていたので再編しました！
検討をお願いします。

https://github.com/yama/basercms/commit/b6d6aa45d0f428cce91477b9e49ed5d3183dacf0
上記のコミットで、PHP処理とHTMLコードの分離を行ないました。

lib/Baser/Plugin/Mail/View/Elements/mail_input.php
https://github.com/yama/basercms/blob/b6d6aa45d0f428cce91477b9e49ed5d3183dacf0/lib/Baser/Plugin/Mail/View/Elements/mail_input.php#L26-L50
上記部分でHTMLを設定します。

今後考えているのは、

- defer対応(インラインjsを外部ファイル化しdeferで読む)
- element()の第2引数でパラメータを渡せるようにする
- WAI-ARIA対応(必須)
- input・select・textarea・label要素自体もカスタマイズできるようにする(難しいかも・・)

などです。やるとしたら別チケットで展開します。

以下余談かもですが、
プレースホルダ文字列を `{%差し替え文字列%}` のような形にしています。
今回の件だけであれば何でもいいのですが、もし他の機能でも同様の
対応をとる方向で広がる可能性があるとしたら、
`{差し替え文字列}` ・ `{{差し替え文字列}}` だとJavaScriptやマスタッシュ記法との
バッティングが気になるし、 `<差し替え文字列>` のような形だとエディタに
「HTMLタグが正しくない」と警告を出される可能性があるので
このようにしました。