### PR TITLE
管理画面にてゴミ箱に入っているコンテンツがサイドナビに表示されてしまう #1793

### DIFF
--- a/lib/Baser/Plugin/Blog/Config/setting.php
+++ b/lib/Baser/Plugin/Blog/Config/setting.php
@@ -22,6 +22,7 @@ $config['BcApp.adminNavigation'] = [
 /* @var BlogContent $BlogContent */
 $BlogContent = ClassRegistry::init('Blog.BlogContent');
 $blogContents = $BlogContent->find('all', [
+	'conditions' => ['Content.deleted' => 0],
 	'recursive' => 0,
 	'order' => $BlogContent->id,
 ]);

--- a/lib/Baser/Plugin/Mail/Config/setting.php
+++ b/lib/Baser/Plugin/Mail/Config/setting.php
@@ -23,6 +23,7 @@ $config['BcApp.adminNavigation'] = [
 /* @var MailContent $MailContent */
 $MailContent = ClassRegistry::init('Mail.MailContent');
 $mailContents = $MailContent->find('all', [
+	'conditions' => ['Content.deleted' => 0],
 	'recursive' => 0,
 	'order' => $MailContent->id
 ]);


### PR DESCRIPTION
管理画面にてゴミ箱に入っているコンテンツがサイドナビに表示されており、リンクが無効になっている箇所があったため「ゴミ箱に入ったコンテンツはサイドナビに表示させない」ように改修を入れております。