### PR TITLE
fix #1661【システム】セッションをDBに保存する場合のファイル関係の不都合を解消

### DIFF
--- a/app/Config/Schema/sessions.php
+++ b/app/Config/Schema/sessions.php
@@ -54,4 +54,9 @@ class SessionsSchema extends CakeSchema {
 		'indexes' => array('PRIMARY' => array('column' => 'id', 'unique' => 1))
 	);
 
+	// -------------------------------------------------------------
+	// データベースが MySQL の場合
+	// dataのカラムを text型 → longtext型 に変更してください。
+	// -------------------------------------------------------------
+
 }

--- a/app/Config/Schema/sessions.sql
+++ b/app/Config/Schema/sessions.sql
@@ -9,9 +9,51 @@
 # Redistributions of files must retain the above copyright notice.
 # MIT License (http://www.opensource.org/licenses/mit-license.php)
 
-CREATE TABLE cake_sessions (
+# CUSTOMIZE MODIFY 2021/07/14
+# >>>
+
+# CREATE TABLE cake_sessions (
+#   id varchar(255) NOT NULL default '',
+#   data text,
+#   expires int(11) default NULL,
+#   PRIMARY KEY  (id)
+# );
+
+# ---
+
+# ---------------------------------------------------
+# MySQLの例
+# ※ prefixがmysite_以外の時は書き換えてください
+# ---------------------------------------------------
+DROP TABLE IF EXISTS mysite_cake_sessions;
+CREATE TABLE mysite_cake_sessions (
   id varchar(255) NOT NULL default '',
-  data text,
+  data longtext,
   expires int(11) default NULL,
   PRIMARY KEY  (id)
 );
+
+# ---------------------------------------------------
+# PostgreSQLの例
+# ※ prefixがmysite_以外の時は書き換えてください
+# ---------------------------------------------------
+# DROP TABLE IF EXISTS "mysite_cake_sessions";
+# CREATE TABLE "mysite_cake_sessions" (
+#     "id" character varying(255) DEFAULT '' NOT NULL,
+#     "data" text,
+#     "expires" integer,
+#     PRIMARY KEY ("id")
+# );
+
+# ---------------------------------------------------
+# SQLiteの例
+# ---------------------------------------------------
+# DROP TABLE IF EXISTS cake_sessions;
+# CREATE TABLE cake_sessions (
+#   id varchar(255) NOT NULL default '',
+#   data text,
+#   expires int(11) default NULL,
+#   PRIMARY KEY  (id)
+# );
+
+# <<<

--- a/app/Config/session.php
+++ b/app/Config/session.php
@@ -9,7 +9,7 @@
  * @since			baserCMS v 0.1.0
  * @license			http://basercms.net/license/index.html
  */
- 
+
 /**
  * セッション設定
  */
@@ -21,3 +21,12 @@ require BASER_CONFIGS .'session.php';
  * デフォルト：2日間
  */
 //Configure::write('Session.timeout', 60 * 24 * 2);
+
+/**
+ * セッションをデータベースに保存する場合の設定
+ * デフォルト：php
+ *
+ * 予め セッションのテーブル {prefix}_cake_sessions を作成しておいてください。
+ * SQLは app/Config/Schema/sessions.sql になります。
+ */
+//Configure::write('Session.defaults', 'database');

--- a/lib/Baser/Controller/UploadsController.php
+++ b/lib/Baser/Controller/UploadsController.php
@@ -79,7 +79,7 @@ class UploadsController extends AppController
 		}
 
 		if (!$size) {
-			$data = $this->Session->read('Upload.' . $sessioName . '.data');
+			$data = base64_decode($this->Session->read('Upload.' . $sessioName . '.data'));
 		} else {
 
 			if (is_dir(TMP . 'uploads')) {
@@ -89,7 +89,7 @@ class UploadsController extends AppController
 
 			$path = TMP . 'uploads' . DS . $name;
 			$file = new File($path, true);
-			$file->write($this->Session->read('Upload.' . $sessioName . '.data'), 'wb');
+			$file->write(base64_decode($this->Session->read('Upload.' . $sessioName . '.data')), 'wb');
 			$file->close();
 
 			$thumb = false;

--- a/lib/Baser/Model/Behavior/BcUploadBehavior.php
+++ b/lib/Baser/Model/Behavior/BcUploadBehavior.php
@@ -425,7 +425,7 @@ class BcUploadBehavior extends ModelBehavior
 		$fileName = $Model->data[$Model->alias][$fieldName . '_tmp'];
 		$sessionKey = str_replace(['.', '/'], ['_', '_'], $fileName);
 		$tmpName = $this->savePath[$Model->alias] . $sessionKey;
-		$fileData = $this->Session->read('Upload.' . $sessionKey . '.data');
+		$fileData = base64_decode($this->Session->read('Upload.' . $sessionKey . '.data'));
 		$fileType = $this->Session->read('Upload.' . $sessionKey . '.type');
 		$this->Session->delete('Upload.' . $sessionKey);
 
@@ -494,7 +494,7 @@ class BcUploadBehavior extends ModelBehavior
 			$_fileName = str_replace(['.', '/'], ['_', '_'], $fileName);
 			$this->Session->write('Upload.' . $_fileName, $field);
 			$this->Session->write('Upload.' . $_fileName . '.type', $file['type']);
-			$this->Session->write('Upload.' . $_fileName . '.data', file_get_contents($file['tmp_name']));
+			$this->Session->write('Upload.' . $_fileName . '.data', base64_encode(file_get_contents($file['tmp_name'])));
 			return $fileName;
 		}
 


### PR DESCRIPTION
MySQLの場合はDBのカラムをバイナリにしたらそのまま動作してましたが、PostgreSQL/SQLiteが動作していない感じでしたので、セッションに保存時にbase64エンコードして保存、読み出し時にデコードするようにしました。

よろしくおねがいします。
