### PR TITLE
mysql8.0環境でインストールが失敗する問題を修正

### DIFF
--- a/lib/Baser/Model/BcAppModel.php
+++ b/lib/Baser/Model/BcAppModel.php
@@ -1959,11 +1959,9 @@ class BcAppModel extends Model
 	{
 		$conditions[$this->alias . '.' . $this->publishStatusField] = true;
 		$conditions[] = ['or' => [[$this->alias . '.' . $this->publishBeginField . ' <=' => date('Y-m-d H:i:s')],
-			[$this->alias . '.' . $this->publishBeginField => null],
-			[$this->alias . '.' . $this->publishBeginField => '0000-00-00 00:00:00']]];
+			[$this->alias . '.' . $this->publishBeginField => null]]];
 		$conditions[] = ['or' => [[$this->alias . '.' . $this->publishEndField . ' >=' => date('Y-m-d H:i:s')],
-			[$this->alias . '.' . $this->publishEndField => null],
-			[$this->alias . '.' . $this->publishEndField => '0000-00-00 00:00:00']]];
+			[$this->alias . '.' . $this->publishEndField => null]]];
 		return $conditions;
 	}
 

--- a/lib/Baser/Model/Content.php
+++ b/lib/Baser/Model/Content.php
@@ -1315,11 +1315,9 @@ class Content extends AppModel
 	{
 		$conditions[$this->alias . '.status'] = true;
 		$conditions[] = ['or' => [[$this->alias . '.publish_begin <=' => date('Y-m-d H:i:s')],
-			[$this->alias . '.publish_begin' => null],
-			[$this->alias . '.publish_begin' => '0000-00-00 00:00:00']]];
+			[$this->alias . '.publish_begin' => null]]];
 		$conditions[] = ['or' => [[$this->alias . '.publish_end >=' => date('Y-m-d H:i:s')],
-			[$this->alias . '.publish_end' => null],
-			[$this->alias . '.publish_end' => '0000-00-00 00:00:00']]];
+			[$this->alias . '.publish_end' => null]]];
 		return $conditions;
 	}
 

--- a/lib/Baser/Plugin/Mail/Model/MailContent.php
+++ b/lib/Baser/Plugin/Mail/Model/MailContent.php
@@ -373,11 +373,9 @@ class MailContent extends MailAppModel
 	public function getConditionAllowAccepting()
 	{
 		$conditions[] = ['or' => [[$this->alias . '.publish_begin <=' => date('Y-m-d H:i:s')],
-			[$this->alias . '.publish_begin' => null],
-			[$this->alias . '.publish_begin' => '0000-00-00 00:00:00']]];
+			[$this->alias . '.publish_begin' => null]]];
 		$conditions[] = ['or' => [[$this->alias . '.publish_end >=' => date('Y-m-d H:i:s')],
-			[$this->alias . '.publish_end' => null],
-			[$this->alias . '.publish_end' => '0000-00-00 00:00:00']]];
+			[$this->alias . '.publish_end' => null]]];
 		return $conditions;
 	}
 


### PR DESCRIPTION
fix #1758 

mysql8.0環境でbasercmsのインストールが失敗する問題を修正しました。

mysql8.0に対してsqlを投げるときに、`datetime`として`0000-00-00 00:00:00`を投げることで発生するエラーのようでした。
`lib/Baser/Model/BcAppModel.php`の`getConditionAllowPublish()`について、既にor条件でnullかどうかをチェックしているようでしたので、エラーになる部分は削除することで対応しています。

また、今回は該当箇所と他に同じ条件を指定している箇所についてもその部分を削除することで、インストールが正常に終わることを確認しています。

`./app/Console/cake baser_test baser BcAll`を実行して途中で同じエラーがでないことは確認済みです。

ご確認よろしくお願いいたします。