### PR TITLE
メールフォーム送信時の「送信先名」を空白許容とし、空の際の送信名にサイト名を設定するよう変更 #1648

### DIFF
--- a/app/webroot/theme/admin-third/MailContents/admin/form.php
+++ b/app/webroot/theme/admin-third/MailContents/admin/form.php
@@ -67,10 +67,10 @@ $this->BcBaser->js('Mail.admin/mail_contents/edit', false);
 				&nbsp;<span class="bca-label" data-bca-label-type="required"><?php echo __d('baser', '必須') ?></span>
 			</th>
 			<td class="col-input bca-form-table__input">
-				<?php echo $this->BcForm->input('MailContent.sender_name', ['type' => 'text', 'size' => 80, 'maxlength' => 255]) ?>
+				<?php echo $this->BcForm->input('MailContent.sender_name', ['type' => 'text', 'size' => 80, 'maxlength' => 255, 'placeholder' => '送信先名を入力してください。']) ?>
 				<i class="bca-icon--question-circle btn help bca-help"></i>
 				<?php echo $this->BcForm->error('MailContent.sender_name') ?>
-				<div id="helptextSenderName" class="helptext"><?php echo __d('baser', '自動返信メールの送信者に表示します。') ?></div>
+				<div id="helptextSenderName" class="helptext"><?php echo __d('baser', '自動返信メールの送信者に表示します。入力がない場合、サイト名が設定されます。') ?></div>
 			</td>
 		</tr>
 		<tr>

--- a/lib/Baser/Plugin/Mail/Controller/MailController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailController.php
@@ -397,7 +397,7 @@ class MailController extends MailAppController
 					]);
 					$sendEmailOptions = [];
 					if ($event !== false) {
-						$this->request->data = $event->result === true? $event->data['data'] : $event->result;
+						$this->request->data = $event->result === true ? $event->data['data'] : $event->result;
 						if (!empty($event->data['sendEmailOptions'])) {
 							$sendEmailOptions = $event->data['sendEmailOptions'];
 						}
@@ -590,6 +590,13 @@ class MailController extends MailAppController
 			$fromAdmin = $adminMail;
 		}
 
+		// 送信先名を取得
+		if ($mailContent['sender_name']) {
+			$fromName = $mailContent['sender_name'];
+		} else {
+			$fromName = $this->siteConfigs['name'];
+		}
+
 		$attachments = [];
 		$settings = $this->MailMessage->Behaviors->BcUpload->settings['MailMessage'];
 		foreach($this->dbDatas['mailFields'] as $mailField) {
@@ -643,7 +650,7 @@ class MailController extends MailAppController
 				$data,
 				array_merge(
 					[
-						'fromName' => $mailContent['sender_name'],
+						'fromName' => $fromName,
 						// カンマ区切りで複数設定されていた場合先頭のアドレスをreplayToに利用
 						'replyTo' => strpos($userMail, ',') === false? $userMail : strstr($userMail, ',', true),
 						'from' => $fromAdmin,

--- a/lib/Baser/Plugin/Mail/Model/MailContent.php
+++ b/lib/Baser/Plugin/Mail/Model/MailContent.php
@@ -66,10 +66,6 @@ class MailContent extends MailAppModel
 			],
 			'sender_name' => [
 				[
-					'rule' => ['notBlank'],
-					'message' => __d('baser', '送信先名を入力してください。')
-				],
-				[
 					'rule' => ['maxLength', 255],
 					'message' => __d('baser', '送信先名は255文字以内で入力してください。')
 				]
@@ -183,7 +179,6 @@ class MailContent extends MailAppModel
 	{
 		return [
 			'MailContent' => [
-				'sender_name' => __d('baser', '送信先名を入力してください'),
 				'subject_user' => __d('baser', 'お問い合わせ頂きありがとうございます'),
 				'subject_admin' => __d('baser', 'お問い合わせを頂きました'),
 				'layout_template' => 'default',

--- a/lib/Baser/Plugin/Mail/Test/Case/Model/MailContentTest.php
+++ b/lib/Baser/Plugin/Mail/Test/Case/Model/MailContentTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * baserCMS :  Based Website Development Project <https://basercms.net>
  * Copyright (c) baserCMS Users Community <https://basercms.net/community/>
@@ -89,7 +90,6 @@ class MailContentTest extends BaserTestCase
 		]);
 		$this->assertFalse($this->MailContent->validates());
 		$expected = [
-			'sender_name' => ['送信先名を入力してください。'],
 			'subject_user' => ['自動返信メール件名[ユーザー宛]を入力してください。'],
 			'subject_admin' => ['自動送信メール件名[管理者宛]を入力してください。'],
 			'form_template' => ['メールフォームテンプレート名は半角のみで入力してください。'],

--- a/lib/Baser/Plugin/Mail/View/MailContents/admin/form.php
+++ b/lib/Baser/Plugin/Mail/View/MailContents/admin/form.php
@@ -67,10 +67,10 @@ $this->BcBaser->js('Mail.admin/mail_contents/edit', false);
 			<th class="col-head"><?php echo $this->BcForm->label('MailContent.sender_name', __d('baser', '送信先名')) ?>
 				&nbsp;<span class="required">*</span></th>
 			<td class="col-input">
-				<?php echo $this->BcForm->input('MailContent.sender_name', ['type' => 'text', 'size' => 80, 'maxlength' => 255]) ?>
+				<?php echo $this->BcForm->input('MailContent.sender_name', ['type' => 'text', 'size' => 80, 'maxlength' => 255, 'placeholder' => '送信先名を入力してください。']) ?>
 				<?php echo $this->Html->image('admin/icn_help.png', ['id' => 'helpSenderName', 'class' => 'btn help', 'alt' => __d('baser', 'ヘルプ')]) ?>
 				<?php echo $this->BcForm->error('MailContent.sender_name') ?>
-				<div id="helptextSenderName" class="helptext"><?php echo __d('baser', '自動返信メールの送信者に表示します。') ?></div>
+				<div id="helptextSenderName" class="helptext"><?php echo __d('baser', '自動返信メールの送信者に表示します。入力がない場合、サイト名が設定されます。') ?></div>
 			</td>
 		</tr>
 		<tr>


### PR DESCRIPTION
下記のような仕様に変更してみました。いかがでしょう？

- メールフォーム作成時に「送信先名」は空の状態とし、「送信先名を入力してください」はプレースホルダーにする
- フォーム送信時に条件分岐
    - 空白の場合、サイト名を送信先名とする
    - 入力されている場合、そちらを送信先名とする