### PR TITLE
fix #1654 メールフィールド　区切り文字が20文字以内では、classなどがつけられない問題を解決

### DIFF
--- a/lib/Baser/Plugin/Mail/Config/Schema/mail_fields.php
+++ b/lib/Baser/Plugin/Mail/Config/Schema/mail_fields.php
@@ -37,7 +37,7 @@ class MailFieldsSchema extends CakeSchema
 		'maxlength' => ['type' => 'integer', 'null' => true, 'default' => null],
 		'options' => ['type' => 'string', 'null' => true, 'default' => null],
 		'class' => ['type' => 'string', 'null' => true, 'default' => null],
-		'separator' => ['type' => 'string', 'null' => true, 'default' => null, 'length' => 20],
+		'separator' => ['type' => 'string', 'null' => true, 'default' => null, 'length' => 255],
 		'default_value' => ['type' => 'string', 'null' => true, 'default' => null],
 		'description' => ['type' => 'string', 'null' => true, 'default' => null],
 		'group_field' => ['type' => 'string', 'null' => true, 'default' => null],

--- a/lib/Baser/Plugin/Mail/Model/MailField.php
+++ b/lib/Baser/Plugin/Mail/Model/MailField.php
@@ -119,8 +119,8 @@ class MailField extends MailAppModel
 			],
 			'separator' => [
 				[
-					'rule' => ['maxLength', 20],
-					'message' => __d('baser', '区切り文字は20文字以内で入力してください。')
+					'rule' => ['maxLength', 255],
+					'message' => __d('baser', '区切り文字は255文字以内で入力してください。')
 				]
 			],
 			'default_value' => [


### PR DESCRIPTION
こちら、案件ベースで発生しており、
現状では$this->Mailform->control()で出力された内容を置換して設置する必要があるため、
対応が必要です。

・長過ぎるclassにも対応できるように255文字くらいまで増やす必要がある。
・バリデーションの調整
・DBカラムの調整