### PR TITLE
fix #1708 管理側「最近の動き」が0件のとき一覧画面の表示が崩れている動作を修正

### DIFF
--- a/app/webroot/theme/admin-third/Elements/admin/dblogs/index_list.php
+++ b/app/webroot/theme/admin-third/Elements/admin/dblogs/index_list.php
@@ -14,6 +14,7 @@
  * [ADMIN] 最近の動き一覧 テーブル
  * <div class="bca-action-table-listup">
  */
+$this->BcListTable->setColumnNumber(4);
 ?>
 <div class="bca-data-list__top">
 	<?php if (BcUtil::isAdminUser()): ?>

--- a/lib/Baser/View/Elements/admin/dblogs/index_list.php
+++ b/lib/Baser/View/Elements/admin/dblogs/index_list.php
@@ -14,6 +14,7 @@
  * [ADMIN] 最近の動き一覧 テーブル
  * <div class="bca-action-table-listup">
  */
+$this->BcListTable->setColumnNumber(4);
 ?>
 <div class="bca-data-list__top">
 	<?php if (BcUtil::isAdminUser()): ?>


### PR DESCRIPTION
issueはこちら。 https://github.com/baserproject/basercms/issues/1708
調整しましたので取込み検討お願いします。
