### PR TITLE
fix #1886 【管理画面】 ブログ記事一覧ページで非公開の記事でも「目」のマークが押せる問題を解決

### DIFF
--- a/app/webroot/theme/admin-third/Elements/admin/blog_posts/index_row.php
+++ b/app/webroot/theme/admin-third/Elements/admin/blog_posts/index_row.php
@@ -71,7 +71,12 @@
 	<td class="row-tools bca-table-listup__tbody-td bca-table-listup__tbody-td--actions"><?php // アクション ?>
 		<?php $this->BcBaser->link('', ['action' => 'ajax_unpublish', $data['BlogContent']['id'], $data['BlogPost']['id']], ['title' => __d('baser', '非公開'), 'class' => 'btn-unpublish bca-btn-icon', 'data-bca-btn-type' => 'unpublish', 'data-bca-btn-size' => 'lg']) ?>
 		<?php $this->BcBaser->link('', ['action' => 'ajax_publish', $data['BlogContent']['id'], $data['BlogPost']['id']], ['title' => __d('baser', '公開'), 'class' => 'btn-publish bca-btn-icon', 'data-bca-btn-type' => 'publish', 'data-bca-btn-size' => 'lg']) ?>
-		<?php $this->BcBaser->link('', $this->request->params['Content']['url'] . '/archives/' . $data['BlogPost']['no'], ['title' => __d('baser', '確認'), 'target' => '_blank', 'class' => 'bca-btn-icon', 'data-bca-btn-type' => 'preview', 'data-bca-btn-size' => 'lg']) ?>
+		<?php if ($this->Blog->allowPublish($data)): //公開状態であれば 公開ページヘのリンク ?>
+			<?php $this->BcBaser->link('', $this->request->params['Content']['url'] . '/archives/' . $data['BlogPost']['no'], ['title' => __d('baser', '確認'), 'target' => '_blank', 'class' => 'bca-btn-icon', 'data-bca-btn-type' => 'preview', 'data-bca-btn-size' => 'lg']); ?>
+		<?php else: // 非公開であればボタンを押せなくする ?>
+			<a title="確認" class="btn bca-btn-icon" data-bca-btn-type="preview" data-bca-btn-size="lg"
+			   data-bca-btn-status="gray"></a>
+		<?php endif ?>
 		<?php $this->BcBaser->link('', ['action' => 'edit', $data['BlogContent']['id'], $data['BlogPost']['id']], ['title' => __d('baser', '編集'), 'class' => ' bca-btn-icon', 'data-bca-btn-type' => 'edit', 'data-bca-btn-size' => 'lg']) ?>
 		<?php $this->BcBaser->link('',
 			['action' => 'ajax_copy', $data['BlogContent']['id'], $data['BlogPost']['id']],


### PR DESCRIPTION
・コンテンツの表形式と同様に、非公開ページの「目」のアイコンは押せない仕様に変更
@ryuring 
@gondoh 

こちら、ご確認の上、この仕様で良ければマージをお願いします。