### PR TITLE
fix #1629 メールフォーム emailチェックで、全角文字がバリデーションを通過してしまう問題を解決

### DIFF
--- a/lib/Baser/Plugin/Mail/Model/MailMessage.php
+++ b/lib/Baser/Plugin/Mail/Model/MailMessage.php
@@ -209,10 +209,16 @@ class MailMessage extends MailAppModel {
 					$this->validate[$mailField['field_name']] = $mailField['valid'];
 				}
 				if (!empty($this->data['MailMessage'][$mailField['field_name']]) && $mailField['valid'] == 'VALID_EMAIL') {
-					$this->validate[$mailField['field_name']] = array('email' => array(
-						'rule' => array('email'),
-						'message' => __('形式が無効です。')
-					));
+					$this->validate[$mailField['field_name']] = array(
+						'email' => array(
+							'rule' => array('email'),
+							'message' => __('形式が無効です。')
+						),
+						'english' => array(
+							'rule' => '/^[a-zA-Z0-9-_@.*+]*$/',
+							'message' => __('半角で入力してください。')
+						)
+					);
 				}
 			}
 			// ### 拡張バリデーション


### PR DESCRIPTION
半角英数 + 「-_@.*+」を許可するバリデーションを追加しました。