### PR TITLE
fix #2240 MailFieldsService::update のユニットテストを実装 

### DIFF
--- a/plugins/bc-mail/src/Service/MailFieldsService.php
+++ b/plugins/bc-mail/src/Service/MailFieldsService.php
@@ -182,6 +182,7 @@ class MailFieldsService implements MailFieldsServiceInterface
      * @param array $postData
      * @checked
      * @noTodo
+     * @unitTest
      */
     public function update(EntityInterface $entity, array $postData)
     {

--- a/plugins/bc-mail/tests/TestCase/Service/MailFieldsServiceTest.php
+++ b/plugins/bc-mail/tests/TestCase/Service/MailFieldsServiceTest.php
@@ -159,7 +159,27 @@ class MailFieldsServiceTest extends BcTestCase
      */
     public function test_update()
     {
-        $this->markTestIncomplete('このテストは、まだ実装されていません。');
+        // 準備
+        $this->loadFixtureScenario(MailFieldsScenario::class);
+        $this->loadFixtureScenario(MailContentsScenario::class);
+        $mailField = $this->MailFieldsService->get(1);
+        $postData = [
+            'name' => 'Nghiem',
+            'type' => 'radio',
+            'source' => '1|2|3'
+        ];
+        // 正常系実行
+        $result = $this->MailFieldsService->update($mailField, $postData);
+        $this->assertEquals('Nghiem', $result->name);
+        $this->assertEquals('radio', $result->type);
+        $this->assertEquals("1\n2\n3", $result->source);
+        // 異常系実行
+        $postData = [
+            'field_name' => '',
+            'name' => '',
+        ];
+        $this->expectException("Cake\ORM\Exception\PersistenceFailedException");
+        $this->MailFieldsService->update($mailField, $postData);
     }
 
     /**


### PR DESCRIPTION
fix #2240 MailFieldsService::update のユニットテストを実装 