### PR TITLE
【システム】#1666 エラーログ機構の改善

### DIFF
--- a/app/Config/core.php
+++ b/app/Config/core.php
@@ -57,7 +57,7 @@ Configure::write('Config.language', 'jpn');
  * @see ErrorHandler for more information on error handling and configuration.
  */
 	Configure::write('Error', array(
-		'handler' => 'ErrorHandler::handleError',
+		'handler' => 'BcErrorHandler::handleError',
 		'level' => E_ALL & ~E_DEPRECATED,
 		'trace' => true
 	));
@@ -85,7 +85,7 @@ Configure::write('Config.language', 'jpn');
  * @see ErrorHandler for more information on exception handling and configuration.
  */
 	Configure::write('Exception', array(
-		'handler' => 'ErrorHandler::handleException',
+		'handler' => 'BcErrorHandler::handleException',
 		'renderer' => 'ExceptionRenderer',
 		'log' => true
 	));

--- a/lib/Baser/Config/bootstrap.php
+++ b/lib/Baser/Config/bootstrap.php
@@ -44,6 +44,8 @@ App::build([
 
 //新規登録
 App::build([
+	'Error' => [BASER_LIBS . DS . 'Error' . DS],
+	'Log/Engine' => [BASER_LIBS . DS . 'Log' . DS . 'Engine' . DS],
 	'Event' => [APP . 'Event', BASER_EVENTS],
 	'Routing' => [BASER . 'Routing' . DS],
 	'Routing/Filter' => [BASER . 'Routing' . DS . 'Filter' . DS],
@@ -154,6 +156,8 @@ App::uses('CakeRequest', 'Network');
 App::uses('BcSite', 'Lib');
 App::uses('BcAgent', 'Lib');
 App::uses('BcLang', 'Lib');
+App::uses('BcFileLog', 'Log/Engine');
+App::uses('BcErrorHandler', 'Error');
 
 // @deprecated
 // >>>
@@ -207,14 +211,24 @@ if (BC_INSTALLED) {
 	 */
 	App::uses('CakeLog', 'Log');
 	CakeLog::config('debug', [
-		'engine' => 'FileLog',
+		'engine' => 'BcFile',
 		'types' => ['notice', 'info', 'debug'],
 		'file' => 'debug',
 	]);
+	CakeLog::config('warning', [
+		'engine' => 'BcFile',
+		'types' => ['warning'],
+		'file' => 'warning',
+	]);
 	CakeLog::config('error', [
-		'engine' => 'FileLog',
-		'types' => ['warning', 'error', 'critical', 'alert', 'emergency'],
+		'engine' => 'BcFile',
+		'types' => ['error', 'critical', 'alert', 'emergency'],
 		'file' => 'error',
+	]);
+	CakeLog::config('error404', [
+		'engine' => 'BcFile',
+		'types' => ['error404'],
+		'file' => 'error404',
 	]);
 	CakeLog::config('update', [
 		'engine' => 'FileLog',

--- a/lib/Baser/Lib/Error/BcErrorHandler.php
+++ b/lib/Baser/Lib/Error/BcErrorHandler.php
@@ -1,0 +1,232 @@
+<?php
+
+App::uses('ErrorHandler', 'Error');
+
+class BcErrorHandler extends ErrorHandler
+{
+	/**
+	 * @param Exception|ParseError $exception The exception to render.
+	 * @return void
+	 */
+	public static function handleException($exception)
+	{
+		$config = Configure::read('Exception');
+		if ($exception->getCode() == 404) {
+			CakeLog::write('error404', self::error404msg() . "\n");
+		}
+
+		$renderer = isset($config['renderer']) ? $config['renderer'] : 'ExceptionRenderer';
+		if ($renderer !== 'ExceptionRenderer') {
+			list($plugin, $renderer) = pluginSplit($renderer, true);
+			App::uses($renderer, $plugin . 'Error');
+		}
+		try {
+			$error = new $renderer($exception);
+			$error->render();
+		} catch (Exception $e) {
+			set_error_handler(Configure::read('Error.handler'));
+			Configure::write('Error.trace', false);
+			$message = sprintf(
+				"[%s] %s\n%s",
+				get_class($e),
+				$e->getMessage(),
+				self::readableTrace()
+			);
+			static::$_bailExceptionRendering = 1;
+			trigger_error($message, E_USER_ERROR);
+		}
+	}
+
+	public static function handleError($code, $description, $file_path = null, $line = null, $context = null)
+	{
+		if (error_reporting() === 0) {
+			return false;
+		}
+		$errorSource = self::getErrorSource($file_path, $line);
+		list($error, $log) = static::mapErrorCode($code);
+		if ($log === LOG_ERR) {
+			return static::handleFatalError($code, $description, $file_path, $line);
+		}
+
+		$debug = Configure::read('debug');
+		if ($debug) {
+			$option = array(
+				'level'       => $log,
+				'code'        => $code,
+				'error'       => $error,
+				'description' => $description,
+				'file'        => self::trimPath($file_path),
+				'line'        => $line,
+				'context'     => $context,
+				'start'       => 2,
+				'source'      => $errorSource,
+				'path'        => self::trimPath($file_path)
+			);
+			Debugger::getInstance()->outputError($option);
+		}
+		return CakeLog::write(
+			$log,
+			self::makeMessage($error, $code, $description, $file_path, $line)
+		);
+	}
+
+	public static function handleFatalError($error_code, $description, $file_path, $line)
+	{
+		static $renderException = 1;
+
+		if (!$renderException) {
+			return;
+		}
+
+		CakeLog::write(
+			LOG_ERR,
+			self::makeMessage('Fatal Error', $error_code, $description, $file_path, $line)
+		);
+
+		$exceptionHandler = Configure::read('Exception.handler');
+		if (!is_callable($exceptionHandler)) {
+			return false;
+		}
+
+		if (ob_get_level()) {
+			ob_end_clean();
+		}
+
+		if (Configure::read('debug')) {
+			$exception = new FatalErrorException($description, 500, $file_path, $line);
+		} else {
+			$exception = new InternalErrorException();
+		}
+
+		$renderException = 0;
+
+		call_user_func($exceptionHandler, $exception);
+
+		return false;
+	}
+
+	private static function error404msg()
+	{
+		$rs = [];
+		$rs[] = 'Uri: ' . env('REQUEST_URI');
+		if (env('HTTP_REFERER')) {
+			$rs[] = 'Referer: ' . env('HTTP_REFERER');
+		}
+		$hostname = gethostbyaddr(env('REMOTE_ADDR'));
+		$rs[] = 'IP: ' . env('REMOTE_ADDR') . (preg_match('@[a-z]+@', $hostname) ? ' by ' . $hostname : '');
+		if (env('HTTP_USER_AGENT')) {
+			$rs[] = 'ua: ' . env('HTTP_USER_AGENT');
+		}
+		if (!empty($_POST)) {
+			$rs[] = 'method: POST';
+		}
+		return implode("\n", $rs);
+	}
+
+	private static function getErrorSource($file_path, $line)
+	{
+		if (!is_readable($file_path)) {
+			return null;
+		}
+		$source = file($file_path);
+		return trim($source[$line - 1]);
+	}
+
+	private static function makeMessage($error, $error_code, $description, $file_path, $line)
+	{
+		$rs = [];
+		$rs[] = sprintf('Error Type: %s[%s]', $error, $error_code);
+		if (env('REQUEST_URI')) {
+			$rs[] = 'Uri: ' . env('REQUEST_URI');
+		}
+		$rs[] = 'File: ' . self::trimPath($file_path);
+		$rs[] = 'Line: ' . $line;
+		$rs[] = 'Source: ' . self::getErrorSource($file_path, $line);
+		$rs[] = 'Description: ' . $description;
+		if (env('REMOTE_ADDR')) {
+			$hostname = gethostbyaddr(env('REMOTE_ADDR'));
+			$rs[] = 'IP: ' . env('REMOTE_ADDR') . (preg_match('@[a-z]+@', $hostname) ? ' by ' . $hostname : '');
+		}
+		if (env('HTTP_USER_AGENT')) {
+			$rs[] = 'ua: ' . env('HTTP_USER_AGENT');
+		}
+		if (!empty($_POST)) {
+			$rs[] = 'method: POST';
+		}
+		if (env('HTTP_REFERER')) {
+			$rs[] = 'Referer: ' . env('HTTP_REFERER');
+		}
+
+		if (empty(Configure::read('Error.trace'))) {
+			return implode("\n", $rs);
+		}
+
+		// https://bugs.php.net/bug.php?id=65322
+		if (version_compare(PHP_VERSION, '5.4.21', '<')) {
+			if (!class_exists('Debugger')) {
+				App::load('Debugger');
+			}
+			if (!class_exists('CakeText')) {
+				App::uses('CakeText', 'Utility');
+				App::load('CakeText');
+			}
+		}
+		return sprintf(
+			"%s\nStack Trace:\n%s\n",
+			implode("\n", $rs),
+			self::readableTrace()
+		);
+	}
+
+	private static function trimPath($path) {
+
+		if (!defined('CAKE_CORE_INCLUDE_PATH') || !defined('APP')) {
+			return str_replace('\\', '/', $path);
+		}
+
+		if (strpos($path, APP) === 0) {
+			return str_replace([APP, '\\'], ['{APP}/', '/'], $path);
+		}
+
+		if (strpos($path, CAKE_CORE_INCLUDE_PATH) === 0) {
+			return str_replace([CAKE_CORE_INCLUDE_PATH, '\\'], ['{CORE}', '/'], $path);
+		}
+
+		if (strpos($path, ROOT) === 0) {
+			return str_replace([ROOT, '\\'], ['{ROOT}', '/'], $path);
+		}
+
+		return $path;
+	}
+
+	private static function readableTrace() {
+		$backtrace = debug_backtrace();
+		$default = array(
+			'line' => '??',
+			'file' => '[internal]',
+			'class' => null,
+			'function' => '[main]'
+		);
+		foreach($backtrace as $row) {
+			if(!empty($row['class']) && $row['class'] === __CLASS__) {
+				continue;
+			}
+			$row = array_merge($default, $row);
+			$row['reference'] = 'reference';
+			$row['path'] = self::trimPath($row['file']);
+			$row['method'] = sprintf(
+				'%s%s%s',
+				!empty($row['class']) ? $row['class'] : '',
+				!empty($row['type']) ? $row['type'] : '',
+				!empty($row['function']) ? $row['function'] . '()' : ''
+			);
+			unset($row['object'], $row['args']);
+			$back[] = CakeText::insert(
+				'{:path}, line {:line} - {:method}',
+				$row,
+				array('before' => '{:', 'after' => '}')
+			);
+		}
+		return implode("\n", $back);
+	}
+}

--- a/lib/Baser/Lib/Error/BcErrorHandler.php
+++ b/lib/Baser/Lib/Error/BcErrorHandler.php
@@ -260,8 +260,10 @@ class BcErrorHandler extends ErrorHandler
 		return $path;
 	}
 
-	private static function readableTrace($trace=null) {
-		$backtrace = $trace ?: debug_backtrace();
+	private static function readableTrace($backtrace=null) {
+		if(!$backtrace) {
+			$backtrace = debug_backtrace();
+		}
 		$default = array(
 			'line' => '??',
 			'file' => '[internal]',

--- a/lib/Baser/Lib/Log/Engine/BcFileLog.php
+++ b/lib/Baser/Lib/Log/Engine/BcFileLog.php
@@ -1,0 +1,48 @@
+<?php
+
+App::uses('FileLog', 'Log/Engine');
+
+class BcFileLog extends FileLog {
+	/**
+	 * @param string $type The type of log you are making.
+	 * @param string $message The message you want to log.
+	 * @return bool success of write.
+	 */
+	public function write($type, $message) {
+		$output = sprintf(
+			"[%s] %s ---------------------------------------------------------\n%s\n",
+			ucfirst($type),
+			date('Y-m-d H:i:s'),
+			$message
+		);
+		$filename = $this->_getFilename($type);
+		if (!empty($this->_size)) {
+			$this->_rotateFile($filename);
+		}
+
+		$pathname = $this->_path . $filename;
+		if (empty($this->_config['mask'])) {
+			return file_put_contents($pathname, $output, FILE_APPEND);
+		}
+
+		$exists = is_file($pathname);
+		$result = file_put_contents($pathname, $output, FILE_APPEND);
+		static $selfError = false;
+		if (!$selfError && !$exists && !chmod($pathname, (int)$this->_config['mask'])) {
+			$selfError = true;
+			trigger_error(
+				__d(
+					'cake_dev',
+					'Could not apply permission mask "%s" on log file "%s"',
+					array(
+						$this->_config['mask'],
+						$pathname
+					)
+				),
+				E_USER_WARNING
+			);
+			$selfError = false;
+		}
+		return $result;
+	}
+}


### PR DESCRIPTION
https://github.com/baserproject/basercms/issues/1666
遅くなりましたが、上記の改善を行ないました。動作テストが大変かもしれませんが、確認をお願いします。

直近のSQLクエリーは、デバッグモードを有効にしていないと取得できないため、今回は見送りました。

debug.log・error.log の２つだったのを、
debug.log・error.log・warning.log・error404.log の4つに分けました。