### PR TITLE
BcBaserHelper::crumbs() で onSchema が true の時、ソースの改行に起因する空白が入るのを回避

### DIFF
--- a/lib/Baser/View/Elements/crumbs.php
+++ b/lib/Baser/View/Elements/crumbs.php
@@ -51,10 +51,7 @@ if (!empty($crumbs)) {
 <?php else: ?>
 	<ul itemscope itemtype="http://schema.org/BreadcrumbList">
 		<?php if ($this->BcBaser->isHome()): ?>
-			<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-				<span itemprop="name"><?php echo $home ?></span>
-				<meta itemprop="position" content="1"/>
-			</li>
+			<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><span itemprop="name"><?php echo $home ?></span><meta itemprop="position" content="1"/></li>
 		<?php else: ?>
 			<?php $this->BcBaser->crumbs($separator, $home, true) ?>
 		<?php endif ?>

--- a/lib/Baser/View/Helper/BcBaserHelper.php
+++ b/lib/Baser/View/Helper/BcBaserHelper.php
@@ -1557,10 +1557,7 @@ class BcBaserHelper extends AppHelper
 					$crumb = '<span itemprop="name">' . $crumb[0] . '</span>';
 				}
 				$out[] = <<< EOD
-<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-	{$crumb}
-	<meta itemprop="position" content="{$counter}" />
-</li>
+<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">{$crumb}<meta itemprop="position" content="{$counter}" /></li>
 EOD;
 				$counter++;
 			}


### PR DESCRIPTION
パンくずリストまわりの修正です。

``<li>...</li>`` 内で改行が入るとブラウザでの表示時に意図しない空白が入ることがあるので、1行で記述するようにしました。
レビューお願いいたします。