### PR TITLE
fix #2231 MailFieldsService::create のユニットテストを実装

### DIFF
--- a/plugins/bc-mail/src/Service/MailFieldsService.php
+++ b/plugins/bc-mail/src/Service/MailFieldsService.php
@@ -148,6 +148,7 @@ class MailFieldsService implements MailFieldsServiceInterface
      *
      * @checked
      * @noTodo
+     * @unitTest
      */
     public function create(array $postData)
     {

--- a/plugins/bc-mail/tests/TestCase/Service/MailFieldsServiceTest.php
+++ b/plugins/bc-mail/tests/TestCase/Service/MailFieldsServiceTest.php
@@ -11,7 +11,9 @@
 
 namespace BcMail\Test\TestCase\Service;
 
+use BaserCore\Test\Scenario\InitAppScenario;
 use BaserCore\TestSuite\BcTestCase;
+use BcMail\Test\Scenario\MailContentsScenario;
 use BcMail\Test\Scenario\MailFieldsScenario;
 use BcMail\Service\MailFieldsService;
 use BcMail\Service\MailFieldsServiceInterface;
@@ -39,6 +41,13 @@ class MailFieldsServiceTest extends BcTestCase
      */
     public $fixtures = [
         'plugin.BcMail.Factory/MailFields',
+        'plugin.BcMail.Factory/MailContents',
+        'plugin.BaserCore.Factory/Contents',
+        'plugin.BaserCore.Factory/Sites',
+        'plugin.BaserCore.Factory/SiteConfigs',
+        'plugin.BaserCore.Factory/Users',
+        'plugin.BaserCore.Factory/UsersUserGroups',
+        'plugin.BaserCore.Factory/UserGroups'
     ];
 
     /**
@@ -108,9 +117,21 @@ class MailFieldsServiceTest extends BcTestCase
     /**
      * test create
      */
-    public function test_create()
+    public function testCreate()
     {
-        $this->markTestIncomplete('このテストは、まだ実装されていません。');
+        $this->loadFixtureScenario(InitAppScenario::class);
+        $this->loadFixtureScenario(MailContentsScenario::class);
+        $postData = [
+            'id' => 1,
+            'mail_content_id' => 1,
+            'name' => '性',
+            'source' => '男性|女性',
+            'type' => 'text',
+            'field_name' => 'name_1',
+            'use_field' => 1,
+        ];
+        $result = $this->MailFieldsService->create($postData);
+        $this->assertEquals('name_1', $result->field_name);
     }
 
     /**

--- a/plugins/bc-mail/tests/TestCase/Service/MailFieldsServiceTest.php
+++ b/plugins/bc-mail/tests/TestCase/Service/MailFieldsServiceTest.php
@@ -127,7 +127,7 @@ class MailFieldsServiceTest extends BcTestCase
             'mail_content_id' => '1',
             'no' => '1',
             'name' => '姓漢字',
-            'field_name' => 'name_1',
+            'field_name' => 'test',
             'type' => 'text',
             'head' => 'お名前',
             'attention' => '',

--- a/plugins/bc-mail/tests/TestCase/Service/MailFieldsServiceTest.php
+++ b/plugins/bc-mail/tests/TestCase/Service/MailFieldsServiceTest.php
@@ -13,6 +13,7 @@ namespace BcMail\Test\TestCase\Service;
 
 use BaserCore\Test\Scenario\InitAppScenario;
 use BaserCore\TestSuite\BcTestCase;
+use BcMail\Service\MailMessagesServiceInterface;
 use BcMail\Test\Scenario\MailContentsScenario;
 use BcMail\Test\Scenario\MailFieldsScenario;
 use BcMail\Service\MailFieldsService;
@@ -122,13 +123,25 @@ class MailFieldsServiceTest extends BcTestCase
         $this->loadFixtureScenario(InitAppScenario::class);
         $this->loadFixtureScenario(MailContentsScenario::class);
         $postData = [
-            'id' => 1,
-            'mail_content_id' => 1,
-            'name' => '性',
-            'source' => '男性|女性',
-            'type' => 'text',
+            'id' => '1',
+            'mail_content_id' => '1',
+            'no' => '1',
+            'name' => '姓漢字',
             'field_name' => 'name_1',
+            'type' => 'text',
+            'head' => 'お名前',
+            'attention' => '',
+            'before_attachment' => '<small>[姓]</small>',
+            'after_attachment' => '',
+            'options' => '',
+            'class' => '',
+            'default_value' => '',
+            'description' => '',
+            'group_field' => 'name',
+            'group_valid' => 'name',
+            'valid_ex' => '',
             'use_field' => 1,
+            'sort' => '1',
         ];
         $result = $this->MailFieldsService->create($postData);
         $this->assertEquals('name_1', $result->field_name);


### PR DESCRIPTION
MailFieldsService::create のユニットテストを実装 #2231