### PR TITLE
fix #1829 親フォルダが公開状態の非公開の固定ページが閲覧できる

### DIFF
--- a/lib/Baser/Model/Content.php
+++ b/lib/Baser/Model/Content.php
@@ -791,8 +791,12 @@ class Content extends AppModel
 				'conditions' => ['Content.id' => $data['Content']['parent_id']],
 				'recursive' => -1
 			]);
-			if (!$parent['Content']['status'] || $parent['Content']['publish_begin'] || $parent['Content']['publish_begin']) {
+			// 親フォルダが非公開の場合は自身も非公開
+			if (!$parent['Content']['status']) {
 				$data['Content']['status'] = $parent['Content']['status'];
+			}
+			// 親フォルダに公開期間が設定されている場合は自身の公開期間を上書き
+			if ($parent['Content']['publish_begin'] || $parent['Content']['publish_end']) {
 				$data['Content']['publish_begin'] = $parent['Content']['publish_begin'];
 				$data['Content']['publish_end'] = $parent['Content']['publish_end'];
 			}


### PR DESCRIPTION
issue: https://github.com/baserproject/basercms/issues/1829

@ryuring mtgでお時間をとっていただいて申し訳ないのですが、原因としてはシンプルでしたので軽い修正ですみました。

原因としては親要素に公開期間が設定されている場合、親要素の公開状態まで上書きされてしまうということでした。
でしたので、以下のように調整しています。

- 親要素が非公開の場合は子要素も非公開
- 親要素に公開期間が設定されている場合は子要素の公開期間を上書き

今までこのあたりの処理が混ざっていたので分割しています。

また、親要素と子要素、両方に公開期間が設定されていた場合はどうするか、という問題なのですが、
現在の仕様でも親要素の公開期間を優先する仕様でしたので特に対応は不要でした。

ご確認お願いします。