### PR TITLE
【フォーム】マルチチェックボックスを使用しているとエラーがでる場合がある問題を改善

### DIFF
--- a/lib/Baser/View/Helper/BcFormHelper.php
+++ b/lib/Baser/View/Helper/BcFormHelper.php
@@ -605,6 +605,9 @@ DOC_END;
 		$secure = $options['secure'];
 		unset($options['secure']);
 
+		// 明示的にフィールド名を指定
+		$this->setEntity($fieldName);
+
 		// CUSTOMIZE ADD 2010/07/24 ryuring
 		// セキュリティコンポーネントのトークン生成の仕様として、
 		// ・hiddenタグ以外はフィールド情報のみ


### PR DESCRIPTION
フォームでマルチチェックボックスを使用している場合に、確認画面から入力画面・送信画面に遷移する際にセキュリティエラーが出る場合があるので修正しています。

■発生条件

- マルチチェックボックスが使用されている
- メールのビューで `$this->Mailform->control` を実行する前に ` $this->Mailform->label` や `$this->Mailform->value` が使用されていない

■問題

- BcFormHelperから呼び出す`_secure()`は引数でフィールド名が指定されていない場合、`entity()`からフィールド名を取得する
    - ここで正しいフィールド名を取得できないと、その後の処理でセキュリティエラーが発生する原因になる
- マルチチェックボックス以外では、`_secure()`を実行する前に`_initInputField()`経由で`setEntity()`を呼び出し、フィールド名を設定している
- マルチチェックボックスの場合には`_initInputField()`を実行する前に`_secure()`を実行している

■修正内容

- BcFormHelperの`hidden()`内に`setEntity()`の実行処理を追加