### PR TITLE
fix #2286 PHP 8.2 deprecation notices in CakeEvent class.

### DIFF
--- a/lib/Cake/Event/CakeEvent.php
+++ b/lib/Cake/Event/CakeEvent.php
@@ -24,6 +24,30 @@
 class CakeEvent {
 
 /**
+ * PHP 8.2 deprecation notice: added to avoid `Creation of dynamic property ... is deprecated.`
+ * @var mixed|true
+ */
+	public $break;
+
+/**
+ * PHP 8.2 deprecation notice: added to avoid `Creation of dynamic property ... is deprecated.`
+ * @var mixed|true
+ */
+	public $modParams;
+
+/**
+ * PHP 8.2 deprecation notice: added to avoid `Creation of dynamic property ... is deprecated.`
+ * @var array|mixed
+ */
+	public $breakOn;
+
+/**
+ * PHP 8.2 deprecation notice: added to avoid `Creation of dynamic property ... is deprecated.`
+ * @var array|mixed
+ */
+	public $omitSubject;
+
+/**
  * Name of the event
  *
  * @var string


### PR DESCRIPTION
php8.2対応の調整になります。