### PR TITLE
fix #1784 管理者メールアドレスを複数設定時にパスワードリセット、メール送信テストでエラーになる件を修正

### DIFF
--- a/lib/Baser/Controller/BcAppController.php
+++ b/lib/Baser/Controller/BcAppController.php
@@ -1031,6 +1031,7 @@ class BcAppController extends Controller
 				$from = $this->siteConfigs['email'];
 				if (strpos($from, ',') !== false) {
 					$from = explode(',', $from);
+					// $from = $from[0]; // 複数あるアドレスのうちの1つ目を取得
 				}
 			} else {
 				$from = $toAddress;


### PR DESCRIPTION
1つ目のアドレスをFROMに設定してcakeEmailでエラーにならないように改修しました。
（メールフォームのFROMの部分の仕様と同様にしています。）