### PR TITLE
fix #2048 ブログ公開判定修正

### DIFF
--- a/plugins/bc-blog/src/Model/Table/BlogPostsTable.php
+++ b/plugins/bc-blog/src/Model/Table/BlogPostsTable.php
@@ -491,21 +491,19 @@ class BlogPostsTable extends BlogAppTable
      */
     public function allowPublish($post)
     {
-        $allowPublish = (int)$post->status;
-        if ($post->publish_begin === '0000-00-00 00:00:00') {
-            $post->publish_begin = null;
-        }
-        if ($post->publish_end === '0000-00-00 00:00:00') {
-            $post->publish_end = null;
+        if (!$post->status) {
+            return false;
         }
 
         // 期限を設定している場合に条件に該当しない場合は強制的に非公開とする
-        if (($post->publish_begin && $post->publish_begin >= date('Y-m-d H:i:s')) ||
-            ($post->publish_end && $post->publish_end <= date('Y-m-d H:i:s'))
+        $currentTime = time();
+        if (($post->publish_begin && $post->publish_begin->getTimestamp() > $currentTime) ||
+            ($post->publish_end && $post->publish_end->getTimestamp() < $currentTime)
         ) {
-            $allowPublish = false;
+            return false;
         }
-        return $allowPublish;
+
+        return true;
     }
 
     /**

--- a/plugins/bc-blog/tests/TestCase/Model/BlogPostsTableTest.php
+++ b/plugins/bc-blog/tests/TestCase/Model/BlogPostsTableTest.php
@@ -17,6 +17,7 @@ use BcBlog\Model\Table\BlogPostsTable;
 use BcBlog\Test\Factory\BlogContentFactory;
 use BcBlog\Test\Factory\BlogPostFactory;
 use Cake\Filesystem\Folder;
+use Cake\I18n\FrozenTime;
 use CakephpFixtureFactories\Scenario\ScenarioAwareTrait;
 
 /**
@@ -403,13 +404,14 @@ class BlogPostsTableTest extends BcTestCase
      *
      * @dataProvider allowPublishDataProvider
      */
-    public function testAllowPublish($publish_begin, $publish_end, $status, $expected)
+    public function testAllowPublish($publishBegin, $publishEnd, $status, $expected)
     {
-        $this->markTestIncomplete('こちらのテストはまだ未確認です');
-        $data['publish_begin'] = $publish_begin;
-        $data['publish_end'] = $publish_end;
-        $data['status'] = $status;
-        $this->assertEquals($this->BlogPost->allowPublish($data), $expected);
+        $post = $this->BlogPostsTable->newEntity([
+            'publish_begin' => $publishBegin,
+            'publish_end' => $publishEnd,
+            'status' => $status,
+        ]);
+        $this->assertEquals($this->BlogPostsTable->allowPublish($post), $expected);
     }
 
     public function allowPublishDataProvider()
@@ -417,11 +419,17 @@ class BlogPostsTableTest extends BcTestCase
         return [
             [null, null, false, false],
             [null, null, true, true],
-            [null, date('Y-m-d H:i:s'), true, false],
-            [null, date('Y-m-d H:i:s', strtotime("+1 hour")), true, true],
-            [date('Y-m-d H:i:s'), null, true, true],
-            [date('Y-m-d H:i:s', strtotime("+1 hour")), null, true, false],
-            [date('Y-m-d H:i:s'), date('Y-m-d H:i:s'), true, false]
+
+            [null, new FrozenTime('+1 hour'), true, true],
+            [new FrozenTime('-1 hour'), null, true, true],
+            [null, new FrozenTime('-1 hour'), true, false],
+            [new FrozenTime('+1 hour'), null, true, false],
+
+            [new FrozenTime('-1 hour'), new FrozenTime('+1 hour'), true, true],
+            [new FrozenTime('-1 hour'), new FrozenTime('+1 hour'), false, false],
+            [new FrozenTime('-1 hour'), new FrozenTime('-1 hour'), true, false],
+            [new FrozenTime('+1 hour'), new FrozenTime('-1 hour'), true, false],
+            [new FrozenTime('+1 hour'), new FrozenTime('+2 hour'), true, false],
         ];
     }
 


### PR DESCRIPTION
issue: https://github.com/baserproject/basercms/issues/2048

FrozenTimeに対応した方法に調整しています。ご確認お願いします。

修正前の状態で再現する方法としては以下となります。

- 公開状態: 公開
- 開始日時: 空
- 終了日時: 過去