### PR TITLE
fix #1656 テーマ用初期データダウンロード時のメモリー制限を無効にする

### DIFF
--- a/lib/Baser/Controller/ThemesController.php
+++ b/lib/Baser/Controller/ThemesController.php
@@ -573,6 +573,9 @@ class ThemesController extends AppController
 	 */
 	public function admin_download_default_data_pattern()
 	{
+		set_time_limit(0);
+		ini_set('memory_limit', -1);
+
 		/* コアのCSVを生成 */
 		$tmpDir = TMP . 'csv' . DS;
 		$Folder = new Folder();


### PR DESCRIPTION
https://forum.basercms.net/t/topic/607
上記の件です。よろしくお願いします。