### PR TITLE
fix #2406 [ver4] /tags/{存在しないタグ名} がステータス200として戻される問題を解決

### DIFF
--- a/lib/Baser/Plugin/Blog/Controller/BlogController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogController.php
@@ -735,7 +735,7 @@ class BlogController extends BlogAppController
 			$this->notFound();
 		}
 		// /tags/{存在しないタグ名} がステータス200として戻される問題の解決
-		$tag = $this->BlogTag->findByName($name);
+		$tag = $this->BlogTag->find('first', ['conditions' => ['BlogTag.name' => $name], 'recursive' => -1]);
 		if (empty($tag)) {
 			$this->notFound();
 		}

--- a/lib/Baser/Plugin/Blog/Controller/BlogController.php
+++ b/lib/Baser/Plugin/Blog/Controller/BlogController.php
@@ -734,6 +734,12 @@ class BlogController extends BlogAppController
 		if (empty($name)) {
 			$this->notFound();
 		}
+		// /tags/{存在しないタグ名} がステータス200として戻される問題の解決
+		$tag = $this->BlogTag->findByName($name);
+		if (empty($tag)) {
+			$this->notFound();
+		}
+
 		$num = 10;
 		if (!empty($this->request->params['named']['num'])) {
 			$num = $this->request->params['named']['num'];


### PR DESCRIPTION
@gondoh 
@kaburk 
@ryuring 
タグの存在確認判定を追加しました。

ご確認の上、baserCMS 4系にマージお願いします。