### PR TITLE
jwtトークンタイプチェック修正

### DIFF
--- a/plugins/baser-core/src/Controller/Api/Admin/BcAdminApiController.php
+++ b/plugins/baser-core/src/Controller/Api/Admin/BcAdminApiController.php
@@ -79,7 +79,7 @@ class BcAdminApiController extends BcApiController
         if ($auth instanceof JwtAuthenticator) {
             $payload = $auth->getPayload();
             if ($payload->token_type !== 'access_token' && $this->getRequest()->getParam('action') !== 'refresh_token') {
-                $this->setResponse($this->response->withStatus(401));
+                return $this->response->withStatus(401);
             }
         }
 


### PR DESCRIPTION
APIにrefresh_tokenを送信した場合401ステータスが返却されるのですが、処理自体は実行されていたので止めています。
ご確認お願いします。