### PR TITLE
fix #1928 expectExceptionを使用したテストの修正

### DIFF
--- a/plugins/baser-core/tests/TestCase/Service/ContentsServiceTest.php
+++ b/plugins/baser-core/tests/TestCase/Service/ContentsServiceTest.php
@@ -274,14 +274,21 @@ class ContentsServiceTest extends BcTestCase
     {
         // treeBehavior falseの場合
         $this->assertTrue($this->ContentsService->hardDelete(15));
-        $this->expectException('Cake\Datasource\Exception\RecordNotFoundException');
-        $this->ContentsService->getTrash(15);
+        try {
+            $this->ContentsService->getTrash(15);
+            $this->fail();
+        } catch (RecordNotFoundException $e) {}
+
         // treeBehavior trueの場合
         $this->assertTrue($this->ContentsService->hardDelete(16, true));
-        $this->expectException('Cake\Datasource\Exception\RecordNotFoundException');
-        $this->ContentsService->getTrash(16); // 親要素
-        $this->expectException('Cake\Datasource\Exception\RecordNotFoundException');
-        $this->ContentsService->getTrash(17); // 子要素
+        try {
+            $this->ContentsService->getTrash(16); // 親要素
+            $this->fail();
+        } catch (RecordNotFoundException $e) {}
+        try {
+            $this->ContentsService->getTrash(17); // 子要素
+            $this->fail();
+        } catch (RecordNotFoundException $e) {}
     }
 
     /**

--- a/plugins/bc-favorite/tests/TestCase/Service/FavoritesServiceTest.php
+++ b/plugins/bc-favorite/tests/TestCase/Service/FavoritesServiceTest.php
@@ -76,12 +76,11 @@ class FavoritesServiceTest extends BcTestCase
      */
     public function testGet(): void
     {
-        $this->expectException("Cake\Datasource\Exception\RecordNotFoundException");
-        $result = $this->FavoritesService->get(0);
-        $this->assertEmpty($result);
-
         $result = $this->FavoritesService->get(1);
         $this->assertEquals("固定ページ管理", $result->name);
+
+        $this->expectException('Cake\Datasource\Exception\RecordNotFoundException');
+        $result = $this->FavoritesService->get(0);
     }
 
     /**


### PR DESCRIPTION
issue: https://github.com/baserproject/basercms/issues/1928

expectExceptionのあとに書かれていたテストが実行されていなかったため修正しています。

修正して正常にテストが実行されるようになって発見したエラーもあるのですが、テストと処理どちらの修正が必要か判断できなかったので確認をお願いします。

## エラーになる箇所

https://github.com/baserproject/basercms/compare/dev-5...seto1:fix-test?expand=1#diff-fdfa30dcde75d58ad4d44f372e41ca69c5038ddceb556f8601ce618d96740a56R289

```
$this->assertTrue($this->ContentsService->hardDelete(16, true));

...

try {
    $this->ContentsService->getTrash(17); // 子要素
    $this->fail();
} catch (RecordNotFoundException $e) {}
```

親コンテンツを削除しても子コンテンツが削除されない

https://github.com/baserproject/basercms/blob/dev-5/plugins/baser-core/src/Service/ContentsService.php#L499

一方、ContentsService->hardDeleteの第2引数は使用されていない