### PR TITLE
fix #1853 [ツールバー]管理画面にアクセス権限がない場合表示がおかしくなる問題を解決

### DIFF
--- a/app/webroot/theme/admin-third/Elements/admin/toolbar.php
+++ b/app/webroot/theme/admin-third/Elements/admin/toolbar.php
@@ -127,7 +127,13 @@ if (!empty($currentAuthPrefix['name']) && $currentPrefix !== 'front') {
 					?>
 					<?php // 管理画面にアクセス権限がない場合 ?>
 				<?php else: ?>
-					<?php $this->BcBaser->link(h($authName), Configure::read('BcAuthPrefix.' . $currentPrefix . '.loginRedirect'), ['title' => h($authName)]) ?>
+					<?php
+					$this->BcBaser->link(
+						sprintf('<span class="bca-toolbar__logo-text">%s</span>', h($authName)), 
+						Configure::read('BcAuthPrefix.' . $currentPrefix . '.loginRedirect'), 
+						['class' => 'bca-toolbar__logo-link', 'title' => h($authName)]
+					); 
+					?>
 				<?php endif ?>
 			<?php endif ?>
 		</div>


### PR DESCRIPTION
@ryuring 
@gondoh 
管理画面にアクセス可能な権限がある場合と同様のHTML形状にしました。
ただし、フロント側なのでbaserCMSのロゴマークは外しています。
お手数ですが、ご確認の上、マージお願いします。
