### PR TITLE
ブログカテゴリ取得時のデフォルトの並び順を変更

### DIFF
--- a/lib/Baser/Plugin/Blog/Model/BlogCategory.php
+++ b/lib/Baser/Plugin/Blog/Model/BlogCategory.php
@@ -254,7 +254,7 @@ class BlogCategory extends BlogAppModel
 		$options = array_merge([
 			'id' => null,
 			'siteId' => null,
-			'order' => 'BlogCategory.id',
+			'order' => 'BlogCategory.lft asc',
 			'conditions' => [],
 			'threaded' => false
 		], $options);


### PR DESCRIPTION
Treeビヘイビアを使用している場合、デフォルトの並び順はidよりもlftを参照したほうが自然なので変更しています。
ご確認よろしくお願いします。