### PR TITLE
BcEventDispatcherTraitをAppTableに追加

### DIFF
--- a/plugins/baser-core/src/Model/Table/AppTable.php
+++ b/plugins/baser-core/src/Model/Table/AppTable.php
@@ -23,12 +23,14 @@ use BaserCore\Annotation\NoTodo;
 use BaserCore\Annotation\Checked;
 use BaserCore\Annotation\UnitTest;
 use Cake\Datasource\EntityInterface;
+use BaserCore\Event\BcEventDispatcherTrait;
 
 /**
  * Class AppTable
  */
 class AppTable extends Table
 {
+    use BcEventDispatcherTrait;
 
     /**
      * 一時イベント

--- a/plugins/baser-core/src/Model/Table/ContentFoldersTable.php
+++ b/plugins/baser-core/src/Model/Table/ContentFoldersTable.php
@@ -12,7 +12,6 @@
 namespace BaserCore\Model\Table;
 
 use ArrayObject;
-use BaserCore\Event\BcEventDispatcherTrait;
 use BaserCore\Model\Entity\Content;
 use BcSearchIndex\Service\SearchIndexesService;
 use BcSearchIndex\Service\SearchIndexesServiceInterface;
@@ -36,7 +35,6 @@ class ContentFoldersTable extends AppTable
      * Trait
      */
     use BcContainerTrait;
-    use BcEventDispatcherTrait;
 
     /**
      * 変更前ステータス

--- a/plugins/baser-core/src/Model/Table/PagesTable.php
+++ b/plugins/baser-core/src/Model/Table/PagesTable.php
@@ -21,7 +21,6 @@ use Cake\Event\EventInterface;
 use Cake\Validation\Validator;
 use Cake\Datasource\EntityInterface;
 use BaserCore\Utility\BcContainerTrait;
-use BaserCore\Event\BcEventDispatcherTrait;
 use BaserCore\Annotation\Checked;
 use BaserCore\Annotation\UnitTest;
 use BaserCore\Annotation\NoTodo;
@@ -35,7 +34,6 @@ class PagesTable extends AppTable
     /**
      * Trait
      */
-    use BcEventDispatcherTrait;
     use BcContainerTrait;
 
     /**

--- a/plugins/baser-core/src/Model/Table/PasswordRequestsTable.php
+++ b/plugins/baser-core/src/Model/Table/PasswordRequestsTable.php
@@ -11,7 +11,6 @@
 
 namespace BaserCore\Model\Table;
 
-use BaserCore\Event\BcEventDispatcherTrait;
 use BaserCore\Model\Entity\User;
 use Cake\Datasource\EntityInterface;
 use Cake\ORM\Association\BelongsTo;
@@ -35,12 +34,6 @@ use BaserCore\Annotation\Checked;
  */
 class PasswordRequestsTable extends AppTable
 {
-
-    /**
-     * Trait
-     */
-    use BcEventDispatcherTrait;
-
     /**
      * Initialize
      *

--- a/plugins/baser-core/src/Model/Table/PluginsTable.php
+++ b/plugins/baser-core/src/Model/Table/PluginsTable.php
@@ -11,7 +11,6 @@
 
 namespace BaserCore\Model\Table;
 
-use BaserCore\Event\BcEventDispatcherTrait;
 use BaserCore\Utility\BcUtil;
 use Cake\Core\Configure;
 use Cake\ORM\TableRegistry;
@@ -27,12 +26,6 @@ use Cake\Validation\Validator;
  */
 class PluginsTable extends AppTable
 {
-
-    /**
-     * Trait
-     */
-    use BcEventDispatcherTrait;
-
     /**
      * Initialize
      *

--- a/plugins/baser-core/src/Model/Table/SiteConfigsTable.php
+++ b/plugins/baser-core/src/Model/Table/SiteConfigsTable.php
@@ -11,7 +11,6 @@
 
 namespace BaserCore\Model\Table;
 
-use BaserCore\Event\BcEventDispatcherTrait;
 use BaserCore\Model\Behavior\BcKeyValueBehavior;
 use BaserCore\Model\Entity\SiteConfig;
 use Cake\Validation\Validator;
@@ -30,12 +29,6 @@ use BaserCore\Utility\BcUtil;
  */
 class SiteConfigsTable extends AppTable
 {
-
-    /**
-     * Trait
-     */
-    use BcEventDispatcherTrait;
-
     /**
      * Initialize
      *

--- a/plugins/baser-core/src/Model/Table/SitesTable.php
+++ b/plugins/baser-core/src/Model/Table/SitesTable.php
@@ -27,7 +27,6 @@ use BaserCore\Utility\BcContainerTrait;
 use Cake\Datasource\ResultSetInterface;
 use BaserCore\Service\SiteConfigsService;
 use BaserCore\Utility\BcAbstractDetector;
-use BaserCore\Event\BcEventDispatcherTrait;
 use BaserCore\Service\ContentsServiceInterface;
 use BaserCore\Service\ContentFoldersServiceInterface;
 use BaserCore\Annotation\Note;
@@ -47,7 +46,6 @@ class SitesTable extends AppTable
     /**
      * Trait
      */
-    use BcEventDispatcherTrait;
     use BcContainerTrait;
 
     /**

--- a/plugins/baser-core/src/Model/Table/UserGroupsTable.php
+++ b/plugins/baser-core/src/Model/Table/UserGroupsTable.php
@@ -11,7 +11,6 @@
 
 namespace BaserCore\Model\Table;
 
-use BaserCore\Event\BcEventDispatcherTrait;
 use BaserCore\Model\Entity\UserGroup;
 use Cake\Core\Configure;
 use Cake\ORM\Association\BelongsToMany;
@@ -44,12 +43,6 @@ use BaserCore\Annotation\Checked;
  */
 class UserGroupsTable extends AppTable
 {
-
-    /**
-     * Trait
-     */
-    use BcEventDispatcherTrait;
-
     /**
      * Initialize method
      *

--- a/plugins/baser-core/src/Model/Table/UsersTable.php
+++ b/plugins/baser-core/src/Model/Table/UsersTable.php
@@ -24,7 +24,6 @@ use BaserCore\View\BcAdminAppView;
 use Cake\ORM\Association\BelongsTo;
 use Cake\Datasource\EntityInterface;
 use Cake\ORM\Behavior\TimestampBehavior;
-use BaserCore\Event\BcEventDispatcherTrait;
 use BaserCore\Annotation\NoTodo;
 use BaserCore\Annotation\Checked;
 use BaserCore\Annotation\UnitTest;
@@ -43,12 +42,6 @@ use BaserCore\Annotation\UnitTest;
  */
 class UsersTable extends AppTable
 {
-
-    /**
-     * Trait
-     */
-    use BcEventDispatcherTrait;
-
     /**
      * Initialize
      *

--- a/plugins/bc-blog/src/Model/Table/BlogCategoriesTable.php
+++ b/plugins/bc-blog/src/Model/Table/BlogCategoriesTable.php
@@ -11,7 +11,6 @@
 
 namespace BcBlog\Model\Table;
 
-use BaserCore\Event\BcEventDispatcherTrait;
 use BaserCore\Service\PermissionsService;
 use BaserCore\Service\PermissionsServiceInterface;
 use BaserCore\Utility\BcContainerTrait;
@@ -36,7 +35,6 @@ class BlogCategoriesTable extends BlogAppTable
      * Trait
      */
     use BcContainerTrait;
-    use BcEventDispatcherTrait;
 
     /**
      * バリデーション設定

--- a/plugins/bc-blog/src/Model/Table/BlogContentsTable.php
+++ b/plugins/bc-blog/src/Model/Table/BlogContentsTable.php
@@ -11,7 +11,6 @@
 
 namespace BcBlog\Model\Table;
 
-use BaserCore\Event\BcEventDispatcherTrait;
 use BaserCore\Model\Entity\Content;
 use BaserCore\Model\Table\ContentsTable;
 use BaserCore\Utility\BcUtil;
@@ -33,12 +32,6 @@ use Cake\Validation\Validator;
  */
 class BlogContentsTable extends BlogAppTable
 {
-
-    /**
-     * Trait
-     */
-    use BcEventDispatcherTrait;
-
     /**
      * Validation Default
      *

--- a/plugins/bc-blog/src/Model/Table/BlogPostsTable.php
+++ b/plugins/bc-blog/src/Model/Table/BlogPostsTable.php
@@ -16,7 +16,6 @@ use BaserCore\Annotation\NoTodo;
 use BaserCore\Annotation\Checked;
 use BaserCore\Annotation\UnitTest;
 use BaserCore\Error\BcException;
-use BaserCore\Event\BcEventDispatcherTrait;
 use BaserCore\Model\Entity\Content;
 use BaserCore\Model\Table\UsersTable;
 use BaserCore\Utility\BcUtil;
@@ -42,12 +41,6 @@ use Cake\Validation\Validator;
  */
 class BlogPostsTable extends BlogAppTable
 {
-
-    /**
-     * Trait
-     */
-    use BcEventDispatcherTrait;
-
     /**
      * 検索テーブルへの保存可否
      *
@@ -439,7 +432,7 @@ class BlogPostsTable extends BlogAppTable
      * @return array
      * @checked
      * @noTodo
-     * @unitTest 
+     * @unitTest
      */
     protected function _getEntryDatesConditions($blogContentId, $year, $month)
     {

--- a/plugins/bc-blog/src/Model/Table/BlogTagsTable.php
+++ b/plugins/bc-blog/src/Model/Table/BlogTagsTable.php
@@ -11,7 +11,6 @@
 
 namespace BcBlog\Model\Table;
 
-use BaserCore\Event\BcEventDispatcherTrait;
 use BaserCore\Annotation\UnitTest;
 use BaserCore\Annotation\NoTodo;
 use BaserCore\Annotation\Checked;
@@ -33,8 +32,6 @@ class BlogTagsTable extends BlogAppTable
     /**
      * Trait
      */
-    use BcEventDispatcherTrait;
-
     use BcContainerTrait;
 
     /**

--- a/plugins/bc-content-link/src/Model/Table/ContentLinksTable.php
+++ b/plugins/bc-content-link/src/Model/Table/ContentLinksTable.php
@@ -11,7 +11,6 @@
 
 namespace BcContentLink\Model\Table;
 
-use BaserCore\Event\BcEventDispatcherTrait;
 use BaserCore\Model\Entity\Content;
 use BaserCore\Model\Table\AppTable;
 use Cake\ORM\Exception\PersistenceFailedException;
@@ -27,9 +26,6 @@ use BaserCore\Annotation\UnitTest;
  */
 class ContentLinksTable extends AppTable
 {
-
-    use BcEventDispatcherTrait;
-
     /**
      * initialize
      *

--- a/plugins/bc-custom-content/src/Model/Table/CustomContentsTable.php
+++ b/plugins/bc-custom-content/src/Model/Table/CustomContentsTable.php
@@ -11,7 +11,6 @@
 
 namespace BcCustomContent\Model\Table;
 
-use BaserCore\Event\BcEventDispatcherTrait;
 use BaserCore\Model\Table\AppTable;
 use BaserCore\Annotation\UnitTest;
 use BaserCore\Annotation\NoTodo;
@@ -25,12 +24,6 @@ use Cake\Validation\Validator;
  */
 class CustomContentsTable extends AppTable
 {
-
-    /**
-     * Trait
-     */
-    use BcEventDispatcherTrait;
-
     /**
      * Initialize
      *

--- a/plugins/bc-custom-content/src/Model/Table/CustomEntriesTable.php
+++ b/plugins/bc-custom-content/src/Model/Table/CustomEntriesTable.php
@@ -12,7 +12,6 @@
 namespace BcCustomContent\Model\Table;
 
 use ArrayObject;
-use BaserCore\Event\BcEventDispatcherTrait;
 use BaserCore\Model\Entity\Content;
 use BaserCore\Model\Table\AppTable;
 use BaserCore\Annotation\UnitTest;
@@ -46,7 +45,6 @@ class CustomEntriesTable extends AppTable
     /**
      * Trait
      */
-    use BcEventDispatcherTrait;
     use BcContainerTrait;
 
     /**

--- a/plugins/bc-custom-content/src/Model/Table/CustomFieldsTable.php
+++ b/plugins/bc-custom-content/src/Model/Table/CustomFieldsTable.php
@@ -12,7 +12,6 @@
 namespace BcCustomContent\Model\Table;
 
 use ArrayObject;
-use BaserCore\Event\BcEventDispatcherTrait;
 use BaserCore\Model\Table\AppTable;
 use BaserCore\Annotation\UnitTest;
 use BaserCore\Annotation\NoTodo;
@@ -26,12 +25,6 @@ use Cake\Validation\Validator;
  */
 class CustomFieldsTable extends AppTable
 {
-
-    /**
-     * Trait
-     */
-    use BcEventDispatcherTrait;
-
     /**
      * Initialize
      *

--- a/plugins/bc-custom-content/src/Model/Table/CustomLinksTable.php
+++ b/plugins/bc-custom-content/src/Model/Table/CustomLinksTable.php
@@ -12,7 +12,6 @@
 namespace BcCustomContent\Model\Table;
 
 use ArrayObject;
-use BaserCore\Event\BcEventDispatcherTrait;
 use BaserCore\Model\Table\AppTable;
 use BaserCore\Annotation\UnitTest;
 use BaserCore\Annotation\NoTodo;
@@ -31,12 +30,6 @@ use Cake\Validation\Validator;
  */
 class CustomLinksTable extends AppTable
 {
-
-    /**
-     * Trait
-     */
-    use BcEventDispatcherTrait;
-
     /**
      * Initialize
      *

--- a/plugins/bc-custom-content/src/Model/Table/CustomTablesTable.php
+++ b/plugins/bc-custom-content/src/Model/Table/CustomTablesTable.php
@@ -11,7 +11,6 @@
 
 namespace BcCustomContent\Model\Table;
 
-use BaserCore\Event\BcEventDispatcherTrait;
 use BaserCore\Model\Table\AppTable;
 use BaserCore\Annotation\UnitTest;
 use BaserCore\Annotation\NoTodo;
@@ -26,12 +25,6 @@ use Cake\Validation\Validator;
  */
 class CustomTablesTable extends AppTable
 {
-
-    /**
-     * Trait
-     */
-    use BcEventDispatcherTrait;
-
     /**
      * Initialize
      *

--- a/plugins/bc-mail/src/Model/Table/MailConfigsTable.php
+++ b/plugins/bc-mail/src/Model/Table/MailConfigsTable.php
@@ -11,7 +11,6 @@
 
 namespace BcMail\Model\Table;
 
-use BaserCore\Event\BcEventDispatcherTrait;
 use Cake\Validation\Validator;
 use BaserCore\Annotation\UnitTest;
 use BaserCore\Annotation\NoTodo;
@@ -22,12 +21,6 @@ use BaserCore\Annotation\Checked;
  */
 class MailConfigsTable extends MailAppTable
 {
-
-    /**
-     * Trait
-     */
-    use BcEventDispatcherTrait;
-
     /**
      * Initialize
      *

--- a/plugins/bc-mail/src/Model/Table/MailContentsTable.php
+++ b/plugins/bc-mail/src/Model/Table/MailContentsTable.php
@@ -11,7 +11,6 @@
 
 namespace BcMail\Model\Table;
 
-use BaserCore\Event\BcEventDispatcherTrait;
 use BaserCore\Model\Entity\Content;
 use BaserCore\Utility\BcContainerTrait;
 use BcMail\Service\MailMessagesServiceInterface;
@@ -34,7 +33,6 @@ class MailContentsTable extends MailAppTable
     /**
      * Trait
      */
-    use BcEventDispatcherTrait;
     use BcContainerTrait;
 
     /**

--- a/plugins/bc-mail/src/Model/Table/MailFieldsTable.php
+++ b/plugins/bc-mail/src/Model/Table/MailFieldsTable.php
@@ -11,7 +11,6 @@
 
 namespace BcMail\Model\Table;
 
-use BaserCore\Event\BcEventDispatcherTrait;
 use Cake\Datasource\EntityInterface;
 use Cake\Validation\Validator;
 use BaserCore\Annotation\UnitTest;
@@ -25,12 +24,6 @@ use BaserCore\Annotation\Checked;
  */
 class MailFieldsTable extends MailAppTable
 {
-
-    /**
-     * Trait
-     */
-    use BcEventDispatcherTrait;
-
     /**
      * Initialize method
      *

--- a/plugins/bc-search-index/src/Model/Table/SearchIndexesTable.php
+++ b/plugins/bc-search-index/src/Model/Table/SearchIndexesTable.php
@@ -11,7 +11,6 @@
 
 namespace BcSearchIndex\Model\Table;
 
-use BaserCore\Event\BcEventDispatcherTrait;
 use BaserCore\Model\Table\AppTable;
 use BaserCore\Annotation\UnitTest;
 use BaserCore\Annotation\NoTodo;
@@ -23,11 +22,6 @@ use BaserCore\Annotation\Note;
  */
 class SearchIndexesTable extends AppTable
 {
-    /**
-     * Trait
-     */
-    use BcEventDispatcherTrait;
-
     /**
      * Initialize
      *

--- a/plugins/bc-search-index/src/View/Helper/BcSearchIndexHelper.php
+++ b/plugins/bc-search-index/src/View/Helper/BcSearchIndexHelper.php
@@ -11,7 +11,6 @@
 
 namespace BcSearchIndex\View\Helper;
 
-use BaserCore\Event\BcEventDispatcherTrait;
 use BaserCore\Utility\BcContainerTrait;
 use BcSearchIndex\Service\SearchIndexesServiceInterface;
 use Cake\View\Helper;
@@ -28,7 +27,6 @@ class BcSearchIndexHelper extends Helper
     /**
      * Trait
      */
-    use BcEventDispatcherTrait;
     use BcContainerTrait;
 
     /**

--- a/plugins/bc-uploader/src/Model/Table/UploaderCategoriesTable.php
+++ b/plugins/bc-uploader/src/Model/Table/UploaderCategoriesTable.php
@@ -11,7 +11,6 @@
 
  namespace BcUploader\Model\Table;
 
-use BaserCore\Event\BcEventDispatcherTrait;
 use BaserCore\Model\Table\AppTable;
 use Cake\Datasource\EntityInterface;
 use Cake\ORM\Exception\PersistenceFailedException;
@@ -26,12 +25,6 @@ use BaserCore\Annotation\Checked;
  */
 class UploaderCategoriesTable extends AppTable
 {
-
-    /**
-     * Trait
-     */
-    use BcEventDispatcherTrait;
-
     /**
      * Initialize
      *

--- a/plugins/bc-widget-area/src/View/Helper/BcWidgetAreaHelper.php
+++ b/plugins/bc-widget-area/src/View/Helper/BcWidgetAreaHelper.php
@@ -11,7 +11,6 @@
 
 namespace BcWidgetArea\View\Helper;
 
-use BaserCore\Event\BcEventDispatcherTrait;
 use BaserCore\Utility\BcContainerTrait;
 use BaserCore\View\Helper\BcBaserHelper;
 use BcWidgetArea\Service\WidgetAreasService;
@@ -33,7 +32,6 @@ class BcWidgetAreaHelper extends Helper
     /**
      * Trait
      */
-    use BcEventDispatcherTrait;
     use BcContainerTrait;
 
     /**


### PR DESCRIPTION
AppTableを継承したモデルに必ずイベントを発火してほしいので、BcEventDispatcherTraitの読み込みを各クラスからAppTableに移動しました。
他の基底クラスであるAppControllerやAppViewはすでに追加済みのようです。

https://github.com/baserproject/basercms/blob/dev-5/plugins/baser-core/src/Controller/AppController.php#L53
https://github.com/baserproject/basercms/blob/dev-5/plugins/baser-core/src/View/AppView.php#L41

ご確認お願いします。