### PR TITLE
fix #1692【フォーム】フィールド設定にて、「表示サイズ」に数値以外を入力するとシステムエラーになる件の修正

### DIFF
--- a/lib/Baser/Plugin/Mail/Model/MailField.php
+++ b/lib/Baser/Plugin/Mail/Model/MailField.php
@@ -111,6 +111,39 @@ class MailField extends MailAppModel
 					'message' => __d('baser', 'オプションは255文字以内で入力してください。')
 				]
 			],
+			'size' => [
+				[
+					'rule' => ['naturalNumber'],
+					'message' => __d('baser', '表示サイズは半角数字のみで入力してください。'),
+					'allowEmpty' => true,
+				],
+				[
+					'rule' => ['maxLength', 9],
+					'message' => __d('baser', '表示サイズは9文字以内で入力してください。')
+				]
+			],
+			'rows' => [
+				[
+					'rule' => ['naturalNumber'],
+					'message' => __d('baser', '行数は半角数字のみで入力してください。'),
+					'allowEmpty' => true,
+				],
+				[
+					'rule' => ['maxLength', 9],
+					'message' => __d('baser', '行数は9文字以内で入力してください。')
+				]
+			],
+			'maxlength' => [
+				[
+					'rule' => ['naturalNumber'],
+					'message' => __d('baser', '最大値は半角数字のみで入力してください。'),
+					'allowEmpty' => true,
+				],
+				[
+					'rule' => ['maxLength', 9],
+					'message' => __d('baser', '最大値は9文字以内で入力してください。')
+				]
+			],
 			'class' => [
 				[
 					'rule' => ['maxLength', 255],


### PR DESCRIPTION
メールフィールドの各数値項目にバリデーションを追加しました。

各DBのINTEGER最大桁数は下記のとおりだったので上限を9桁（999,999,999）にしています。

MySQL int(11)
4bytes 
-2,147,483,648〜2,147,483,647
https://dev.mysql.com/doc/refman/8.0/ja/integer-types.html

PostgreSQL integer
4bytes 
-2,147,483,648〜2,147,483,647
https://www.postgresql.jp/document/12/html/datatype-numeric.html

SQLite INTEGER
1, 2, 3, 4, 6, or 8 bytes
-9,223,372,036,854,775,808〜9,223,372,036,854,775,807
https://www.sqlite.org/datatype3.html

※ 操作誤ってコミットしたり消してしまったので再度プルリクします、、、