### PR TITLE
#1700　【フォーム】Eメールチェックの機能追加 #1700

### DIFF
--- a/lib/Baser/Plugin/Mail/Model/MailField.php
+++ b/lib/Baser/Plugin/Mail/Model/MailField.php
@@ -189,6 +189,7 @@ class MailField extends MailAppModel
 			'VALID_FILE_EXT' => __d('baser', 'ファイル拡張子チェック'),
 			'VALID_ZENKAKU_KATAKANA' => __d('baser', '全角カタカナチェック'),
 			'VALID_ZENKAKU_HIRAGANA' => __d('baser', '全角ひらがなチェック'),
+			'VALID_NOT_EMOJI' 		=> __d('baser', '絵文字を含めない'),
 			'VALID_REGEX' => __d('baser', '正規表現チェック'),
 		];
 		$source['auto_convert'] = ['CONVERT_HANKAKU' => __d('baser', '半角変換')];

--- a/lib/Baser/Plugin/Mail/Model/MailMessage.php
+++ b/lib/Baser/Plugin/Mail/Model/MailMessage.php
@@ -325,18 +325,29 @@ class MailMessage extends MailAppModel
 				}
 				continue;
 			}
-
 			if (in_array('VALID_ZENKAKU_KATAKANA', $valids)) {
-				if (!preg_match('/^(|[ァ-ヾ 　]+)$/u', $data['MailMessage'][$field_name])) {
-					$this->invalidate($field_name, __('全て全角カタカナで入力してください。'));
+				if (!preg_match('/^(|[ァ-ヾ 　]+)$/u', $this->data['MailMessage'][$mailField['field_name']])) {
+					preg_match_all('/[^ァ-ヾ 　]/u', $this->data['MailMessage'][$mailField['field_name']], $notKatakanaArray);
+					$notKatakana = implode('', $notKatakanaArray[0]);
+					$this->invalidate($mailField['field_name'], __('次の文字はカタカナではないので受け付けられません: ' . $notKatakana));
 				}
 				continue;
 			}
-
 			if (in_array('VALID_ZENKAKU_HIRAGANA', $valids)) {
-				if (!preg_match('/^([　 \t\r\n]|[ぁ-ん]|[ー])+$/u', $data['MailMessage'][$field_name])) {
-					$this->invalidate($field_name, __('全て全角ひらがなで入力してください。'));
+				if (!preg_match('/^(|[ぁ-ゞ 　]+)$/u', $this->data['MailMessage'][$mailField['field_name']])) {
+					preg_match_all('/[^ぁ-ゞ　]/u', $this->data['MailMessage'][$mailField['field_name']], $notHiraganaArray);
+					$notHiragana = implode('', $notHiraganaArray[0]);
+					$this->invalidate($mailField['field_name'], __('次の文字はひらがなではないので受け付けられません: ' . $notHiragana));
 				}
+				continue;
+			}
+			if (in_array('VALID_NOT_EMOJI', $valids)) {
+				if (preg_match('/[\xF0-\xF7][\x80-\xBF][\x80-\xBF][\x80-\xBF]/', $data['MailMessage'][$mailField['field_name']])) {
+					preg_match_all('/[\xF0-\xF7][\x80-\xBF][\x80-\xBF][\x80-\xBF]/', $data['MailMessage'][$mailField['field_name']], $emojiArray);
+					$emoji = implode('', $emojiArray[0]);
+					$this->invalidate($mailField['field_name'], __('『' . $emoji . '』は『' . $mailField['name'] . '』に利用できません。取り除くか、もしくは文字による代替をしてください。'));
+				}
+				continue;
 			}
 		}
 	}
@@ -533,6 +544,22 @@ class MailMessage extends MailAppModel
 				// TRIM
 				if (!is_array($value)) {
 					$value = trim($value);
+				}
+				// メールアドレスを半角に変換
+				if ($mailField['valid'] == 'VALID_EMAIL') {
+					$value = mb_convert_kana($value, 'a');
+				}
+				// 半角カタカナ・全角カタカナをひらがなに変換・半角スペースを全角スペースに変換
+				if ($mailField['valid_ex'] == 'VALID_ZENKAKU_HIRAGANA') {
+					$value = mb_convert_kana($value, 'H');
+					$value = mb_convert_kana($value, 'c');
+					$value = mb_convert_kana($value, 'S');
+				}
+				// ひらがな・半角カタカナを全角カタカナに変換
+				if ($mailField['valid_ex'] == 'VALID_ZENKAKU_KATAKANA') {
+					$value = mb_convert_kana($value, 'C');
+					$value = mb_convert_kana($value, 'K');
+					$value = mb_convert_kana($value, 'S');
 				}
 			}
 

--- a/lib/Baser/Plugin/Mail/Model/MailMessage.php
+++ b/lib/Baser/Plugin/Mail/Model/MailMessage.php
@@ -219,16 +219,20 @@ class MailMessage extends MailAppModel
 					$this->validate[$mailField['field_name']] = $mailField['valid'];
 				}
 				if (!empty($this->data['MailMessage'][$mailField['field_name']]) && $mailField['valid'] == 'VALID_EMAIL') {
-					$this->validate[$mailField['field_name']] = [
-						'email' => [
-							'rule' => ['email'],
-							'message' => __('形式が無効です。')
-						],
-						'english' => [
-							'rule' => '/^[a-zA-Z0-9!#$%&\’*+-\/=?^_`{|}~@.]*$/',
-							'message' => __('半角で入力してください。')
-						]
-					];
+					if (preg_match('/[^a-zA-Z0-9@\._\+\-]/u', $this->data['MailMessage'][$mailField['field_name']])) {
+						preg_match_all('/[^a-zA-Z0-9@\._\+\-]/u', $this->data['MailMessage'][$mailField['field_name']], $notForEmailArray);
+						$notForEmail = implode('', $notForEmailArray[0]);
+						$this->invalidate($mailField['field_name'], __('次の文字はメールアドレスでは受け付けられません: ' .$notForEmail));
+					}
+					elseif (strpos($this->data['MailMessage'][$mailField['field_name']], '@') === false){
+						$this->invalidate($mailField['field_name'], __('@が必要です。'));
+					}
+					else {
+						$this->validate[$mailField['field_name']] = array('email' => array(
+							'rule' => array('email'),
+							'message' => __('形式が無効です。「XXXXXXXXXX@XXX.XX」で記述してください。')
+						));
+					}
 				}
 			}
 			// ### 拡張バリデーション


### PR DESCRIPTION
メールフォームのバリデーションについて、下記の変更をしました。

Eメールチェックについて、

- 全角文字を半角に変換

- 認められない文字を明確に指摘する。例: 「*はEメールに利用できません。取り除いてください。」

- @がない場合指摘する。例:「@が必要です。」

全角カタカナチェックについて、

- 全角ひらがなは全角カタカナに変換

- 半角カタカナは全角カタカナに変換

- 認められない文字を明確に指摘する。例: 「ひらがなでない『漢字ABC』は〇〇に利用できません。ひらがなに変更してください。」

- 変換できるのであれば自動で変換（確認ページで）

全角ひらがなチェックについて、

- 全角ひらがなは全角ひらがなに変換

- 半角カタカナは全角ひらがなに変換

- 認められない文字を明確に指摘する。例: 「カタカナでない『漢字ABC』は〇〇に利用できません。ひらがなに変更してください。」

- 変換できるのであれば自動で変換（確認ページで）