### PR TITLE
 fix #1615【ブログ】ツールバー「編集」リンクの隣に「新規記事追加」リンクを追加

### DIFF
--- a/app/webroot/theme/admin-third/Elements/admin/toolbar.php
+++ b/app/webroot/theme/admin-third/Elements/admin/toolbar.php
@@ -137,7 +137,8 @@ if (!empty($currentAuthPrefix['name']) && $currentPrefix !== 'front') {
 					<?php $this->BcBaser->editLink() ?>
 				</div>
 			<?php endif ?>
-			<?php if(!empty($this->request->params['Content']['type']) && $this->request->params['Content']['type'] === 'ContentFolder'): ?>
+			<?php if (!BcUtil::isAdminSystem()): ?>
+			<?php if(!empty($this->request->params['Content']['type']) && ($this->request->params['Content']['type'] === 'ContentFolder')): ?>
 				<div class="bca-toolbar__tools-button bca-toolbar__tools-button-add">
 					<?php $this->BcBaser->link(__d('baser', '新規ページ追加'), [
 						'plugin' => '',
@@ -146,6 +147,16 @@ if (!empty($currentAuthPrefix['name']) && $currentPrefix !== 'front') {
 						'action' => 'add', $this->request->params['Content']['id']
 					], ['class' => 'tool-menu']); ?>
 				</div>
+			<?php elseif(!empty($this->request->params['Content']['type']) && $this->request->params['Content']['type'] === 'BlogContent'): ?>
+				<div class="bca-toolbar__tools-button bca-toolbar__tools-button-add">
+					<?php $this->BcBaser->link(__d('baser', '新規記事追加'), [
+						'plugin' => 'blog',
+						'admin' => true,
+						'controller' => 'blog_posts',
+						'action' => 'add', $this->request->params['Content']['entity_id']
+					], ['class' => 'tool-menu']); ?>
+				</div>
+			<?php endif ?>
 			<?php endif ?>
 			<?php if ($this->BcBaser->existsPublishLink()): ?>
 				<div class="bca-toolbar__tools-button bca-toolbar__tools-button-publish">


### PR DESCRIPTION
https://github.com/baserproject/basercms/commit/5f8c960557061af490592816a32e7038a207cc58 のコミットでツールバーに固定ページ用の新規追加ボタンが追加されていたので、そちらにあわせてブログ記事用を実装してみました。

よろしくお願いいたします。
