### PR TITLE
fix #1880 メールフォームのマルチチェックボックスなどで（）などを使用すると、inputタグのidのみ（）が外れ、labelのチェ…

### DIFF
--- a/lib/Baser/View/Helper/BcFormHelper.php
+++ b/lib/Baser/View/Helper/BcFormHelper.php
@@ -1229,7 +1229,7 @@ DOC_END;
 					if ($attributes['style'] === 'checkbox') {
 						$htmlOptions['value'] = $name;
 
-						$tagName = $attributes['id'] . $this->domIdSuffix($name);
+						$tagName = $attributes['id'] . $this->domIdSuffix($name, 'html5');
 						$htmlOptions['id'] = $tagName;
 						$label = ['for' => $tagName];
 
@@ -1561,7 +1561,7 @@ DOC_END;
 			if ($disabled && (!is_array($disabled) || in_array((string)$optValue, $disabled, !$isNumeric))) {
 				$optionsHere['disabled'] = true;
 			}
-			$tagName = $attributes['id'] . $this->domIdSuffix($optValue);
+			$tagName = $attributes['id'] . $this->domIdSuffix($optValue, 'html5');
 
 			if ($label) {
 				$labelOpts = is_array($label)? $label : [];


### PR DESCRIPTION
…ックが効かなくなる問題を解決

@ryuring @gondoh 
すみませんこちらご確認の上マージをお願いします。
