### PR TITLE
fix #1858【ユーザー】ユーザー一覧のページネーションに隙間がない

### DIFF
--- a/app/webroot/theme/admin-third/Elements/admin/blog_categories/index_list.php
+++ b/app/webroot/theme/admin-third/Elements/admin/blog_categories/index_list.php
@@ -25,10 +25,6 @@ $this->BcListTable->setColumnNumber(6);
 			<?php echo $this->BcForm->button(__d('baser', '適用'), ['id' => 'BtnApplyBatch', 'disabled' => 'disabled', 'class' => 'bca-btn', 'data-bca-btn-size' => 'lg']) ?>
 		</div>
 	<?php endif ?>
-	<div class="bca-data-list__sub">
-		<!-- pagination -->
-		<?php $this->BcBaser->element('pagination') ?>
-	</div>
 </div>
 
 
@@ -84,12 +80,3 @@ $this->BcListTable->setColumnNumber(6);
 	<?php endif; ?>
 	</tbody>
 </table>
-
-<div class="bca-data-list__bottom">
-	<div class="bca-data-list__sub">
-		<!-- pagination -->
-		<?php $this->BcBaser->element('pagination') ?>
-		<!-- list-num -->
-		<?php $this->BcBaser->element('list_num') ?>
-	</div>
-</div>

--- a/app/webroot/theme/admin-third/Elements/admin/contents/index_list_table.php
+++ b/app/webroot/theme/admin-third/Elements/admin/contents/index_list_table.php
@@ -110,6 +110,9 @@ $this->BcListTable->setColumnNumber(8);
 
 <div class="bca-data-list__bottom">
 	<div class="bca-data-list__sub">
+		<!-- pagination -->
+		<?php $this->BcBaser->element('pagination') ?>
+		<!-- list-num -->
 		<?php $this->BcBaser->element('list_num') ?>
 	</div>
 </div>

--- a/app/webroot/theme/admin-third/Elements/admin/dblogs/index_list.php
+++ b/app/webroot/theme/admin-third/Elements/admin/dblogs/index_list.php
@@ -34,9 +34,12 @@ $this->BcListTable->setColumnNumber(4);
 	?>
 	</div>
 	<?php endif ?>
-	<!-- pagination -->
-	<?php $this->BcBaser->element('pagination') ?>
+	<div class="bca-data-list__sub">
+		<!-- pagination -->
+		<?php $this->BcBaser->element('pagination') ?>
+	</div>
 </div>
+
 <table class="list-table bca-table-listup" id="ListTable">
 	<thead class="bca-table-listup__thead">
 	<tr>
@@ -107,5 +110,12 @@ $this->BcListTable->setColumnNumber(4);
 	<?php endif; ?>
 	</tbody>
 </table>
-<!-- list-num -->
-<?php $this->BcBaser->element('list_num') ?>
+
+<div class="bca-data-list__bottom">
+	<div class="bca-data-list__sub">
+		<!-- pagination -->
+		<?php $this->BcBaser->element('pagination') ?>
+		<!-- list-num -->
+		<?php $this->BcBaser->element('list_num') ?>
+	</div>
+</div>

--- a/app/webroot/theme/admin-third/Elements/admin/search_indices/index_list.php
+++ b/app/webroot/theme/admin-third/Elements/admin/search_indices/index_list.php
@@ -69,8 +69,10 @@ $this->BcListTable->setColumnNumber(8);
 			<?php echo $this->BcForm->button(__d('baser', '適用'), ['id' => 'BtnApplyBatch', 'disabled' => 'disabled', 'class' => 'bca-btn']) ?>
 		</div>
 	<?php endif ?>
-	<!-- pagination -->
-	<?php $this->BcBaser->element('pagination') ?>
+	<div class="bca-data-list__sub">
+		<!-- pagination -->
+		<?php $this->BcBaser->element('pagination') ?>
+	</div>
 </div>
 
 <!-- list -->
@@ -109,5 +111,11 @@ $this->BcListTable->setColumnNumber(8);
 	</tbody>
 </table>
 
-<!-- list-num -->
-<?php $this->BcBaser->element('list_num') ?>
+<div class="bca-data-list__bottom">
+	<div class="bca-data-list__sub">
+		<!-- pagination -->
+		<?php $this->BcBaser->element('pagination') ?>
+		<!-- list-num -->
+		<?php $this->BcBaser->element('list_num') ?>
+	</div>
+</div>

--- a/app/webroot/theme/admin-third/Elements/admin/theme_files/index_list.php
+++ b/app/webroot/theme/admin-third/Elements/admin/theme_files/index_list.php
@@ -35,8 +35,6 @@ $this->BcListTable->setColumnNumber(3);
 		</div>
 	<?php endif ?>
 	<div class="bca-data-list__sub">
-		<!-- list-num -->
-		<?php $this->BcBaser->element('list_num') ?>
 		<!-- pagination -->
 		<?php $this->BcBaser->element('pagination') ?>
 	</div>
@@ -82,3 +80,12 @@ $this->BcListTable->setColumnNumber(3);
 	<?php endif; ?>
 	</tbody>
 </table>
+
+<div class="bca-data-list__bottom">
+	<div class="bca-data-list__sub">
+		<!-- pagination -->
+		<?php $this->BcBaser->element('pagination') ?>
+		<!-- list-num -->
+		<?php $this->BcBaser->element('list_num') ?>
+	</div>
+</div>

--- a/app/webroot/theme/admin-third/Elements/admin/uploader_categories/index_list.php
+++ b/app/webroot/theme/admin-third/Elements/admin/uploader_categories/index_list.php
@@ -71,5 +71,11 @@ $this->BcListTable->setColumnNumber(5);
 	</tbody>
 </table>
 
-<!-- list-num -->
-<?php $this->BcBaser->element('list_num') ?>
+<div class="bca-data-list__bottom">
+	<div class="bca-data-list__sub">
+		<!-- pagination -->
+		<?php $this->BcBaser->element('pagination') ?>
+		<!-- list-num -->
+		<?php $this->BcBaser->element('list_num') ?>
+	</div>
+</div>

--- a/app/webroot/theme/admin-third/Elements/admin/uploader_files/index.php
+++ b/app/webroot/theme/admin-third/Elements/admin/uploader_files/index.php
@@ -50,12 +50,6 @@ if (!isset($listId)) {
 <!-- ファイルリスト -->
 <div id="FileList<?php echo $listId ?>" class="corner5 file-list"></div>
 
-
-<!-- list-num -->
-<?php if (empty($this->params['isAjax'])): ?>
-	<?php $this->BcBaser->element('list_num') ?>
-<?php endif ?>
-
 <!-- 編集ダイアログ -->
 <div id="EditDialog" title="<?php echo __d('baser', 'ファイル情報編集') ?>">
 	<?php $this->BcBaser->element('uploader_files/form', ['listId', $listId, 'popup' => true]) ?>

--- a/app/webroot/theme/admin-third/Elements/admin/uploader_files/index_list.php
+++ b/app/webroot/theme/admin-third/Elements/admin/uploader_files/index_list.php
@@ -49,7 +49,7 @@ $this->BcBaser->js([
 		<p style="color:#C00;font-weight:bold"><?php echo $installMessage ?></p>
 	<?php endif ?>
 
-	<div class="bca-list-head">
+	<div class="bca-data-list__top bca-list-head">
 		<?php if (!$listId): ?>
 			<div id="UploaderForm">
 				<?php if (!$installMessage): ?>
@@ -65,8 +65,10 @@ $this->BcBaser->js([
 				<?php endif ?>
 			</div>
 		<?php endif ?>
-
-		<?php $this->BcBaser->element('pagination') ?>
+		<div class="bca-data-list__sub">
+			<!-- pagination -->
+			<?php $this->BcBaser->element('pagination') ?>
+		</div>
 	</div>
 
 	<div class="file-list-body clearfix corner5">
@@ -104,6 +106,15 @@ $this->BcBaser->js([
 			<?php endif ?>
 		</table>
 
+	</div>
+
+	<div class="bca-data-list__bottom">
+		<div class="bca-data-list__sub">
+			<!-- pagination -->
+			<?php $this->BcBaser->element('pagination') ?>
+			<!-- list-num -->
+			<?php $this->BcBaser->element('list_num') ?>
+		</div>
 	</div>
 
 </div>

--- a/app/webroot/theme/admin-third/Elements/admin/uploader_files/index_panel.php
+++ b/app/webroot/theme/admin-third/Elements/admin/uploader_files/index_panel.php
@@ -55,4 +55,13 @@ $this->BcBaser->js('admin/vendors/jquery.upload-1.0.0.min');
 		<?php endif ?>
 	</div>
 
+	<div class="bca-data-list__bottom">
+		<div class="bca-data-list__sub">
+			<!-- pagination -->
+			<?php $this->BcBaser->element('pagination') ?>
+			<!-- list-num -->
+			<?php $this->BcBaser->element('list_num') ?>
+		</div>
+	</div>
+
 </div>

--- a/app/webroot/theme/admin-third/Elements/admin/user_groups/index_list.php
+++ b/app/webroot/theme/admin-third/Elements/admin/user_groups/index_list.php
@@ -19,56 +19,66 @@ $this->BcListTable->setColumnNumber(5);
 ?>
 
 
-	<script type="text/javascript">
-		$(function () {
-			$('.tag a').css({'text-decoration': 'none'})
-		});
-	</script>
+<script type="text/javascript">
+	$(function () {
+		$('.tag a').css({'text-decoration': 'none'})
+	});
+</script>
 
+<div class="bca-data-list__top">
+	<div class="bca-data-list__sub">
+		<!-- pagination -->
+		<?php $this->BcBaser->element('pagination') ?>
+	</div>
+</div>
 
-<?php $this->BcBaser->element('pagination') ?>
-
-	<table cellpadding="0" cellspacing="0" class="list-table bca-form-table" id="ListTable">
-		<thead>
+<table cellpadding="0" cellspacing="0" class="list-table bca-form-table" id="ListTable">
+	<thead>
+	<tr>
+		<th class="bca-table-listup__thead-th"><?php echo $this->Paginator->sort('id',
+				[
+					'asc' => '<i class="bca-icon--asc" title="' . __d('baser', '昇順') . '"></i>' . __d('baser', 'No'),
+					'desc' => '<i class="bca-icon--desc" title="' . __d('baser', '降順') . '"></i>' . __d('baser', 'No')
+				],
+				['escape' => false, 'class' => 'btn-direction bca-table-listup__a']) ?></th>
+		<th class="bca-table-listup__thead-th">
+			<?php echo $this->Paginator->sort('name',
+				[
+					'asc' => '<i class="bca-icon--asc" title="' . __d('baser', '昇順') . '"></i>' . __d('baser', 'ユーザーグループ名'),
+					'desc' => '<i class="bca-icon--desc" title="' . __d('baser', '降順') . '"></i>' . __d('baser', 'ユーザーグループ名')],
+				['escape' => false, 'class' => 'btn-direction bca-table-listup__a']
+			) ?>
+		</th>
+		<th class="bca-table-listup__thead-th"><?php echo $this->Paginator->sort('title', ['asc' => '<i class="bca-icon--asc" title="' . __d('baser', '昇順') . '"></i>' . __d('baser', '表示名'), 'desc' => '<i class="bca-icon--desc" title="' . __d('baser', '降順') . '"></i>' . __d('baser', '表示名')], ['escape' => false, 'class' => 'btn-direction bca-table-listup__a']) ?></th>
+		<?php echo $this->BcListTable->dispatchShowHead() ?>
+		<th class="bca-table-listup__thead-th">
+			<?php echo $this->Paginator->sort('created', ['asc' => '<i class="bca-icon--asc" title="' . __d('baser', '昇順') . '"></i>' . __d('baser', '登録日'), 'desc' => '<i class="bca-icon--desc" title="' . __d('baser', '降順') . '"></i>' . __d('baser', '登録日')], ['escape' => false, 'class' => 'btn-direction bca-table-listup__a']) ?>
+			<br>
+			<?php echo $this->Paginator->sort('modified', ['asc' => '<i class="bca-icon--asc" title="' . __d('baser', '昇順') . '"></i>' . __d('baser', '更新日'), 'desc' => '<i class="bca-icon--desc" title="' . __d('baser', '降順') . '"></i>' . __d('baser', '更新日')], ['escape' => false, 'class' => 'btn-direction bca-table-listup__a']) ?>
+		</th>
+		<th class="bca-table-listup__thead-th"><?php echo __d('baser', 'アクション') ?></th>
+	</tr>
+	</thead>
+	<tbody>
+	<?php if (!empty($datas)): ?>
+		<?php foreach($datas as $data): ?>
+			<?php $this->BcBaser->element('user_groups/index_row', ['data' => $data]) ?>
+		<?php endforeach; ?>
+	<?php else: ?>
 		<tr>
-			<th class="bca-table-listup__thead-th"><?php echo $this->Paginator->sort('id',
-					[
-						'asc' => '<i class="bca-icon--asc" title="' . __d('baser', '昇順') . '"></i>' . __d('baser', 'No'),
-						'desc' => '<i class="bca-icon--desc" title="' . __d('baser', '降順') . '"></i>' . __d('baser', 'No')
-					],
-					['escape' => false, 'class' => 'btn-direction bca-table-listup__a']) ?></th>
-			<th class="bca-table-listup__thead-th">
-				<?php echo $this->Paginator->sort('name',
-					[
-						'asc' => '<i class="bca-icon--asc" title="' . __d('baser', '昇順') . '"></i>' . __d('baser', 'ユーザーグループ名'),
-						'desc' => '<i class="bca-icon--desc" title="' . __d('baser', '降順') . '"></i>' . __d('baser', 'ユーザーグループ名')],
-					['escape' => false, 'class' => 'btn-direction bca-table-listup__a']
-				) ?>
-			</th>
-			<th class="bca-table-listup__thead-th"><?php echo $this->Paginator->sort('title', ['asc' => '<i class="bca-icon--asc" title="' . __d('baser', '昇順') . '"></i>' . __d('baser', '表示名'), 'desc' => '<i class="bca-icon--desc" title="' . __d('baser', '降順') . '"></i>' . __d('baser', '表示名')], ['escape' => false, 'class' => 'btn-direction bca-table-listup__a']) ?></th>
-			<?php echo $this->BcListTable->dispatchShowHead() ?>
-			<th class="bca-table-listup__thead-th">
-				<?php echo $this->Paginator->sort('created', ['asc' => '<i class="bca-icon--asc" title="' . __d('baser', '昇順') . '"></i>' . __d('baser', '登録日'), 'desc' => '<i class="bca-icon--desc" title="' . __d('baser', '降順') . '"></i>' . __d('baser', '登録日')], ['escape' => false, 'class' => 'btn-direction bca-table-listup__a']) ?>
-				<br>
-				<?php echo $this->Paginator->sort('modified', ['asc' => '<i class="bca-icon--asc" title="' . __d('baser', '昇順') . '"></i>' . __d('baser', '更新日'), 'desc' => '<i class="bca-icon--desc" title="' . __d('baser', '降順') . '"></i>' . __d('baser', '更新日')], ['escape' => false, 'class' => 'btn-direction bca-table-listup__a']) ?>
-			</th>
-			<th class="bca-table-listup__thead-th"><?php echo __d('baser', 'アクション') ?></th>
+			<td colspan="<?php echo $this->BcListTable->getColumnNumber() ?>"><p
+					class="no-data"><?php echo __d('baser', 'データが見つかりませんでした。') ?></p>
+			</td>
 		</tr>
-		</thead>
-		<tbody>
-		<?php if (!empty($datas)): ?>
-			<?php foreach($datas as $data): ?>
-				<?php $this->BcBaser->element('user_groups/index_row', ['data' => $data]) ?>
-			<?php endforeach; ?>
-		<?php else: ?>
-			<tr>
-				<td colspan="<?php echo $this->BcListTable->getColumnNumber() ?>"><p
-						class="no-data"><?php echo __d('baser', 'データが見つかりませんでした。') ?></p>
-				</td>
-			</tr>
-		<?php endif; ?>
-		</tbody>
-	</table>
+	<?php endif; ?>
+	</tbody>
+</table>
 
-	<!-- list-num -->
-<?php $this->BcBaser->element('list_num') ?>
+<div class="bca-data-list__bottom">
+	<div class="bca-data-list__sub">
+		<!-- pagination -->
+		<?php $this->BcBaser->element('pagination') ?>
+		<!-- list-num -->
+		<?php $this->BcBaser->element('list_num') ?>
+	</div>
+</div>

--- a/app/webroot/theme/admin-third/Elements/admin/users/index_list.php
+++ b/app/webroot/theme/admin-third/Elements/admin/users/index_list.php
@@ -16,8 +16,12 @@
 $this->BcListTable->setColumnNumber(7);
 ?>
 
-<!-- pagination -->
-<?php $this->BcBaser->element('pagination') ?>
+<div class="bca-data-list__top">
+	<div class="bca-data-list__sub">
+		<!-- pagination -->
+		<?php $this->BcBaser->element('pagination') ?>
+	</div>
+</div>
 
 <table cellpadding="0" cellspacing="0" class="list-table bca-table-listup" id="ListTable">
 	<thead class="bca-table-listup__thead">
@@ -94,5 +98,11 @@ $this->BcListTable->setColumnNumber(7);
 	</tbody>
 </table>
 
-<!-- list-num -->
-<?php $this->BcBaser->element('list_num') ?>
+<div class="bca-data-list__bottom">
+	<div class="bca-data-list__sub">
+		<!-- pagination -->
+		<?php $this->BcBaser->element('pagination') ?>
+		<!-- list-num -->
+		<?php $this->BcBaser->element('list_num') ?>
+	</div>
+</div>

--- a/app/webroot/theme/admin-third/Elements/admin/widget_areas/index_list.php
+++ b/app/webroot/theme/admin-third/Elements/admin/widget_areas/index_list.php
@@ -26,8 +26,6 @@ $this->BcListTable->setColumnNumber(6);
 		</div>
 	<?php endif ?>
 	<div class="bca-data-list__sub">
-		<!-- list-num -->
-		<?php $this->BcBaser->element('list_num') ?>
 		<!-- pagination -->
 		<?php $this->BcBaser->element('pagination') ?>
 	</div>
@@ -65,3 +63,12 @@ $this->BcListTable->setColumnNumber(6);
 	<?php endif; ?>
 	</tbody>
 </table>
+
+<div class="bca-data-list__bottom">
+	<div class="bca-data-list__sub">
+		<!-- pagination -->
+		<?php $this->BcBaser->element('pagination') ?>
+		<!-- list-num -->
+		<?php $this->BcBaser->element('list_num') ?>
+	</div>
+</div>


### PR DESCRIPTION
ユーザーの一覧画面だけでなく他の一覧画面のスタイル、表示位置など揃っていない所が他にもあったのであわせて揃えました。

管理画面一覧の右上
・ページネーション 

管理画面一覧の右下
・ページネーション 
・ページ数切り替え

よろしくおねがいします。
