### PR TITLE
fix #2173 [コンテンツ]同一階層にindexがなくてもindex_1があるとindexが作成できない問題を解決

### DIFF
--- a/lib/Baser/Model/Content.php
+++ b/lib/Baser/Model/Content.php
@@ -311,7 +311,7 @@ class Content extends AppModel
 			foreach($datas as $data) {
 				if ($name === $data) {
 					$numbers[1] = 1;
-				} elseif (preg_match("/^" . preg_quote($name, '/') . "_([0-9]+)$/s", $data, $matches)) {
+				} elseif ($data !== $name. '_1' && preg_match("/^" . preg_quote($name, '/') . "_([0-9]+)$/s", $data, $matches)) {
 					$numbers[$matches[1]] = true;
 				}
 			}


### PR DESCRIPTION
@ryuring 
@gondoh 
@kaburk 
_1がついているname値と同nameでないかどうかの判定を入れました。
ご確認の上マージお願いします。