### PR TITLE
fix #1658 【メール】和暦フィールドの年だけ選択している状態で、バリデーションエラーが発生すると選択した年が現在の年になる

### DIFF
--- a/lib/Baser/View/Helper/BcTimeHelper.php
+++ b/lib/Baser/View/Helper/BcTimeHelper.php
@@ -162,7 +162,11 @@ class BcTimeHelper extends TimeHelper
 			if (empty($date['year']) || empty($date['month']) || empty($date['day'])) {
 				return '';
 			}
-			$date = $this->convertToSeirekiYear($date['year']) . '-' . $date['month'] . '-' . $date['day'];
+			if (strpos($date['year'], '-') === false) {
+				$date = $date['year'] . '-' . $date['month'] . '-' . $date['day'];
+			} else {
+				$date = $this->convertToSeirekiYear($date['year']) . '-' . $date['month'] . '-' . $date['day'];
+			}
 		}
 
 		$time = strtotime($date);


### PR DESCRIPTION
ご確認お願いします。

対象issue: https://github.com/baserproject/basercms/issues/1658