### PR TITLE
fix #2107 #1965 #2108 #2111 #2109 MailContentsService Unit Test

### DIFF
--- a/plugins/bc-mail/src/Service/MailContentsService.php
+++ b/plugins/bc-mail/src/Service/MailContentsService.php
@@ -130,6 +130,7 @@ class MailContentsService implements MailContentsServiceInterface
      * @return bool
      * @checked
      * @noTodo
+     * @unitTest
      */
     public function delete(int $id): bool
     {

--- a/plugins/bc-mail/src/Service/MailContentsService.php
+++ b/plugins/bc-mail/src/Service/MailContentsService.php
@@ -52,6 +52,7 @@ class MailContentsService implements MailContentsServiceInterface
      * @return EntityInterface
      * @checked
      * @noTodo
+     * @unitTest
      */
     public function getNew()
     {

--- a/plugins/bc-mail/src/Service/MailContentsService.php
+++ b/plugins/bc-mail/src/Service/MailContentsService.php
@@ -79,6 +79,7 @@ class MailContentsService implements MailContentsServiceInterface
      * @throws \Cake\ORM\Exception\PersistenceFailedException
      * @checked
      * @noTodo
+     * @unitTest
      */
     public function create(array $postData, $options = []): ?EntityInterface
     {

--- a/plugins/bc-mail/src/Service/MailContentsService.php
+++ b/plugins/bc-mail/src/Service/MailContentsService.php
@@ -110,6 +110,7 @@ class MailContentsService implements MailContentsServiceInterface
      * @return EntityInterface|null
      * @checked
      * @noTodo
+     * @unitTest
      */
     public function update(EntityInterface $entity, array $postData): ?EntityInterface
     {

--- a/plugins/bc-mail/src/Service/MailContentsService.php
+++ b/plugins/bc-mail/src/Service/MailContentsService.php
@@ -154,6 +154,7 @@ class MailContentsService implements MailContentsServiceInterface
      * @return EntityInterface
      * @checked
      * @noTodo
+     * @unitTest
      */
     public function get(int $id, array $options = [])
     {

--- a/plugins/bc-mail/tests/Scenario/MailContentsScenario.php
+++ b/plugins/bc-mail/tests/Scenario/MailContentsScenario.php
@@ -43,6 +43,7 @@ class MailContentsScenario implements FixtureScenarioInterface
             'redirect_url' => '/',
         ])->persist();
         ContentFactory::make([
+            'id' => 1,
             'name' => 'name_test',
             'plugin' => 'BcMail',
             'type' => 'MailContent',
@@ -52,12 +53,8 @@ class MailContentsScenario implements FixtureScenarioInterface
             'parent_id' => 1,
             'rght' => 1,
             'lft' => 2,
-            'status'=> true,
+            'status' => true,
             'created_date' => '2023-02-16 16:41:37',
-        ])->persist();
-        ContentFactory::make([
-            'id' => 1,
-            'publish_end' => '2099-12-09 12:56:53',
         ])->persist();
 
         MailContentFactory::make([

--- a/plugins/bc-mail/tests/Scenario/MailContentsScenario.php
+++ b/plugins/bc-mail/tests/Scenario/MailContentsScenario.php
@@ -41,6 +41,7 @@ class MailContentsScenario implements FixtureScenarioInterface
             'form_template' => 'default',
             'mail_template' => 'mail_default',
             'redirect_url' => '/',
+            'ssl_on' => 0
         ])->persist();
         ContentFactory::make([
             'id' => 1,

--- a/plugins/bc-mail/tests/TestCase/Service/MailContentsServiceTest.php
+++ b/plugins/bc-mail/tests/TestCase/Service/MailContentsServiceTest.php
@@ -221,4 +221,22 @@ class MailContentsServiceTest extends BcTestCase
         $this->MailContentsService->update($mailContent, $data);
     }
 
+    /**
+     * copy test
+     */
+    public function test_copy()
+    {
+        $this->loadFixtureScenario(InitAppScenario::class);
+        $this->loadFixtureScenario(MailContentsScenario::class);
+        $data = [
+            'entity_id' => 1,
+            'parent_id' => 1,
+            'title' => 'Nghiem',
+            'site_id' => 1
+        ];
+        $this->loginAdmin($this->getRequest());
+        $result = $this->MailContentsService->copy($data);
+        $this->assertEquals('Nghiem', $result->content->title);
+    }
+
 }

--- a/plugins/bc-mail/tests/TestCase/Service/MailContentsServiceTest.php
+++ b/plugins/bc-mail/tests/TestCase/Service/MailContentsServiceTest.php
@@ -15,6 +15,7 @@ use BaserCore\TestSuite\BcTestCase;
 use BcMail\Service\MailContentsService;
 use BcMail\Service\MailContentsServiceInterface;
 use BcMail\Test\Scenario\MailContentsScenario;
+use Cake\Datasource\Exception\RecordNotFoundException;
 use CakephpFixtureFactories\Scenario\ScenarioAwareTrait;
 
 /**
@@ -142,8 +143,31 @@ class MailContentsServiceTest extends BcTestCase
         $rs = $this->MailContentsService->getList();
         //戻る値を確認
         $this->assertCount(2, $rs);
-        $this->assertEquals('お問い合わせ',$rs[1]);
-        $this->assertEquals('テスト',$rs[2]);
+        $this->assertEquals('お問い合わせ', $rs[1]);
+        $this->assertEquals('テスト', $rs[2]);
     }
+
+    /**
+     * test delete
+     * @throws \Throwable
+     */
+    public function test_delete()
+    {
+        //data create
+        $this->loadFixtureScenario(MailContentsScenario::class);
+
+        $mailContent = $this->MailContentsService->get(1, ['contain' => []]);
+        $this->assertEquals(1, $mailContent->id);
+
+        $result = $this->MailContentsService->delete(1);
+        $this->assertTrue($result);
+        $this->expectException(RecordNotFoundException::class);
+        $this->MailContentsService->get(1, ['contain' => []]);
+
+        $result = $this->MailContentsService->delete(0);
+        $this->assertFalse($result);
+
+    }
+
 
 }

--- a/plugins/bc-mail/tests/TestCase/Service/MailContentsServiceTest.php
+++ b/plugins/bc-mail/tests/TestCase/Service/MailContentsServiceTest.php
@@ -11,6 +11,8 @@
 
 namespace BcMail\Test\TestCase\Service;
 
+use BaserCore\Test\Factory\ContentFactory;
+use BaserCore\Test\Scenario\InitAppScenario;
 use BaserCore\TestSuite\BcTestCase;
 use BcMail\Service\MailContentsService;
 use BcMail\Service\MailContentsServiceInterface;
@@ -39,6 +41,12 @@ class MailContentsServiceTest extends BcTestCase
     public $fixtures = [
         'plugin.BaserCore.Factory/Contents',
         'plugin.BcMail.Factory/MailContents',
+        'plugin.BaserCore.Factory/Sites',
+        'plugin.BaserCore.Factory/SiteConfigs',
+        'plugin.BaserCore.Factory/Users',
+        'plugin.BaserCore.Factory/UsersUserGroups',
+        'plugin.BaserCore.Factory/UserGroups',
+        'plugin.BcMail.Factory/MailFields',
     ];
 
     /**
@@ -129,7 +137,19 @@ class MailContentsServiceTest extends BcTestCase
      */
     public function test_create()
     {
-        $this->markTestIncomplete('このテストは、まだ実装されていません。');
+        $this->loadFixtureScenario(InitAppScenario::class);
+        $this->loadFixtureScenario(MailContentsScenario::class);
+        $data = [
+            'content' => [
+                'name' => 'コンテンツ名',
+                'title' => 'add mail content',
+                'site_id' => 1,
+                'parent_id' => 0
+            ],
+            'description' => 'Nghiem',
+        ];
+        $mailContent = $this->MailContentsService->create($data, []);
+        $this->assertEquals('Nghiem', $mailContent->description);
     }
 
     /**

--- a/plugins/bc-mail/tests/TestCase/Service/MailContentsServiceTest.php
+++ b/plugins/bc-mail/tests/TestCase/Service/MailContentsServiceTest.php
@@ -77,8 +77,8 @@ class MailContentsServiceTest extends BcTestCase
         $rs = $this->MailContentsService->getIndex([])->toArray();
         //戻る値を確認
         $this->assertCount(2, $rs);
-        $this->assertEquals($rs[1]->description, 'description test');
-        $this->assertEquals($rs[1]->content->title, 'お問い合わせ');
+        $this->assertEquals('description test 2', $rs[1]->description);
+        $this->assertEquals('テスト', $rs[1]->content->title);
     }
 
     /**
@@ -96,6 +96,31 @@ class MailContentsServiceTest extends BcTestCase
         $this->assertEquals(true, $result->save_info);
         $this->assertEquals(false, $result->validate);
         $this->assertEquals(false, $result->ssl_on);
+    }
+
+    /**
+     * test get
+     */
+    public function test_get()
+    {
+        $options = [
+            'contain' => []
+        ];
+        $this->loadFixtureScenario(MailContentsScenario::class);
+        $result = $this->MailContentsService->get(1, $options)->toArray();
+        $this->assertEquals('description test', $result['description']);
+        $this->assertNull($result['content']);
+
+        $options = [
+            'contain' => [
+                'Contents' => ['Sites'],
+                'MailFields'
+            ]
+        ];
+        $result = $this->MailContentsService->get(1, $options)->toArray();
+        $this->assertEquals('description test', $result['description']);
+        $this->assertEquals('お問い合わせ', $result['content']['title']);
+
     }
 
     /**

--- a/plugins/bc-mail/tests/TestCase/Service/MailContentsServiceTest.php
+++ b/plugins/bc-mail/tests/TestCase/Service/MailContentsServiceTest.php
@@ -20,6 +20,7 @@ use BcMail\Test\Scenario\MailContentsScenario;
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\ORM\Exception\PersistenceFailedException;
 use CakephpFixtureFactories\Scenario\ScenarioAwareTrait;
+use Error;
 
 /**
  * MailContentsServiceTest
@@ -237,6 +238,10 @@ class MailContentsServiceTest extends BcTestCase
         $this->loginAdmin($this->getRequest());
         $result = $this->MailContentsService->copy($data);
         $this->assertEquals('Nghiem', $result->content->title);
+
+        $data['entity_id'] = 0;
+        $this->expectException(Error::class);
+        $this->MailContentsService->copy($data);
     }
 
 }

--- a/plugins/bc-mail/tests/TestCase/Service/MailContentsServiceTest.php
+++ b/plugins/bc-mail/tests/TestCase/Service/MailContentsServiceTest.php
@@ -213,6 +213,12 @@ class MailContentsServiceTest extends BcTestCase
         ];
         $result = $this->MailContentsService->update($mailContent, $data);
         $this->assertEquals('Nghiem', $result->description);
+
+        $data = [
+            'description' => 'Nghiem',
+        ];
+        $this->expectException(PersistenceFailedException::class);
+        $this->MailContentsService->update($mailContent, $data);
     }
 
 }

--- a/plugins/bc-mail/tests/TestCase/Service/MailContentsServiceTest.php
+++ b/plugins/bc-mail/tests/TestCase/Service/MailContentsServiceTest.php
@@ -18,6 +18,7 @@ use BcMail\Service\MailContentsService;
 use BcMail\Service\MailContentsServiceInterface;
 use BcMail\Test\Scenario\MailContentsScenario;
 use Cake\Datasource\Exception\RecordNotFoundException;
+use Cake\ORM\Exception\PersistenceFailedException;
 use CakephpFixtureFactories\Scenario\ScenarioAwareTrait;
 
 /**
@@ -150,6 +151,11 @@ class MailContentsServiceTest extends BcTestCase
         ];
         $mailContent = $this->MailContentsService->create($data, []);
         $this->assertEquals('Nghiem', $mailContent->description);
+        $data = [
+            'description' => 'Nghiem',
+        ];
+        $this->expectException(PersistenceFailedException::class);
+        $this->MailContentsService->create($data, []);
     }
 
     /**

--- a/plugins/bc-mail/tests/TestCase/Service/MailContentsServiceTest.php
+++ b/plugins/bc-mail/tests/TestCase/Service/MailContentsServiceTest.php
@@ -86,7 +86,16 @@ class MailContentsServiceTest extends BcTestCase
      */
     public function test_getNew()
     {
-        $this->markTestIncomplete('このテストは、まだ実装されていません。');
+        $result = $this->MailContentsService->getNew();
+        $this->assertEquals('お問い合わせ頂きありがとうございます', $result->subject_user);
+        $this->assertEquals('お問い合わせを頂きました', $result->subject_admin);
+        $this->assertEquals('default', $result->layout_template);
+        $this->assertEquals('default', $result->form_template);
+        $this->assertEquals('mail_default', $result->mail_template);
+        $this->assertEquals(true, $result->use_description);
+        $this->assertEquals(true, $result->save_info);
+        $this->assertEquals(false, $result->validate);
+        $this->assertEquals(false, $result->ssl_on);
     }
 
     /**

--- a/plugins/bc-mail/tests/TestCase/Service/MailContentsServiceTest.php
+++ b/plugins/bc-mail/tests/TestCase/Service/MailContentsServiceTest.php
@@ -195,5 +195,24 @@ class MailContentsServiceTest extends BcTestCase
 
     }
 
+    /**
+     * update test
+     */
+    public function test_update()
+    {
+        $this->loadFixtureScenario(MailContentsScenario::class);
+        $mailContent = $this->MailContentsService->get(1, ['contain' => []]);
+        $data = [
+            'content' => [
+                'name' => 'コンテンツ名',
+                'title' => 'add mail content',
+                'site_id' => 1,
+                'parent_id' => 0
+            ],
+            'description' => 'Nghiem',
+        ];
+        $result = $this->MailContentsService->update($mailContent, $data);
+        $this->assertEquals('Nghiem', $result->description);
+    }
 
 }


### PR DESCRIPTION
MailContentsService::get のユニットテストを実装 #2107
MailContentsService::getNew のユニットテスト実装 #1965
MailContentsService::create のユニットテストを実装 #2108
MailContentsService::copy のユニットテストを実装 #2111
MailContentsService::update のユニットテストを実装 #2109