### PR TITLE
fix #1744 アップローダーで誤ったURLが表示される問題の改善

### DIFF
--- a/app/webroot/theme/admin-third/UploaderFiles/admin/ajax_image.php
+++ b/app/webroot/theme/admin-third/UploaderFiles/admin/ajax_image.php
@@ -15,12 +15,12 @@
  * @var array $file
  * @var string $size
  */
-$url = $this->BcBaser->getUrl($this->Uploader->getFileUrl($file['UploaderFile']['name']));
+$url = rtrim(Configure::read('BcEnv.siteUrl'), '/') . $this->Uploader->getFileUrl($file['UploaderFile']['name']);
 ?>
 
 
 <p class="url">
-	<a href="<?php echo h($url) ?>" target="_blank"><?php echo h(Router::url($url, true)) ?></a>
+	<a href="<?php echo h($url) ?>" target="_blank"><?php echo h($url) ?></a>
 </p>
 <p class="image">
 	<a href="<?php echo h($url) ?>"


### PR DESCRIPTION
よろしくおねがいします！
前回の修正について、サブディレクトリ上に設置するとパスがミスってる問題も合わせて改善となります。