### PR TITLE
fix #1872 管理画面 ブログが複数ある場合id順で表示されてしまうため並び替えができない問題を解決

### DIFF
--- a/lib/Baser/Plugin/Blog/Config/setting.php
+++ b/lib/Baser/Plugin/Blog/Config/setting.php
@@ -24,7 +24,7 @@ $BlogContent = ClassRegistry::init('Blog.BlogContent');
 $blogContents = $BlogContent->find('all', [
 	'conditions' => ['Content.deleted' => 0],
 	'recursive' => 0,
-	'order' => $BlogContent->id,
+	'order' =>  'Content.lft',
 ]);
 foreach($blogContents as $blogContent) {
 	$blog = $blogContent['BlogContent'];


### PR DESCRIPTION
@ryuring 
こちら、コンテンツツリーと同じ順番で表示できるのが良いと思いましたので、プッシュしました。
ご確認下さい。