### PR TITLE
fix #1651 セッションメッセージの表示テキストが折り返して表示されないため修正

### DIFF
--- a/app/webroot/theme/admin-third/__assets/css/components/_notification.scss
+++ b/app/webroot/theme/admin-third/__assets/css/components/_notification.scss
@@ -10,6 +10,7 @@
 #BcMessageBox .notice-message,
 #UpdateMessage {
   color: $color_notification;
+  word-break: break-word;
   @include bca-icon(notification) {
     margin: 0 .3em 0 0;
   }

--- a/app/webroot/theme/admin-third/css/admin/style.css
+++ b/app/webroot/theme/admin-third/css/admin/style.css
@@ -7655,7 +7655,8 @@ body {
 #MessageBox .notice-message,
 #BcMessageBox .notice-message,
 #UpdateMessage {
-  color: #0087bc; }
+  color: #0087bc;
+  word-break: break-word; }
   #MessageBox .message::before,
   #MessageBox .notice-message::before,
   #BcMessageBox .notice-message::before,

--- a/lib/Baser/Controller/PagesController.php
+++ b/lib/Baser/Controller/PagesController.php
@@ -162,7 +162,7 @@ class PagesController extends AppController
 				// 完了メッセージ
 				$site = BcSite::findById($data['Content']['site_id']);
 				$url = $this->Content->getUrl($data['Content']['url'], true, $site->useSubDomain);
-				$this->BcMessage->setSuccess(sprintf(__d('baser', "固定ページ「%s」を更新しました。\n%s"), $data['Content']['name'], urldecode($url)));
+				$this->BcMessage->setSuccess(sprintf(__d('baser', "固定ページ「%s」を更新しました。\n%s"), rawurldecode($data['Content']['name']), urldecode($url)));
 
 				// EVENT Pages.afterEdit
 				$this->dispatchEvent('afterEdit', [


### PR DESCRIPTION
https://github.com/baserproject/basercms/issues/1651 を改善しました。良かったら可能な際に取込み検討お願いします。  
修正前の画面はissueに貼ってます。  
修正後はこちら。

![sc_flash_message_after](https://user-images.githubusercontent.com/1115768/108798078-36ebc300-75d0-11eb-956a-57f42c2944e5.png)

