### PR TITLE
fix #1770 メールフィールドの数が多い場合に、受信データ用テーブルのフィールドが不足状態で作成されるケースが発生する点を改修

### DIFF
--- a/lib/Baser/Plugin/Mail/Model/MailMessage.php
+++ b/lib/Baser/Plugin/Mail/Model/MailMessage.php
@@ -912,11 +912,24 @@ class MailMessage extends MailAppModel
 			$this->cacheSources = false;
 			ClassRegistry::flush();
 			$schema = $this->schema();
+			$mailFieldColumnList = [];
+
 			$messageFields = array_keys($schema);
 			foreach($mailFields as $mailField) {
 				if (!in_array($mailField['MailField']['field_name'], $messageFields)) {
-					$this->addMessageField($mailContentId, $mailField['MailField']['field_name']);
+					$mailFieldColumnList[$mailField['MailField']['field_name']] = [
+						'type' => 'text', 'null' => null, 'default' => null, 'length' => null,
+					];
 				}
+			}
+
+			if ($this->tableExists($this->createFullTableName($mailContentId))) {
+				// 初回時にid,created,modifiedカラムを持つテーブルが作成されている
+				$this->dropTable($mailContentId);
+				$db = $this->getDataSource();
+				// id,create,modifiedカラムとフォームのメールフィールド全部を併せたテーブルを作る
+				$db->createTable(array('schema' => array_merge($schema, $mailFieldColumnList), 'table' => $this->createFullTableName($mailContentId)));
+				$this->deleteModelCache();
 			}
 		}
 		return true;

--- a/lib/Baser/Plugin/Mail/Model/MailMessage.php
+++ b/lib/Baser/Plugin/Mail/Model/MailMessage.php
@@ -912,12 +912,12 @@ class MailMessage extends MailAppModel
 			$this->cacheSources = false;
 			ClassRegistry::flush();
 			$schema = $this->schema();
-			$mailFieldColumnList = [];
+			$mailFieldNameList = [];
 
 			$messageFields = array_keys($schema);
 			foreach($mailFields as $mailField) {
 				if (!in_array($mailField['MailField']['field_name'], $messageFields)) {
-					$mailFieldColumnList[$mailField['MailField']['field_name']] = [
+					$mailFieldNameList[$mailField['MailField']['field_name']] = [
 						'type' => 'text', 'null' => null, 'default' => null, 'length' => null,
 					];
 				}
@@ -928,7 +928,7 @@ class MailMessage extends MailAppModel
 				$this->dropTable($mailContentId);
 				$db = $this->getDataSource();
 				// id,create,modifiedカラムとフォームのメールフィールド全部を併せたテーブルを作る
-				$db->createTable(array('schema' => array_merge($schema, $mailFieldColumnList), 'table' => $this->createFullTableName($mailContentId)));
+				$db->createTable(['schema' => array_merge($schema, $mailFieldNameList), 'table' => $this->createFullTableName($mailContentId)]);
 				$this->deleteModelCache();
 			}
 		}


### PR DESCRIPTION
issueはこちらです。 https://github.com/baserproject/basercms/issues/1770  
フォーム複製時、受信用テーブルに不足フィールドが発生することがあるため、動作調整を入れてみました。  
よかったら取込み検討お願いします。
