### PR TITLE
fix #2404 Vew関連のイベント（beforeGetTemplateFileName/ beforeGetElementFileName / beforeGetLayoutFileName）を実装

### DIFF
--- a/plugins/baser-core/src/View/AppView.php
+++ b/plugins/baser-core/src/View/AppView.php
@@ -23,6 +23,11 @@ use BaserCore\View\Helper\BcContentsHelper;
 use BaserCore\View\Helper\BcBaserHelper;
 use BaserCore\Event\BcEventDispatcherTrait;
 
+use RuntimeException;
+use Cake\View\Exception\MissingElementException;
+use Cake\View\Exception\MissingLayoutException;
+use Cake\View\Exception\MissingTemplateException;
+
 /**
  * Class AppView
  * @property BcBaserHelper $BcBaser
@@ -86,4 +91,163 @@ class AppView extends View
         return $this->_ext;
     }
 
+    /**
+     * Returns filename of given action's template file as a string.
+     * CamelCased action names will be under_scored by default.
+     * This means that you can have LongActionNames that refer to
+     * long_action_names.php templates. You can change the inflection rule by
+     * overriding _inflectTemplateFileName.
+     *
+     * @param string|null $name Controller action to find template filename for
+     * @return string Template filename
+     * @throws \Cake\View\Exception\MissingTemplateException when a template file could not be found.
+     * @throws \RuntimeException When template name not provided.
+     */
+    protected function _getTemplateFileName(?string $name = null): string
+    {
+        $templatePath = $subDir = '';
+
+        if ($this->templatePath) {
+            $templatePath = $this->templatePath . DIRECTORY_SEPARATOR;
+        }
+        if ($this->subDir !== '') {
+            $subDir = $this->subDir . DIRECTORY_SEPARATOR;
+            // Check if templatePath already terminates with subDir
+            if ($templatePath != $subDir && substr($templatePath, -strlen($subDir)) === $subDir) {
+                $subDir = '';
+            }
+        }
+
+        if ($name === null) {
+            $name = $this->template;
+        }
+
+        if (empty($name)) {
+            throw new RuntimeException('Template name not provided');
+        }
+
+        // CUSTOMIZE ADD 2013/08/27 ryuring
+        // イベントを追加
+        // >>>
+        // EVENT beforeGetTemplateFileName
+        $event = $this->dispatchLayerEvent('beforeGetTemplateFileName', ['name' => $name], ['class' => '', 'plugin' => '']);
+        if ($event !== false) {
+            $name = ($event->getResult() === null || $event->getResult() === true)? $event->getData('name') : $event->getResult();
+        }
+        // EVENT PluginName.ControllerName.beforeGetTemplateFileName
+        $event = $this->dispatchLayerEvent('beforeGetTemplateFileName', ['name' => $name]);
+        if ($event !== false) {
+            $name = ($event->getResult() === null || $event->getResult() === true)? $event->getData('name') : $event->getResult();
+        }
+        // <<<
+
+        [$plugin, $name] = $this->pluginSplit($name);
+        $name = str_replace('/', DIRECTORY_SEPARATOR, $name);
+
+        if (strpos($name, DIRECTORY_SEPARATOR) === false && $name !== '' && $name[0] !== '.') {
+            $name = $templatePath . $subDir . $this->_inflectTemplateFileName($name);
+        } elseif (strpos($name, DIRECTORY_SEPARATOR) !== false) {
+            if ($name[0] === DIRECTORY_SEPARATOR || $name[1] === ':') {
+                $name = trim($name, DIRECTORY_SEPARATOR);
+            } elseif (!$plugin || $this->templatePath !== $this->name) {
+                $name = $templatePath . $subDir . $name;
+            } else {
+                $name = $subDir . $name;
+            }
+        }
+
+        $name .= $this->_ext;
+        $paths = $this->_paths($plugin);
+        foreach ($paths as $path) {
+            if (is_file($path . $name)) {
+                return $this->_checkFilePath($path . $name, $path);
+            }
+        }
+
+        throw new MissingTemplateException($name, $paths);
+    }
+
+    /**
+     * Returns layout filename for this template as a string.
+     *
+     * @param string|null $name The name of the layout to find.
+     * @return string Filename for layout file.
+     * @throws \Cake\View\Exception\MissingLayoutException when a layout cannot be located
+     * @throws \RuntimeException
+     */
+    protected function _getLayoutFileName(?string $name = null): string
+    {
+        if ($name === null) {
+            if (empty($this->layout)) {
+                throw new RuntimeException(
+                    'View::$layout must be a non-empty string.' .
+                    'To disable layout rendering use method View::disableAutoLayout() instead.'
+                );
+            }
+            $name = $this->layout;
+        }
+
+        // CUSTOMIZE ADD 2013/08/27 ryuring
+        // イベントを追加
+        // >>>
+        // EVENT beforeGetLayoutFileName
+        $event = $this->dispatchLayerEvent('beforeGetLayoutFileName', ['name' => $name], ['class' => '', 'plugin' => '']);
+        if ($event !== false) {
+            $name = ($event->getResult() === null || $event->getResult() === true)? $event->getData('name') : $event->getResult();
+        }
+        // EVENT PluginName.ControllerName.beforeGetLayoutFileName
+        $event = $this->dispatchLayerEvent('beforeGetLayoutFileName', ['name' => $name]);
+        if ($event !== false) {
+            $name = ($event->getResult() === null || $event->getResult() === true)? $event->getData('name') : $event->getResult();
+        }
+        // <<<
+
+        [$plugin, $name] = $this->pluginSplit($name);
+        $name .= $this->_ext;
+
+        foreach ($this->getLayoutPaths($plugin) as $path) {
+            if (is_file($path . $name)) {
+                return $this->_checkFilePath($path . $name, $path);
+            }
+        }
+
+        $paths = iterator_to_array($this->getLayoutPaths($plugin));
+        throw new MissingLayoutException($name, $paths);
+    }
+
+    /**
+     * Finds an element filename, returns false on failure.
+     *
+     * @param string $name The name of the element to find.
+     * @param bool $pluginCheck - if false will ignore the request's plugin if parsed plugin is not loaded
+     * @return string|false Either a string to the element filename or false when one can't be found.
+     */
+    protected function _getElementFileName(string $name, bool $pluginCheck = true)
+    {
+        // CUSTOMIZE ADD 2013/08/27 ryuring
+        // イベントを追加
+        // >>>
+        // EVENT beforeGetElementFileName
+        $event = $this->dispatchLayerEvent('beforeGetElementFileName', ['name' => $name], ['class' => '', 'plugin' => '']);
+        if ($event !== false) {
+            $name = ($event->getResult() === null || $event->getResult() === true)? $event->getData('name') : $event->getResult();
+        }
+        // EVENT PluginName.ControllerName.beforeGetElementFileName
+        $event = $this->dispatchLayerEvent('beforeGetElementFileName', ['name' => $name]);
+        if ($event !== false) {
+            $name = ($event->getResult() === null || $event->getResult() === true)? $event->getData('name') : $event->getResult();
+        }
+        // <<<
+
+        [$plugin, $name] = $this->pluginSplit($name, $pluginCheck);
+
+        $name .= $this->_ext;
+        foreach ($this->getElementPaths($plugin) as $path) {
+            if (is_file($path . $name)) {
+                return $path . $name;
+            }
+        }
+
+        return false;
+    }
 }


### PR DESCRIPTION
作ってみました。どうでしょうか？
↓ みたいなプラグイン名、ファイル名を指定して プラグイン内に設置したファイルに差し替える使い方想定です。
 ```
    public $events = array(
        'BcBlog.Blog.beforeGetLayoutFileName',
        'BcBlog.Blog.beforeGetElementFileName',
        'BcBlog.Blog.beforeGetTemplateFileName',
    );
    public function bcBlogBlogBeforeGetLayoutFileName(Event $event)
    {
        $event->setData('name', 'HogePlugin.fuga');
        return $event->getData('name');
    }
    public function bcBlogBlogBeforeGetElementFileName(Event $event)
    {
        if ($hoge == 'fuga') {
            $event->setData('name', 'HogePlugin.hoge');
        }
        return $event->getData('name');
    }
    public function bcBlogBlogBeforeGetElementFileName(Event $event)
    {
        if ($hogehoge == 'fugafuga') {
            $event->setData('name', 'HogePlugin.hogehoge');
        }
        return $event->getData('name');
    }
```
