### PR TITLE
Dev #1767 BcUpload->uploadImage()で、'imgsize' => 'mobile_thumb'としても大きい画像が表示されてしまう問題の解決

### DIFF
--- a/lib/Baser/View/Helper/BcUploadHelper.php
+++ b/lib/Baser/View/Helper/BcUploadHelper.php
@@ -318,7 +318,7 @@ class BcUploadHelper extends BcAppHelper
 							continue;
 						}
 					} else {
-						if ($options['mobile'] != preg_match('/^mobile_/', $key)) {
+						if ($options['mobile'] != preg_match('/^mobile_/', $key) && $options['imgsize'] != 'mobile_thumb') {
 							continue;
 						}
 					}


### PR DESCRIPTION
BcUpload->uploadImage()で、'imgsize' => 'mobile_thumb'としても大きい画像が表示されてしまう問題の解決

@ryuring 
@gondoh 

お手数ですが、ご確認の上、マージをお願いできますでしょうか？