### PR TITLE
fix #1045 【ウィジェット】ローカルナビゲーション出力で、表示とリンクが別の内容になる件を修正

### DIFF
--- a/lib/Baser/View/Helper/BcWidgetAreaHelper.php
+++ b/lib/Baser/View/Helper/BcWidgetAreaHelper.php
@@ -32,7 +32,7 @@ class BcWidgetAreaHelper extends AppHelper
 
 		$options = array_merge([
 			'subDir' => true,
-			'cache' => (empty($_SESSION['Auth'][Configure::read('BcAuthPrefix.admin.sessionKey')]))
+			'cache' => false,
 		], $options);
 		if ($options['cache'] === false) {
 			unset($options['cache']);


### PR DESCRIPTION
ウィジェット内のエレメントがすべてキャッシュされる動作になっていたので、
デフォルトはキャッシュしないように変更しました。

よろしくおねがいします。
