### PR TITLE
fix #2302 Jwt認証領域でも未認証の場合はCSRFチェックをスキップしない

### DIFF
--- a/plugins/baser-core/src/Plugin.php
+++ b/plugins/baser-core/src/Plugin.php
@@ -307,9 +307,6 @@ class Plugin extends BcPlugin implements AuthenticationServiceProviderInterface
                     if($authenticator) {
                         // 認証済の際、セッション認証以外はスキップ
                         if(!$authenticator instanceof SessionAuthenticator) return true;
-                    } else {
-                        // 認証できていない場合、領域がJwt認証前提の場合はスキップ
-                        if($authSetting['type'] === 'Jwt') return true;
                     }
                     return false;
                 });

--- a/plugins/baser-core/tests/TestCase/Error/BcExceptionRendererTest.php
+++ b/plugins/baser-core/tests/TestCase/Error/BcExceptionRendererTest.php
@@ -93,8 +93,11 @@ class BcExceptionRendererTest extends BcTestCase
         $this->assertResponseError();
         $this->assertResponseContains('bs-container');
 
-        $this->post('/baser/api/admin/baser-core/users/add.json');
+        $this->get('/baser/api/admin/baser-core/users/index.json');
         $this->assertResponseCode(401);
+
+        $this->post('/baser/api/admin/baser-core/users/add.json');
+        $this->assertResponseCode(403);
 
         Configure::write('debug', $debug);
     }


### PR DESCRIPTION
以下のissueに対応しました。ご確認お願いします。
https://github.com/baserproject/basercms/issues/2302