### PR TITLE
fix #1640 デフォルトテンプレート内で指定しているcssのパスがリンク切れ

### DIFF
--- a/lib/Baser/Plugin/Mail/View/Mail/default/confirm.php
+++ b/lib/Baser/Plugin/Mail/View/Mail/default/confirm.php
@@ -13,7 +13,7 @@
 /**
  * [PUBLISH] メールフォーム確認ページ
  */
-$this->BcBaser->css(['Mail.style', 'admin/jquery-ui/ui.all'], ['inline' => true]);
+$this->BcBaser->css(['Mail.style', 'admin/jquery-ui/jquery-ui.min'], ['inline' => true]);
 $this->BcBaser->js(['admin/vendors/jquery-ui-1.11.4.min', 'admin/vendors/i18n/ui.datepicker-ja'], false);
 if ($freezed) {
 	$this->Mailform->freeze();

--- a/lib/Baser/Plugin/Mail/View/Mail/default/index.php
+++ b/lib/Baser/Plugin/Mail/View/Mail/default/index.php
@@ -13,7 +13,7 @@
 /**
  * [PUBLISH] メールフォーム
  */
-$this->BcBaser->css(['Mail.style', 'admin/jquery-ui/ui.all'], ['inline' => true]);
+$this->BcBaser->css(['Mail.style', 'admin/jquery-ui/jquery-ui.min'], ['inline' => true]);
 $this->BcBaser->js(['admin/vendors/jquery-ui-1.11.4.min', 'admin/vendors/i18n/ui.datepicker-ja'], false);
 ?>
 

--- a/lib/Baser/Plugin/Mail/View/Mail/smartphone/default/confirm.php
+++ b/lib/Baser/Plugin/Mail/View/Mail/smartphone/default/confirm.php
@@ -13,7 +13,7 @@
 /**
  * [PUBLISH] メールフォーム確認ページ
  */
-$this->BcBaser->css('admin/jquery-ui/ui.all', ['inline' => true]);
+$this->BcBaser->css('admin/jquery-ui/jquery-ui.min', ['inline' => true]);
 $this->BcBaser->js(['admin/vendors/jquery-ui-1.11.4.min', 'admin/vendors/i18n/ui.datepicker-ja'], false);
 if ($freezed) {
 	$this->Mailform->freeze();

--- a/lib/Baser/Plugin/Mail/View/Mail/smartphone/default/index.php
+++ b/lib/Baser/Plugin/Mail/View/Mail/smartphone/default/index.php
@@ -13,7 +13,7 @@
 /**
  * [PUBLISH] メールフォーム
  */
-$this->BcBaser->css('admin/jquery-ui/ui.all', ['inline' => true]);
+$this->BcBaser->css('admin/jquery-ui/jquery-ui.min', ['inline' => true]);
 $this->BcBaser->js(['admin/vendors/jquery-ui-1.11.4.min', 'admin/vendors/i18n/ui.datepicker-ja'], false);
 ?>
 

--- a/lib/Baser/View/Layouts/mypage/default.php
+++ b/lib/Baser/View/Layouts/mypage/default.php
@@ -22,7 +22,7 @@
 		<?php $this->BcBaser->title() ?>
 		<?php
 		$this->BcBaser->css([
-			'admin/jquery-ui/ui.all',
+			'admin/jquery-ui/jquery-ui.min',
 			'admin/import',
 			'../js/admin/jquery.contextMenu-1.0/jquery.contextMenu',
 			'admin/colorbox/colorbox-1.6.1'])


### PR DESCRIPTION
リンク切れが原因で500エラーになる件、の元の件です。
マージよろしくお願いします。

既存の案件を修正する場合は、サーバ上のjquery-ui.min.cssをui.all.cssにリネームするのが
簡単・安全かなと思います。