### PR TITLE
【フォーム】フィールドタイプ「Eメール」の場合、input typeを「email」に変更 #1714

### DIFF
--- a/lib/Baser/Plugin/Mail/View/Helper/MailformHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MailformHelper.php
@@ -52,11 +52,17 @@ class MailformHelper extends BcFreezeHelper
 		switch($type) {
 
 			case 'text':
-			case 'email':
 				unset($attributes['separator']);
 				unset($attributes['rows']);
 				unset($attributes['empty']);
 				$out = $this->text($fieldName, $attributes);
+				break;
+
+			case 'email':
+				unset($attributes['separator']);
+				unset($attributes['rows']);
+				unset($attributes['empty']);
+				$out = $this->email($fieldName, $attributes);
 				break;
 
 			case 'radio':

--- a/lib/Baser/View/Helper/BcFreezeHelper.php
+++ b/lib/Baser/View/Helper/BcFreezeHelper.php
@@ -70,6 +70,36 @@ class BcFreezeHelper extends BcFormHelper
 	}
 
 	/**
+	 * テキストボックスを表示する
+	 *
+	 * @param string $fieldName フィールド文字列
+	 * @param array $attributes html属性
+	 * - 凍結時に、$attributes["value"]が指定されている場合、その値がvalueになる。
+	 * 　指定されてない場合、$this->request->data[$model][$field]がvalueになる。
+	 * @return	string	htmlタグ
+	 * @access	public
+	 */
+	public function email($fieldName, $attributes = [])
+	{
+		if ($this->freezed) {
+			list($model, $field) = explode('.', $fieldName);
+			if (isset($attributes)) {
+				$attributes = $attributes + ['type' => 'hidden'];
+			} else {
+				$attributes = ['type' => 'hidden'];
+			}
+			if (isset($attributes["value"])) {
+				$value = $attributes["value"];
+			} else {
+				$value = $this->request->data[$model][$field];
+			}
+			return parent::text($fieldName, $attributes) . h($value);
+		} else {
+			return parent::email($fieldName, $attributes);
+		}
+	}
+
+	/**
 	 * select プルダウンメニューを表示
 	 *
 	 * @param string $fieldName フィールド文字列


### PR DESCRIPTION
アクセシビリティ向上のため、フィールドタイプが「email」の場合のinput typeを「email」に変更しました。