### PR TITLE
fix #1664 Uploaderで0バイトのファイルをアップするとリンク先が ajax_image//midium になる不具合を修正

### DIFF
--- a/lib/Baser/Model/Behavior/BcUploadBehavior.php
+++ b/lib/Baser/Model/Behavior/BcUploadBehavior.php
@@ -190,7 +190,7 @@ class BcUploadBehavior extends ModelBehavior
 			if (!empty($Model->data[$Model->name])) {
 				$data = $Model->data[$Model->name];
 			}
-			if (!empty($data[$field['name']]) && is_array($data[$field['name']]) && $data[$field['name']]['size'] != 0) {
+			if (!empty($data[$field['name']]) && is_array($data[$field['name']]) && $data[$field['name']]['error'] == 0) {
 				if (!empty($data[$field['name']]['name'])) {
 					$upload = true;
 				}


### PR DESCRIPTION
アップロード時のチェックでファイルサイズ0かどうかでチェックしている箇所を、アップロードエラーの有無でチェックするように変更しました。
よろしくお願いします！