### PR TITLE
fix #1649 メールフォーム・テキストエリアで6,553,500文字入力後「確認画面へ」ボタンを押下するとエラー画面へ遷移する問題の解消

### DIFF
--- a/lib/Baser/Plugin/Mail/webroot/js/admin/mail_fields/form.js
+++ b/lib/Baser/Plugin/Mail/webroot/js/admin/mail_fields/form.js
@@ -39,8 +39,7 @@ $(function () {
             case 'textarea':
                 $("#RowSize").show();
                 $("#RowRows").show();
-                $("#RowMaxlength").hide();
-                $("#MailFieldMaxlength").val('');
+                $("#RowMaxlength").show();
                 $("#RowSource").hide();
                 $("#MailFieldSource").val('');
                 $("#RowAutoConvert").show();


### PR DESCRIPTION
テキストエリアの時もmaxlength値の設定項目を使えるようにしました。
よろしくお願いします！