### PR TITLE
fix #2230 MailFieldsService::getNew のユニットテスト

### DIFF
--- a/plugins/bc-mail/src/Service/MailFieldsService.php
+++ b/plugins/bc-mail/src/Service/MailFieldsService.php
@@ -131,6 +131,7 @@ class MailFieldsService implements MailFieldsServiceInterface
      *
      * @checked
      * @noTodo
+     * @unitTest
      */
     public function getNew($mailContentId)
     {

--- a/plugins/bc-mail/tests/TestCase/Service/MailFieldsServiceTest.php
+++ b/plugins/bc-mail/tests/TestCase/Service/MailFieldsServiceTest.php
@@ -100,9 +100,12 @@ class MailFieldsServiceTest extends BcTestCase
     /**
      * test getNew
      */
-    public function test_getNew()
+    public function testGetNew()
     {
-        $this->markTestIncomplete('このテストは、まだ実装されていません。');
+        $result = $this->MailFieldsService->getNew(1);
+        $this->assertInstanceOf('BcMail\Model\Entity\MailField', $result);
+        $result = $this->MailFieldsService->getNew(99);
+        $this->assertEquals(99, $result->mail_content_id);
     }
 
     /**


### PR DESCRIPTION
MailFieldsService::getNew のユニットテストを実装 #2230