### PR TITLE
ブログ記事コピー時のアイキャッチ複製処理を調整

### DIFF
--- a/lib/Baser/Lib/BcFileUploader.php
+++ b/lib/Baser/Lib/BcFileUploader.php
@@ -648,9 +648,15 @@ class BcFileUploader
      */
     public function renameToBasenameFields($entity, $copy = false)
     {
-        $files = $this->getUploadingFiles();
+		if (!$copy) {
+			$files = $this->getUploadingFiles();
+		}
         foreach($this->settings['fields'] as $setting) {
-            $value = $this->renameToBasenameField($setting, $files[$setting['name']], $entity, $copy);
+			if ($copy) {
+				$value = $this->renameToBasenameField($setting, ['name' => $entity[$setting['name']]], $entity, $copy);
+			} else {
+				$value = $this->renameToBasenameField($setting, $files[$setting['name']], $entity, $copy);
+			}
             if ($value !== false) {
                 $entity[$setting['name']] = $value;
             }

--- a/lib/Baser/Plugin/Blog/Model/BlogPost.php
+++ b/lib/Baser/Plugin/Blog/Model/BlogPost.php
@@ -692,12 +692,9 @@ class BlogPost extends BlogAppModel
 			if ($eyeCatch) {
 				$result['BlogPost']['eye_catch'] = $eyeCatch;
 				$this->set($result);
-				$this->Behaviors->BcUpload->BcFileUploader['BlogPost']->setUploadingFiles([
-					'eye_catch' => ['name' => $eyeCatch]
-				]);
 				$result = $this->renameToBasenameFields(true);
 				$this->set($result);    // 内部でリネームされたデータが再セットされる
-				$result = $this->save(null, ['validate' => false, 'callbacks' => false]);
+				$result = $this->save();
 			}
 			// EVENT BlogPost.afterCopy
 			$this->dispatchEvent('afterCopy', [


### PR DESCRIPTION
ブログ記事をコピーする際にアイキャッチ画像がコピーされない問題を、BcFileUploader側で解決する対応
現状の対応方法だと、ファイルのコピー機能があるプラグイン全てに改修が必要になるのでその対策
要動作確認