### PR TITLE
fix #2304  ブログ記事一覧画面で削除→キャンセルするとローディングが消えない件を修正

### DIFF
--- a/plugins/bc-admin-third/templates/Admin/element/Permissions/index_row.php
+++ b/plugins/bc-admin-third/templates/Admin/element/Permissions/index_row.php
@@ -67,7 +67,7 @@ $type = (isset($permissionGroupTypes[$permission->permission_group->type]))? $pe
       ['action' => 'unpublish', $permission->id],
       ['block' => true,
         'title' => __d('baser_core', '無効'),
-        'class' => 'btn-unpublish bca-btn-icon bca-loading',
+        'class' => 'btn-unpublish bca-btn-icon',
         'data-bca-btn-type' => 'unpublish',
         'data-bca-btn-size' => 'lg']
     ) ?>
@@ -77,7 +77,7 @@ $type = (isset($permissionGroupTypes[$permission->permission_group->type]))? $pe
       ['action' => 'publish', $permission->id],
       ['block' => true,
         'title' => __d('baser_core', '有効'),
-        'class' => 'btn-publish bca-btn-icon bca-loading',
+        'class' => 'btn-publish bca-btn-icon',
         'data-bca-btn-type' => 'publish',
         'data-bca-btn-size' => 'lg']
     ) ?>
@@ -98,7 +98,7 @@ $type = (isset($permissionGroupTypes[$permission->permission_group->type]))? $pe
       ['block' => true,
         'confirm' => __d('baser_core', "{0} を複製してもいいですか？", $permission->name),
         'title' => __d('baser_core', '複製'),
-        'class' => 'btn-copy bca-btn-icon bca-loading',
+        'class' => 'btn-copy bca-btn-icon',
         'data-bca-btn-type' => 'copy',
         'data-bca-btn-size' => 'lg']
     ) ?>
@@ -108,7 +108,7 @@ $type = (isset($permissionGroupTypes[$permission->permission_group->type]))? $pe
       [
         'confirm' => __d('baser_core', "{0} を本当に削除してもいいですか？", $permission->name),
         'title' => __d('baser_core', '削除'),
-        'class' => 'btn-delete bca-btn-icon bca-loading',
+        'class' => 'btn-delete bca-btn-icon',
         'data-bca-btn-type' => 'delete',
         'data-bca-btn-size' => 'lg']
     ) ?>

--- a/plugins/bc-admin-third/templates/plugin/BcBlog/Admin/element/BlogPosts/index_row.php
+++ b/plugins/bc-admin-third/templates/plugin/BcBlog/Admin/element/BlogPosts/index_row.php
@@ -103,7 +103,7 @@ use Cake\Utility\Hash;
       ['action' => 'unpublish', $post->blog_content->id, $post->id],
       [
         'title' => __d('baser_core', '非公開'),
-        'class' => 'btn-unpublish bca-btn-icon bca-loading',
+        'class' => 'btn-unpublish bca-btn-icon',
         'data-bca-btn-type' => 'unpublish',
         'data-bca-btn-size' => 'lg']
     ) ?>
@@ -113,7 +113,7 @@ use Cake\Utility\Hash;
       ['action' => 'publish', $post->blog_content->id, $post->id],
       [
         'title' => __d('baser_core', '公開'),
-        'class' => 'btn-publish bca-btn-icon bca-loading',
+        'class' => 'btn-publish bca-btn-icon',
         'data-bca-btn-type' => 'publish',
         'data-bca-btn-size' => 'lg']
     ) ?>
@@ -131,7 +131,7 @@ use Cake\Utility\Hash;
       ['action' => 'copy', $post->blog_content->id, $post->id],
       [
         'title' => __d('baser_core', 'コピー'),
-        'class' => 'btn-copy bca-btn-icon bca-loading',
+        'class' => 'btn-copy bca-btn-icon',
         'data-bca-btn-type' => 'copy',
         'data-bca-btn-size' => 'lg']
     ) ?>
@@ -141,7 +141,7 @@ use Cake\Utility\Hash;
       [
         'confirm' => __d('baser_core', "{0} を本当に削除してもいいですか？", $post->title),
         'title' => __d('baser_core', '削除'),
-        'class' => 'btn-delete bca-btn-icon bca-loading',
+        'class' => 'btn-delete bca-btn-icon',
         'data-bca-btn-type' => 'delete',
         'data-bca-btn-size' => 'lg']
     ) ?>


### PR DESCRIPTION
よろしくお願いします。
同様の箇所が他にもあったので合わせて変更しています。