### PR TITLE
php8以上でパスワード再発行完了画面でエラーがでる問題解決

### DIFF
--- a/app/webroot/theme/admin-third/Users/admin/reset_password.php
+++ b/app/webroot/theme/admin-third/Users/admin/reset_password.php
@@ -27,7 +27,7 @@
 			$this->BcBaser->link(
 				__d('baser', 'アカウント設定'),
 				[
-					SessionHelper::read('Auth.Admin.id'),
+					$this->Session->read('Auth.Admin.id'),
 					'admin' => true,
 					'plugin' => null,
 					'controller' => 'users',


### PR DESCRIPTION
[issue](https://github.com/baserproject/basercms/issues/2282)はこちらです。

静的関数でない関数を静的関数として呼び出そうとしてエラーが出ていました。