### PR TITLE
関連コンテンツを複製時に生じるバグ修正追加

### DIFF
--- a/app/webroot/theme/admin-third/Elements/admin/content_related.php
+++ b/app/webroot/theme/admin-third/Elements/admin/content_related.php
@@ -67,11 +67,7 @@ $pureUrl = $this->BcContents->getPureUrl($this->request->data['Content']['url'],
 				} else {
 					$class = ' class="bca-disablerow"';
 				}
-				$prefix = $relatedContent['Site']['name'];
-				if ($relatedContent['Site']['alias']) {
-					$prefix = $relatedContent['Site']['alias'];
-				}
-				$targetUrl = '/' . $prefix . $pureUrl;
+				$targetUrl = '/' . $this->BcContents->getTargetPrefix($relatedContent) . $pureUrl;
 				$mainSiteId = $relatedContent['Site']['main_site_id'];
 				if ($mainSiteId === '') {
 					$mainSiteId = 0;

--- a/lib/Baser/View/Helper/BcContentsHelper.php
+++ b/lib/Baser/View/Helper/BcContentsHelper.php
@@ -677,4 +677,27 @@ class BcContentsHelper extends AppHelper
 		return ($this->request->params['Content']['type'] === 'ContentFolder');
 	}
 
+	/**
+	 * getTargetUrl
+	 *
+     * @param  array $relatedContent
+     * @return string $prefix
+	 */
+	public function getTargetPrefix($relatedContent)
+	{
+		$prefix = $relatedContent['Site']['name'];
+		if ($relatedContent['Site']['alias']) {
+			$prefix = $relatedContent['Site']['alias'];
+			if ($this->_Content->existsContentByUrl("/$prefix")) {
+				$prefix = $this->_Content->find('first',
+					['conditions' => [
+							'Content.site_id' => $relatedContent['Site']['id'],
+							'Content.title' => $relatedContent['Site']['alias']
+						]
+				]);
+			}
+		}
+		return $prefix;
+	}
 }
+


### PR DESCRIPTION
エイリアスとコンテンツ名が同じことで関連サイトでコピーやエイリアスを作成できないバグが生じるため修正追加
例)
1. メインサイトでコンテンツaaaを作成
2. サイトaaaを作成（エイリアス=aaa）
3. メインサイトで適当なコンテンツを関連コンテンツのところよりサブサイトaaaにコピーしようとすると
```
指定したサイトの同じ階層上にフォルダではない同名のコンテンツが存在します。コピーの作成を実行する前に、指定したサイト上の同名コンテンツを確認し名称を変更してください。
```
とエラーが出る。

$prefixがエイリアスを見ているため、適切なurlを取得できるように変更を追加