### PR TITLE
fix #1706 「最近の動き」に1件もデータが存在しない場合に「処理に失敗しました。」メッセージが表示される動作を修正

### DIFF
--- a/app/webroot/theme/admin-third/js/admin/dblogs/ajax_index.js
+++ b/app/webroot/theme/admin-third/js/admin/dblogs/ajax_index.js
@@ -18,14 +18,16 @@ $(function () {
             ajaxurl = $.baseUrl + '/' + $.bcUtil.adminPrefix + '/dblogs/ajax_index';
         }
         $.bcUtil.ajax(ajaxurl, function (response, status) {
-            if (response) {
-                $('#DblogList').hide();
-                $('#DblogList').html(response);
-                $('#DblogList').slideDown(500);
-                let link = $('#DblogList .pagination a, #DblogList .list-num a');
-                link.unbind();
-                link.click(loadDblogs);
-                $.bcToken.replaceLinkToSubmitToken("#DblogList a.submit-token");
+            if (status === 'success') {
+                if (response) {
+                    $('#DblogList').hide();
+                    $('#DblogList').html(response);
+                    $('#DblogList').slideDown(500);
+                    var link = $('#DblogList .pagination a, #DblogList .list-num a');
+                    link.unbind();
+                    link.click(loadDblogs);
+                    $.bcToken.replaceLinkToSubmitToken("#DblogList a.submit-token");
+                }
             } else {
                 $.bcUtil.showAlertMessage(bcI18n.alertMessage1);
             }

--- a/lib/Baser/webroot/js/admin/dblogs/ajax_index.js
+++ b/lib/Baser/webroot/js/admin/dblogs/ajax_index.js
@@ -18,14 +18,16 @@ $(function () {
             ajaxurl = $.baseUrl + '/' + $.bcUtil.adminPrefix + '/dblogs/ajax_index';
         }
         $.bcUtil.ajax(ajaxurl, function (response, status) {
-            if (response) {
-                $('#DblogList').hide();
-                $('#DblogList').html(response);
-                $('#DblogList').slideDown(500);
-                var link = $('#DblogList .pagination a, #DblogList .list-num a');
-                link.unbind();
-                link.click(loadDblogs);
-                $.bcToken.replaceLinkToSubmitToken("#DblogList a.submit-token");
+            if (status === 'success') {
+                if (response) {
+                    $('#DblogList').hide();
+                    $('#DblogList').html(response);
+                    $('#DblogList').slideDown(500);
+                    var link = $('#DblogList .pagination a, #DblogList .list-num a');
+                    link.unbind();
+                    link.click(loadDblogs);
+                    $.bcToken.replaceLinkToSubmitToken("#DblogList a.submit-token");
+                }
             } else {
                 $.bcUtil.showAlertMessage(bcI18n.alertMessage1);
             }


### PR DESCRIPTION
「最近の動き」にデータが存在しないとき、常に処理失敗のアラートメッセージを表示する動作となっているのを修正しました。
取込み検討お願いします。
