### PR TITLE
fix #1930 FrozenTime::setToStringFormat 書式変更

### DIFF
--- a/plugins/baser-core/src/Model/Table/AppTable.php
+++ b/plugins/baser-core/src/Model/Table/AppTable.php
@@ -147,7 +147,7 @@ class AppTable extends Table
     public function initialize(array $config): void
     {
         parent::initialize($config);
-        FrozenTime::setToStringFormat('yyyy/MM/dd HH:mm:ss');
+        FrozenTime::setToStringFormat('yyyy-MM-dd HH:mm:ss');
     }
 
     /**

--- a/plugins/baser-core/tests/TestCase/Model/Table/AppTableTest.php
+++ b/plugins/baser-core/tests/TestCase/Model/Table/AppTableTest.php
@@ -68,8 +68,8 @@ class AppTableTest extends BcTestCase
         $Permission = new TablePermissionsTable();
 
         $this->assertMatchesRegularExpression(
-            // yyyy/MM/dd HH:mm:ssのパターン
-            '{^[0-9]{4}/(0[1-9]|1[0-2])/(0[1-9]|[12][0-9]|3[01])\s([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$}',
+            // yyyy-MM-dd HH:mm:ssのパターン
+            '{^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])\s([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$}',
             $Permission->find()->first()->created->__toString()
         );
     }

--- a/plugins/baser-core/tests/TestCase/Model/Table/ContentsTableTest.php
+++ b/plugins/baser-core/tests/TestCase/Model/Table/ContentsTableTest.php
@@ -771,8 +771,8 @@ class ContentsTableTest extends BcTestCase
                     'self_publish_end' => new FrozenTime('2022/12/30 00:00:00'),
                 ],
                 [
-                    'publish_begin' => '2022/12/01 00:00:00',
-                    'publish_end' => '2022/12/30 00:00:00',
+                    'publish_begin' => '2022-12-01 00:00:00',
+                    'publish_end' => '2022-12-30 00:00:00',
                 ]
             ],
             // nullになる場合


### PR DESCRIPTION
issue: https://github.com/baserproject/basercms/issues/1930

BcFormHelper->dateTimePickerのhiddenの日時が「Y/m/d H:i:s」形式だと、エンティティ変換時にnullになってしまうため「Y-m-d H:i:s」に変更しています。

「Y/m/d H:i:s」だと以下のフォーマットに含まれていないためnullになります。
https://github.com/cakephp/cakephp/blob/4.x/src/Database/Type/DateTimeType.php

```
protected $_marshalFormats = [
    'Y-m-d H:i',
    'Y-m-d H:i:s',
    'Y-m-d\TH:i',
    'Y-m-d\TH:i:s',
    'Y-m-d\TH:i:sP',
];
```

日付の取り扱いは「Y-m-d」の方が統一されているようです。
https://ja.wikipedia.org/wiki/%E6%97%A5%E4%BB%98#%E5%B9%B4%E6%9C%88%E6%97%A5%E3%81%AE%E9%A0%86%E5%BA%8F%E3%81%AE%E6%B7%B7%E4%B9%B1

基本的に、日付の取り回しは「Y-m-d」の形式で、必要に応じて表示のタイミングでformatするのが良いのではと思います。

ご確認お願いします。
