### PR TITLE
fix #2177 PHP5.4に対応していない問題を解決 [ver4]

### DIFF
--- a/lib/Baser/Lib/Error/BcErrorHandler.php
+++ b/lib/Baser/Lib/Error/BcErrorHandler.php
@@ -336,7 +336,8 @@ class BcErrorHandler extends ErrorHandler
 			$rs[] = 'Referer: ' . env('HTTP_REFERER');
 		}
 
-		if (empty(Configure::read('Error.trace'))) {
+		$trace = Configure::read('Error.trace');
+		if (empty($trace)) {
 			return implode("\n", $rs);
 		}
 


### PR DESCRIPTION
@ryuring 
@gondoh 
@kaburk 
ここを修正すれば、php5.4で開いたときにいきなり画面が真っ白になることがなくなります。
お手数ですが、ご確認の上マージお願いします。
