### PR TITLE
fix #1784 管理者メールアドレスを複数設定時にパスワードリセット、メール送信テストでエラーになる問題を解決

### DIFF
--- a/lib/Baser/Controller/BcAppController.php
+++ b/lib/Baser/Controller/BcAppController.php
@@ -1030,7 +1030,7 @@ class BcAppController extends Controller
 			if (!empty($this->siteConfigs['email'])) {
 				$from = $this->siteConfigs['email'];
 				if (strpos($from, ',') !== false) {
-					$from = explode(',', $from);
+					$from = strstr($from, ',', true);
 				}
 			} else {
 				$from = $toAddress;


### PR DESCRIPTION
1つ目のアドレスをFROMに設定してcakeEmailでエラーにならないように改修しました。
（メールフォームのFROMの部分の仕様と同様にしています。）

