### PR TITLE
記事一覧が投稿日時順に表示されない問題を修正

### DIFF
--- a/plugins/bc-blog/src/Service/BlogPostsService.php
+++ b/plugins/bc-blog/src/Service/BlogPostsService.php
@@ -255,9 +255,9 @@ class BlogPostsService implements BlogPostsServiceInterface
                     unset($fields[array_search('content_draft', $fields)]);
                     unset($fields[array_search('detail_draft', $fields)]);
                 }
-                $query = $this->BlogPosts->find()->contain(['BlogContents' => ['Contents']])->select($fields);
+                $query->contain(['BlogContents' => ['Contents']])->select($fields);
             } elseif(!isset($params['contain']['BlogContents']['Contents'])) {
-                $query = $this->BlogPosts->find()->contain(array_merge_recursive($query->getContain(), ['BlogContents' => ['Contents']]));
+                $query->contain(array_merge_recursive($query->getContain(), ['BlogContents' => ['Contents']]));
             }
             $conditions = array_merge($conditions, $this->BlogPosts->BlogContents->Contents->getConditionAllowPublish());
         } elseif ((string)$params['status'] === '0') {


### PR DESCRIPTION
@ryuring 
引数の$queryを上書きしてしまい、公開側ののブログ記事一覧が投稿日時順に表示されない問題を修正しました。

ご確認お願いします。