### PR TITLE
fix #1196【メール】テキストエリア項目について、未入力にて送信した場合送信メールに見出しが表示されない件の修正

### DIFF
--- a/lib/Baser/Config/theme/bc_sample/Emails/text/mail_data.php
+++ b/lib/Baser/Config/theme/bc_sample/Emails/text/mail_data.php
@@ -20,7 +20,7 @@
 $group_field = null;
 foreach ($mailFields as $field) {
 	$field = $field['MailField'];
-	if ($field['use_field'] && isset($message[$field['field_name']]) && ($group_field != $field['group_field'] || (!$group_field && !$field['group_field']))) {
+	if ($field['use_field'] && ($group_field != $field['group_field'] || (!$group_field && !$field['group_field']))) {
 ?>
 
 

--- a/lib/Baser/Plugin/Mail/View/Emails/text/mail_data.php
+++ b/lib/Baser/Plugin/Mail/View/Emails/text/mail_data.php
@@ -16,7 +16,7 @@
 $group_field = null;
 foreach ($mailFields as $field) {
 	$field = $field['MailField'];
-	if ($field['use_field'] && isset($message[$field['field_name']]) && ($group_field != $field['group_field'] || (!$group_field && !$field['group_field']))) {
+	if ($field['use_field'] && ($group_field != $field['group_field'] || (!$group_field && !$field['group_field']))) {
 ?>
 
 


### PR DESCRIPTION
よろしくおねがいします！

<img width="900" alt="スクリーンショット 2021-07-09 15 05 39" src="https://user-images.githubusercontent.com/310333/125050203-bb049a00-e0dc-11eb-801c-fe76f647a99a.png">
<img width="926" alt="スクリーンショット 2021-07-09 15 05 50" src="https://user-images.githubusercontent.com/310333/125050213-bd66f400-e0dc-11eb-85f1-deba0a740036.png">
<img width="731" alt="スクリーンショット 2021-07-09 15 19 57" src="https://user-images.githubusercontent.com/310333/125050218-bdff8a80-e0dc-11eb-82d9-69c7fadf7892.png">
