### PR TITLE
fix #1704 ヘルプのバルーンチップをサイドバーより前面に表示

### DIFF
--- a/app/webroot/theme/admin-third/__assets/css/components/_main.scss
+++ b/app/webroot/theme/admin-third/__assets/css/components/_main.scss
@@ -2,7 +2,6 @@
   font-size: $label_font_size_small;
   position: relative;
   flex-basis: 100%;
-  overflow: auto;
   background: $color_background_primary;
   line-height:1.4;
   // border-top: 1px solid #ccc;
@@ -10,6 +9,7 @@
   // ❗ .contents-body と同じ要素 ❗
   &__body {
     padding: 0;
+    overflow: auto;
     //a:link {
     //  color:$color_primary;
     //}

--- a/app/webroot/theme/admin-third/css/admin/style.css
+++ b/app/webroot/theme/admin-third/css/admin/style.css
@@ -7278,12 +7278,12 @@ body * {
   font-size: 1.4rem;
   position: relative;
   flex-basis: 100%;
-  overflow: auto;
   background: #f8f8f8;
   line-height: 1.4;
 }
 .bca-main__body {
   padding: 0;
+  overflow: auto;
 }
 .bca-main__contents {
   padding: 20px;


### PR DESCRIPTION
バルーンチップがサイドバーに重なる際に状態を修正しました。
表示順の優先度ではなく overflow で切り取られていた為、overflow を設定する要素をバルーンチップの兄弟要素に変更しております。
ご確認よろしくお願いいたします！