### PR TITLE
BcAdminFormHelper::controlでnumberの入力フィールドを出力できるように調整

### DIFF
--- a/plugins/baser-core/src/View/Helper/BcAdminFormHelper.php
+++ b/plugins/baser-core/src/View/Helper/BcAdminFormHelper.php
@@ -80,6 +80,7 @@ class BcAdminFormHelper extends BcFormHelper
                 case 'datePicker':
                 case 'tel':
                 case 'email':
+                case 'number':
                     $class = 'bca-textbox__input';
                     $containerClass = 'bca-textbox';
                     $labelClass = 'bca-textbox__label';


### PR DESCRIPTION
`<?php echo $this->BcAdminForm->control('sample', ['type' => 'number']) ?>`でも`'type' => 'text'`と同様のclassが適用されるように調整しました。
