### PR TITLE
リンク更新

### DIFF
--- a/plugins/baser-core/config/setting.php
+++ b/plugins/baser-core/config/setting.php
@@ -657,11 +657,9 @@ return [
         // baserCMSオフィシャルニュース
         'baserNewsRss' => 'https://basercms.net/news/index.rss',
         // インストールマニュアル
-        // TODO ucmitz リンク先を準備した上で変更要
-        'installManual' => 'https://wiki.basercms.net/%E3%82%A4%E3%83%B3%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AB%E3%82%AC%E3%82%A4%E3%83%89',
+        'installManual' => 'https://baserproject.github.io/5/introduce/',
         // アップデートマニュアル
-        // TODO ucmitz リンク先を準備した上で変更要
-        'updateManual' => 'https://wiki.basercms.net/%E3%83%90%E3%83%BC%E3%82%B8%E3%83%A7%E3%83%B3%E3%82%A2%E3%83%83%E3%83%97%E3%82%AC%E3%82%A4%E3%83%89'
+        'updateManual' => 'https://baserproject.github.io/5/operation/update'
     ],
 
     /**

--- a/plugins/baser-core/tests/TestCase/View/Helper/BcToolbarHelperTest.php
+++ b/plugins/baser-core/tests/TestCase/View/Helper/BcToolbarHelperTest.php
@@ -304,12 +304,12 @@ class BcToolbarHelperTest extends BcTestCase
         $this->assertEquals('https://localhost/', $bcToolbar->getLogoLink());
         // アップデーター
         Configure::write('BcRequest.isUpdater', true);
-        $this->assertEquals('https://wiki.basercms.net/%E3%83%90%E3%83%BC%E3%82%B8%E3%83%A7%E3%83%B3%E3%82%A2%E3%83%83%E3%83%97%E3%82%AC%E3%82%A4%E3%83%89', $bcToolbar->getLogoLink());
+        $this->assertEquals('https://baserproject.github.io/5/operation/update', $bcToolbar->getLogoLink());
         Configure::write('BcRequest.isUpdater', false);
         // インストーラー
         Configure::write('BcRequest.isInstalled', false);
         $bcToolbar = new BcToolbarHelper(new View(null, null, null, ['name' => 'Installations']));
-        $this->assertEquals('https://wiki.basercms.net/%E3%82%A4%E3%83%B3%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AB%E3%82%AC%E3%82%A4%E3%83%89', $bcToolbar->getLogoLink());
+        $this->assertEquals('https://baserproject.github.io/5/introduce/', $bcToolbar->getLogoLink());
         Configure::write('BcRequest.isInstalled', true);
     }
 


### PR DESCRIPTION
インストール・アップデートマニュアルのリンクを更新したためご確認お願いします。

<img width="1412" alt="スクリーンショット_2023-05-02_17_05_09" src="https://user-images.githubusercontent.com/30764014/235613793-88389219-fb54-4d70-9c02-014a5ff656d9.png">

アップデートマニュアルの方は設定書き換えで表示して確認しました。

```
Configure::write('BcRequest.isUpdater', true);
```

ただ、4系と5系ではアップデートの仕組みが異なるようですので、この設定値が必要かどうかは要検討かと思います。