### PR TITLE
fix #1629 メールフォーム emailチェックで、全角文字がバリデーションを通過してしまう問題を解決

### DIFF
--- a/lib/Baser/Plugin/Mail/Model/MailMessage.php
+++ b/lib/Baser/Plugin/Mail/Model/MailMessage.php
@@ -217,10 +217,16 @@ class MailMessage extends MailAppModel
 					$this->validate[$mailField['field_name']] = $mailField['valid'];
 				}
 				if (!empty($this->data['MailMessage'][$mailField['field_name']]) && $mailField['valid'] == 'VALID_EMAIL') {
-					$this->validate[$mailField['field_name']] = ['email' => [
-						'rule' => ['email'],
-						'message' => __('形式が無効です。')
-					]];
+					$this->validate[$mailField['field_name']] = [
+						'email' => [
+							'rule' => ['email'],
+							'message' => __('形式が無効です。')
+						], 
+						'english' => [
+							'rule' => '/^[a-zA-Z0-9-_@.*+]*$/',
+							'message' => __('半角で入力してください。')
+						]
+					];
 				}
 			}
 			// ### 拡張バリデーション

--- a/lib/Baser/Plugin/Mail/Model/MailMessage.php
+++ b/lib/Baser/Plugin/Mail/Model/MailMessage.php
@@ -223,7 +223,7 @@ class MailMessage extends MailAppModel
 							'message' => __('形式が無効です。')
 						], 
 						'english' => [
-							'rule' => '/^[a-zA-Z0-9-_@.*+]*$/',
+							'rule' => '/^[a-zA-Z0-9!#$%&\’*+-\/=?^_`{|}~@.]*$/',
 							'message' => __('半角で入力してください。')
 						]
 					];


### PR DESCRIPTION
・dev-4とのコンフリクトを解消
・半角英数以外で「-_@.*+」を許可