### PR TITLE
fix #2229 MailFieldsService::getIndex のユニットテストを実装

### DIFF
--- a/plugins/bc-blog/tests/TestCase/Service/BlogTagsServiceTest.php
+++ b/plugins/bc-blog/tests/TestCase/Service/BlogTagsServiceTest.php
@@ -151,7 +151,7 @@ class BlogTagsServiceTest extends BcTestCase
         $whereSql = $result->clause('where')->sql(new ValueBinder());
         $this->assertStringContainsString('BlogTags.name like', $whereSql);
         $this->assertStringContainsString('Contents.site_id =', $whereSql);
-        $this->assertStringContainsString('Content.url =', $whereSql);
+        $this->assertStringContainsString('Contents.url =', $whereSql);
         $sortSql = $result->clause('order')->sql(new ValueBinder());
         $this->assertStringContainsString('BlogTags.name ASC', $sortSql);
         $params['direction'] = 'DESC';

--- a/plugins/bc-mail/src/Service/MailFieldsService.php
+++ b/plugins/bc-mail/src/Service/MailFieldsService.php
@@ -77,6 +77,7 @@ class MailFieldsService implements MailFieldsServiceInterface
      * 一覧データ取得
      * @checked
      * @noTodo
+     * @unitTest
      */
     public function getIndex(int $mailContentId, array $queryParams = [])
     {

--- a/plugins/bc-mail/tests/TestCase/Service/MailFieldsServiceTest.php
+++ b/plugins/bc-mail/tests/TestCase/Service/MailFieldsServiceTest.php
@@ -81,30 +81,32 @@ class MailFieldsServiceTest extends BcTestCase
      */
     public function testGetIndex()
     {
+        //　準備
         $this->loadFixtureScenario(MailFieldsScenario::class);
         $this->loadFixtureScenario(MailContentsScenario::class);
+        // パラメータなしでテストする
         $queryParams = [];
         $result = $this->MailFieldsService->getIndex(1, $queryParams);
         $this->assertCount(3, $result->all());
-
+        // レコード数を制限するのをテストする
         $queryParams = [
             'limit' => '1'
         ];
         $result = $this->MailFieldsService->getIndex(1, $queryParams);
         $this->assertCount(1, $result->all());
-
+        // フィールドを利用するレコードの取得をテストする
         $queryParams = [
             'use_field' => 1
         ];
         $result = $this->MailFieldsService->getIndex(1, $queryParams);
         $this->assertCount(3, $result->all());
-
+        // フィールドを利用しないレコードの取得をテストする
         $queryParams = [
             'use_field' => 0
         ];
         $result = $this->MailFieldsService->getIndex(1, $queryParams);
         $this->assertCount(0, $result->all());
-
+        // ステータスが公開するレコードの取得をテストする
         $queryParams = [
             'status' => 'publish'
         ];

--- a/plugins/bc-mail/tests/TestCase/Service/MailFieldsServiceTest.php
+++ b/plugins/bc-mail/tests/TestCase/Service/MailFieldsServiceTest.php
@@ -12,6 +12,7 @@
 namespace BcMail\Test\TestCase\Service;
 
 use BaserCore\TestSuite\BcTestCase;
+use BcMail\Test\Scenario\MailContentsScenario;
 use BcMail\Test\Scenario\MailFieldsScenario;
 use BcMail\Service\MailFieldsService;
 use BcMail\Service\MailFieldsServiceInterface;
@@ -78,9 +79,37 @@ class MailFieldsServiceTest extends BcTestCase
     /**
      * test getIndex
      */
-    public function test_getIndex()
+    public function testGetIndex()
     {
-        $this->markTestIncomplete('このテストは、まだ実装されていません。');
+        $this->loadFixtureScenario(MailFieldsScenario::class);
+        $this->loadFixtureScenario(MailContentsScenario::class);
+        $queryParams = [];
+        $result = $this->MailFieldsService->getIndex(1, $queryParams);
+        $this->assertCount(3, $result->all());
+
+        $queryParams = [
+            'limit' => '1'
+        ];
+        $result = $this->MailFieldsService->getIndex(1, $queryParams);
+        $this->assertCount(1, $result->all());
+
+        $queryParams = [
+            'use_field' => 1
+        ];
+        $result = $this->MailFieldsService->getIndex(1, $queryParams);
+        $this->assertCount(3, $result->all());
+
+        $queryParams = [
+            'use_field' => 0
+        ];
+        $result = $this->MailFieldsService->getIndex(1, $queryParams);
+        $this->assertCount(0, $result->all());
+
+        $queryParams = [
+            'status' => 'publish'
+        ];
+        $result = $this->MailFieldsService->getIndex(1, $queryParams);
+        $this->assertCount(3, $result->all());
     }
 
     /**
@@ -102,7 +131,7 @@ class MailFieldsServiceTest extends BcTestCase
      */
     public function test_getNew()
     {
-        $this->markTestIncomplete('このテストは、まだ実装されていません。');
+
     }
 
     /**


### PR DESCRIPTION
MailFieldsService::getIndex のユニットテストを実装 #2229