### PR TITLE
BcAppHelper->url にエスケープ処理を追加

### DIFF
--- a/lib/Baser/Test/Case/View/Helper/BcAppHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcAppHelperTest.php
@@ -92,7 +92,22 @@ class BcAppHelperTest extends BaserTestCase
 
 	public function testUrl()
 	{
-		$this->markTestIncomplete('このテストは、まだ実装されていません。');
+		$this->assertEquals('/sample/pages',
+			$this->View->BcApp->url(['plugin' => 'sample', 'controller' => 'pages', 'action' => 'index']));
+		$this->assertEquals('/sample/pages/index/%3Ci%3E',
+			$this->View->BcApp->url(['plugin' => 'sample', 'controller' => 'pages', 'action' => 'index', '<i>']));
+
+		$this->assertEquals('/img/sample.png', $this->View->BcApp->url('/img/sample.png'));
+		$this->assertEquals('/img/sample.png&lt;i&gt;', $this->View->BcApp->url('/img/sample.png<i>'));
+
+		$this->assertEquals('/sample', $this->View->BcApp->url('/sample'));
+		$this->assertEquals('/sample&lt;i&gt;', $this->View->BcApp->url('/sample<i>'));
+		$this->assertEquals('http://localhost/sample', $this->View->BcApp->url('/sample', true));
+
+		$this->assertEquals('http://example.com', $this->View->BcApp->url('http://example.com'));
+		$this->assertEquals('https://example.com', $this->View->BcApp->url('https://example.com'));
+		$this->assertEquals('http://example.com/&lt;i&gt;', $this->View->BcApp->url('http://example.com/<i>'));
+		$this->assertEquals('https://example.com/&lt;i&gt;', $this->View->BcApp->url('https://example.com/<i>'));
 	}
 
 	public function testWebroot()

--- a/lib/Baser/View/Helper/BcAppHelper.php
+++ b/lib/Baser/View/Helper/BcAppHelper.php
@@ -204,9 +204,9 @@ class BcAppHelper extends Helper
 		}
 
 		if (!is_array($url) && preg_match('/^(javascript|https?|ftp|tel):/', $url)) {
-			return $url;
+			return parent::url($url);
 		} elseif (!is_array($url) && preg_match('/\/(img|css|js|files)/', $url)) {
-			return $this->webroot($url);
+			return $this->webroot(parent::url($url));
 		} else {
 			$url = parent::url($url, $full);
 			$params = explode('?', $url);


### PR DESCRIPTION
BcAppHelper->urlに以下のURLを渡した時だけHTMLエスケープが行われない問題があったので修正しました。
ご確認お願いします。

- httpから始まるURL
- 静的ファイルへのパスを含むURL

変更前

```
<?php $this->BcBaser->url('<b>b</b>') ?>
/_baser/seto1/blog/&lt;b&gt;b&lt;/b&gt;

<?php $this->BcBaser->url('https://<b>b</b>') ?>
https://<b>b</b>

<?php $this->BcBaser->url('/a/img/<b>b</b>') ?>
/_baser/seto1/a/img/<b>b</b>
```

変更後

```
<?php $this->BcBaser->url('<b>b</b>') ?>
/_baser/seto1/blog/&lt;b&gt;b&lt;/b&gt;

<?php $this->BcBaser->url('https://<b>b</b>') ?>
https://&lt;b&gt;b&lt;/b&gt;

<?php $this->BcBaser->url('/a/img/<b>b</b>') ?>
/_baser/seto1/a/img/&lt;b&gt;b&lt;/b&gt;
```