### PR TITLE
fix #2106 ContentsService::setCurrentToRequest のユニットテスト実装 

### DIFF
--- a/plugins/baser-core/src/Service/ContentsService.php
+++ b/plugins/baser-core/src/Service/ContentsService.php
@@ -1528,6 +1528,7 @@ class ContentsService implements ContentsServiceInterface
      * @return false|ServerRequest
      * @checked
      * @noTodo
+     * @unitTest
      */
     public function setCurrentToRequest(string $type, int $entityId, ServerRequest $request)
     {


### PR DESCRIPTION
fix #2106 ContentsService::setCurrentToRequest のユニットテスト実装 