### PR TITLE
fix #1772 【メールフォーム】フィールドをマルチチェックボックス→自動補完郵便番号の順にすると郵便番号自動補完が動作しない問題を修正

### DIFF
--- a/lib/Baser/View/Helper/BcFormHelper.php
+++ b/lib/Baser/View/Helper/BcFormHelper.php
@@ -606,7 +606,9 @@ DOC_END;
 		unset($options['secure']);
 
 		// 明示的にフィールド名を指定
-		$this->setEntity($fieldName);
+		if (!empty($fieldName)) {
+			$this->setEntity($fieldName);
+		}
 
 		// CUSTOMIZE ADD 2010/07/24 ryuring
 		// セキュリティコンポーネントのトークン生成の仕様として、


### PR DESCRIPTION
よろしくおねがいします！