### PR TITLE
fix #1833 【ページ】管理画面で公開期間外の固定ページへの確認リンクが表示される

### DIFF
--- a/lib/Baser/Controller/ContentFoldersController.php
+++ b/lib/Baser/Controller/ContentFoldersController.php
@@ -115,7 +115,7 @@ class ContentFoldersController extends AppController
 		$site = BcSite::findById($this->request->data['Content']['site_id']);
 		$this->set('folderTemplateList', $this->ContentFolder->getFolderTemplateList($this->request->data['Content']['id'], $theme));
 		$this->set('pageTemplateList', $this->Page->getPageTemplateList($this->request->data['Content']['id'], $theme));
-		$this->set('publishLink', $this->Content->getUrl($this->request->data['Content']['url'], true, $site->useSubDomain));
+		$this->set('publishLink', $this->Content->getPublishUrl($this->request->data['Content']));
 	}
 
 	/**

--- a/lib/Baser/Controller/ContentLinksController.php
+++ b/lib/Baser/Controller/ContentLinksController.php
@@ -93,8 +93,7 @@ class ContentLinksController extends AppController
 				$this->redirect(['plugin' => false, 'admin' => true, 'controller' => 'contents', 'action' => 'index']);
 			}
 		}
-		$site = BcSite::findById($this->request->data['Content']['site_id']);
-		$this->set('publishLink', $this->Content->getUrl($this->request->data['Content']['url'], true, $site->useSubDomain));
+		$this->set('publishLink', $this->Content->getPublishUrl($this->request->data['Content']));
 	}
 
 	/**

--- a/lib/Baser/Controller/PagesController.php
+++ b/lib/Baser/Controller/PagesController.php
@@ -265,11 +265,7 @@ class PagesController extends AppController
 		}
 
 		// 公開リンク
-		$publishLink = '';
-		if ($this->request->data['Content']['status']) {
-			$site = BcSite::findById($this->request->data['Content']['site_id']);
-			$publishLink = $this->Content->getUrl($this->request->data['Content']['url'], true, $site->useSubDomain);
-		}
+		$publishLink = $this->Content->getPublishUrl($this->request->data['Content']);
 		// エディタオプション
 		$editorOptions = ['editorDisableDraft' => false];
 		if (!empty($this->siteConfigs['editor_styles'])) {

--- a/lib/Baser/Model/Content.php
+++ b/lib/Baser/Model/Content.php
@@ -1410,6 +1410,21 @@ class Content extends AppModel
 	}
 
 	/**
+	 * 公開されたURLを取得
+	 *
+	 * @param array $content
+	 * @return string|bool
+	 */
+	public function getPublishUrl($content)
+	{
+		if (!$this->isPublish($content['status'], $content['publish_begin'], $content['publish_end'])) {
+			return false;
+		}
+		$site = BcSite::findById($content['site_id']);
+		return $this->getUrl($content['url'], true, $site->useSubDomain);
+	}
+
+	/**
 	 * 移動元のコンテンツと移動先のディレクトリから移動が可能かチェックする
 	 *
 	 * @param $currentId int 移動元コンテンツID

--- a/lib/Baser/Plugin/Blog/Controller/BlogCategoriesController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogCategoriesController.php
@@ -219,7 +219,10 @@ class BlogCategoriesController extends BlogAppController
 		} else {
 			$parents = ['' => __d('baser', '指定しない')];
 		}
-		$this->set('publishLink', $this->Content->getUrl($this->request->params['Content']['url'] . 'archives/category/' . $this->request->data['BlogCategory']['name'], true, $this->request->params['Site']['use_subdomain']));
+
+		if ($this->Content->isPublish($this->request->params['Content']['status'], $this->request->params['Content']['publish_begin'], $this->request->params['Content']['publish_end'])) {
+			$this->set('publishLink', $this->Content->getUrl($this->request->params['Content']['url'] . 'archives/category/' . $this->request->data['BlogCategory']['name'], true, $this->request->params['Site']['use_subdomain']));
+		}
 		$this->set('parents', $parents);
 		$this->pageTitle = sprintf(__d('baser', '%s｜カテゴリ編集'), $this->request->params['Content']['title']);
 		$this->help = 'blog_categories_form';

--- a/lib/Baser/Plugin/Blog/Controller/BlogContentsController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogContentsController.php
@@ -164,10 +164,7 @@ class BlogContentsController extends BlogAppController
 				$this->redirect(['plugin' => false, 'admin' => true, 'controller' => 'contents', 'action' => 'index']);
 			}
 		}
-		$site = BcSite::findById($this->request->data['Content']['site_id']);
-		if (!empty($this->request->data['Content']['status'])) {
-			$this->set('publishLink', $this->Content->getUrl($this->request->data['Content']['url'], true, $site->useSubDomain));
-		}
+		$this->set('publishLink', $this->Content->getPublishUrl($this->request->data['Content']));
 		$this->request->params['Content'] = $this->BcContents->getContent($id)['Content'];
 		$this->set('blogContent', $this->request->data);
 		$this->subMenuElements = ['blog_posts'];

--- a/lib/Baser/Plugin/Blog/Controller/BlogPostsController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogPostsController.php
@@ -182,9 +182,7 @@ class BlogPostsController extends BlogAppController
 			return;
 		}
 
-		if ($this->request->params['Content']['status']) {
-			$this->set('publishLink', $this->Content->getUrl($this->request->params['Content']['url'], true, $this->request->params['Site']['use_subdomain']));
-		}
+		$this->set('publishLink', $this->Content->getPublishUrl($this->request->param('Content')));
 		$this->pageTitle = sprintf(__d('baser', '%s｜記事一覧'), strip_tags($this->request->params['Content']['title']));
 		$this->search = 'blog_posts_index';
 		$this->help = 'blog_posts_index';
@@ -458,7 +456,7 @@ class BlogPostsController extends BlogAppController
 			'empty' => __d('baser', '指定しない')
 		]);
 
-		if ($this->request->data['BlogPost']['status']) {
+		if ($this->BlogPost->allowPublish($this->request->data['BlogPost']) && $this->Content->isPublish($this->request->params['Content']['status'], $this->request->params['Content']['publish_begin'], $this->request->params['Content']['publish_end'])) {
 			$this->set('publishLink', $this->Content->getUrl($this->request->params['Content']['url'] . 'archives/' . $this->request->data['BlogPost']['no'], true, $this->request->params['Site']['use_subdomain']));
 		}
 

--- a/lib/Baser/Plugin/Mail/Controller/MailContentsController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailContentsController.php
@@ -219,17 +219,7 @@ class MailContentsController extends MailAppController
 		}
 
 		$this->request->param('Content', $this->BcContents->getContent($id)['Content']);
-		if ($this->request->data['Content']['status']) {
-			$site = BcSite::findById($this->request->data['Content']['site_id']);
-			$this->set(
-				'publishLink',
-				$this->Content->getUrl(
-					$this->request->data['Content']['url'],
-					true,
-					$site->useSubDomain
-				)
-			);
-		}
+		$this->set('publishLink', $this->Content->getPublishUrl($this->request->data['Content']));
 		$this->set('mailContent', $this->request->data);
 		$this->subMenuElements = ['mail_fields'];
 		$this->pageTitle = __d('baser', 'メールフォーム設定編集');

--- a/lib/Baser/Plugin/Mail/Controller/MailFieldsController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailFieldsController.php
@@ -79,12 +79,7 @@ class MailFieldsController extends MailAppController
 				$mailContentId
 			]
 		];
-		if ($this->request->param('Content.status')) {
-			$site = BcSite::findById($this->request->param('Content.site_id'));
-			$this->set('publishLink', $this->Content->getUrl(
-				$this->request->param('Content.url'), true, $site->useSubDomain)
-			);
-		}
+		$this->set('publishLink', $this->Content->getPublishUrl($this->request->param('Content')));
 	}
 
 	/**

--- a/lib/Baser/Test/Case/Model/ContentTest.php
+++ b/lib/Baser/Test/Case/Model/ContentTest.php
@@ -24,6 +24,7 @@ class ContentTest extends BaserTestCase
 	public $fixtures = [
 		'baser.Model.Content.ContentIsMovable',
 		'baser.Model.Content.ContentStatusCheck',
+		'baser.Model.Site.SiteSubDomain',
 		'baser.Routing.Route.BcContentsRoute.SiteBcContentsRoute',
 		'baser.Routing.Route.BcContentsRoute.ContentBcContentsRoute',
 		'baser.Default.SiteConfig',
@@ -591,6 +592,28 @@ class ContentTest extends BaserTestCase
 			[true, '', '0000-00-00 00:00:00', true],
 			[true, '', '0000-00-00 00:00:01', false],
 			[true, '', date('Y-m-d H:i:s', strtotime("+1 hour")), true],
+		];
+	}
+
+	/**
+	 * 公開されたURLを取得
+	 *
+	 * @dataProvider getPublishUrlProvider
+	 */
+	public function testGetPublishUrl($content, $expected)
+	{
+		$this->loadFixtures('SiteSubDomain');
+		$result = $this->Content->getPublishUrl($content);
+		$this->assertEquals($expected, $result);
+	}
+
+	public function getPublishUrlProvider()
+	{
+		return [
+			[['status' => true, 'publish_begin' => '', 'publish_end' => '', 'site_id' => 0, 'url' => '/test1'], 'https://localhost/test1'],
+			[['status' => true, 'publish_begin' => '', 'publish_end' => '', 'site_id' => 1, 'url' => '/subdomain/test2'], 'http://subdomain.localhost/test2'],
+			[['status' => true, 'publish_begin' => date('Y-m-d H:i:s', strtotime('+1 hour')), 'publish_end' => ''], false],
+			[['status' => false, 'publish_begin' => '', 'publish_end' => ''], false],
 		];
 	}
 

--- a/lib/Baser/Test/Fixture/Model/Site/SiteSubDomainFixture.php
+++ b/lib/Baser/Test/Fixture/Model/Site/SiteSubDomainFixture.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * SiteSubDomainFixture
+ */
+class SiteSubDomainFixture extends BaserTestFixture
+{
+
+	/**
+	 * Name of the object
+	 *
+	 * @var string
+	 */
+	public $name = 'Site';
+
+	/**
+	 * Records
+	 *
+	 * @var array
+	 */
+	public $records = [
+		[
+			'id' => '1',
+			'main_site_id' => '0',
+			'name' => 'subdomain',
+			'display_name' => 'subdomain',
+			'title' => 'subdomain',
+			'alias' => 'subdomain',
+			'theme' => '',
+			'status' => 1,
+			'device' => '',
+			'lang' => '',
+			'auto_redirect' => true,
+			'auto_link' => true,
+			'same_main_url' => false,
+			'use_subdomain' => 1,
+			'relate_main_site' => 0,
+			'created' => '2022-06-18 21:20:15',
+			'modified' => null
+		],
+	];
+
+}


### PR DESCRIPTION
issue: https://github.com/baserproject/basercms/issues/1833

ご確認お願いします。

## 問題

- 公開用URL取得時の判定が不正確

## 変更点

- 公開されているコンテンツのURLを取得する関数を作成
	- この関数の中で公開判定とURLの取得を行う
- 各コントローラーからその関数を使用して公開用のURLを取得するよう変更
	- ブログカテゴリとブログ記事は公開用URLが他とは違うので独自処理
