### PR TITLE
fix #1747 メールフォーム マルチチェックボックスの入力必須の動作を改善

### DIFF
--- a/lib/Baser/Plugin/Mail/Model/MailMessage.php
+++ b/lib/Baser/Plugin/Mail/Model/MailMessage.php
@@ -183,7 +183,7 @@ class MailMessage extends MailAppModel
 	 */
 	protected function _setValidate()
 	{
-		foreach($this->mailFields as $mailField) {
+		foreach($this->mailFields as $i => $mailField) {
 			$mailField = $mailField['MailField'];
 			if ($mailField['valid'] && !empty($mailField['use_field'])) {
 				// 必須項目
@@ -196,6 +196,9 @@ class MailMessage extends MailAppModel
 								'required' => true
 							]];
 						}
+					} elseif ($mailField['type'] === 'multi_check') {
+						// チェックボックス未入力チェックで判別する
+						$this->mailFields[$i]['MailField']['valid_ex'] = 'VALID_NOT_UNCHECKED';
 					} else {
 						$this->validate[$mailField['field_name']] = ['notBlank' => [
 							'rule' => ['notBlank'],


### PR DESCRIPTION
マルチチェックボックスの場合だけ、

入力チェック：なし
拡張入力チェック：チェックボックス未入力チェック

としないと、入力必須にできない仕様になっていたので、
他のタイプと同様に

入力チェック：入力必須

だけでも動作するようにしてみました。
（下位互換の為、これまで同様の設定でもOKにしたほうがいいかと思い、拡張入力チェックの項目は残しています。）

どうでしょうか。