### PR TITLE
 fix #1746 メールメッセージのアップデート中に処理が中断される問題を解決

### DIFF
--- a/lib/Baser/Plugin/Mail/Config/update/4.1.0/updater.php
+++ b/lib/Baser/Plugin/Mail/Config/update/4.1.0/updater.php
@@ -36,6 +36,7 @@ $result = true;
 if ($mailContents) {
 	foreach ($mailContents as $content) {
 		$mailContentId = $content['MailContent']['id'];
+		ClassRegistry::flush();
 		$MailMessage = ClassRegistry::init('Mail.MailMessage');
 		$MailMessage->setup($mailContentId);
 		$types = Hash::combine($content['MailField'], '{n}.field_name', '{n}.type');


### PR DESCRIPTION
複数のメールフォームがある場合に、MailMessageモデルが初期化されていない問題があったので修正しました。
よろしくお願いいたします。