### PR TITLE
BcAppController->dispatchEventに直接アクセスできないように変更

### DIFF
--- a/lib/Baser/Controller/BcAppController.php
+++ b/lib/Baser/Controller/BcAppController.php
@@ -1637,6 +1637,10 @@ class BcAppController extends Controller
 	 */
 	public function dispatchEvent($name, $params = [], $options = [])
 	{
+		$dbg = debug_backtrace();
+		if(!empty($dbg[1]['function']) && $dbg[1]['function'] == 'invokeArgs') {
+			$this->notFound();
+		}
 		$options = array_merge([
 			'modParams' => 0,
 			'plugin' => $this->plugin,


### PR DESCRIPTION
直接実行できないようにすべき関数なので調整しています。

調整内容はsendMailに対する制限と同様のものです。
https://github.com/baserproject/basercms/blob/dev-4/lib/Baser/Controller/BcAppController.php#L864

ご確認よろしくお願いします。