### PR TITLE
WIP: BcUploadBehavior バリデーション中のロック調整

### DIFF
--- a/lib/Baser/Model/Behavior/BcUploadBehavior.php
+++ b/lib/Baser/Model/Behavior/BcUploadBehavior.php
@@ -63,12 +63,6 @@ class BcUploadBehavior extends ModelBehavior
 	public $oldEntity = [];
 
 	/**
-	 * バリデーション中のロック
-	 * @var bool
-	 */
-	public $validatingLock = [];
-
-	/**
 	 * セットアップ
 	 *
 	 * @param Model $Model
@@ -78,7 +72,6 @@ class BcUploadBehavior extends ModelBehavior
 	{
 		$this->BcFileUploader[$Model->alias] = new BcFileUploader();
         $this->BcFileUploader[$Model->alias]->initialize($settings, $Model);
-		$this->validatingLock[$Model->alias] = false;
         // @deprecated 後方互換 since v4.5.6, v5.0.0 で削除予定
         // CuApprover-4.3.2以下に対応するための処理
         // >>>
@@ -105,11 +98,9 @@ class BcUploadBehavior extends ModelBehavior
 	 */
 	public function afterValidate(Model $Model, $options = [])
 	{
-		if($this->validatingLock[$Model->alias]) return true;
         $Model->data[$Model->alias] = $this->BcFileUploader[$Model->alias]->setupRequestData(isset($Model->data[$Model->alias])? $Model->data[$Model->alias] : $Model->data);
         $Model->data[$Model->alias] = $this->BcFileUploader[$Model->alias]->setupTmpData(isset($Model->data[$Model->alias])? $Model->data[$Model->alias] : $Model->data);
         $this->oldEntity[$Model->alias] = (!empty($Model->data[$Model->alias]['id']))? $this->getOldEntity($Model, $Model->data[$Model->alias]['id']) : [];
-        $this->validatingLock[$Model->alias] = true;
 
 		// @deprecated 後方互換 since v4.5.6, v5.0.0 で削除予定
 		// CuApprover-4.3.2以下に対応するための処理


### PR DESCRIPTION
OptionalLinkなど、BcUploadBehaviorを使用するプラグインが有効になっているとブログ記事の保存に失敗する問題について、対象プラグイン全般に改修をいれなくてもいいようにするための変更
要動作確認
おそらく特定のプラグインに対して影響が出るはず