### PR TITLE
CSRFチェックのURLチェックの優先度を上げる

### DIFF
--- a/plugins/baser-core/config/setting.php
+++ b/plugins/baser-core/config/setting.php
@@ -349,9 +349,9 @@ return [
         'systemMessageLangFromSiteSetting' => true,
 
         /**
-         * Web API のPOST送信において CSRF をスキップするURL
+         * POST送信において CSRF をスキップするURL
          */
-        'skipCsrfUrlInPostApi' => [
+        'skipCsrfUrl' => [
             ['plugin' => 'BaserCore', 'controller' => 'Users', 'action' => 'login', '_ext' => 'json'],
             ['plugin' => 'BaserCore', 'controller' => 'Users', 'action' => 'refresh_token', '_ext' => 'json'],
         ],

--- a/plugins/baser-core/src/Plugin.php
+++ b/plugins/baser-core/src/Plugin.php
@@ -297,11 +297,11 @@ class Plugin extends BcPlugin implements AuthenticationServiceProviderInterface
                     $prefix = $request->getParam('prefix');
                     $authSetting = Configure::read('BcPrefixAuth.' . $prefix);
 
-                    // 領域が REST API でない場合はスキップしない
-                    if (empty($authSetting['isRestApi'])) return false;
-
                     // 設定ファイルでスキップの定義がされている場合はスキップ
                     if(in_array($request->getPath(), $this->getSkipCsrfUrl())) return true;
+
+                    // 領域が REST API でない場合はスキップしない
+                    if (empty($authSetting['isRestApi'])) return false;
 
                     $authenticator = $request->getAttribute('authentication')->getAuthenticationProvider();
                     if($authenticator) {
@@ -328,7 +328,7 @@ class Plugin extends BcPlugin implements AuthenticationServiceProviderInterface
     protected function getSkipCsrfUrl(): array
     {
         $skipUrl = [];
-        $skipUrlSrc = Configure::read('BcApp.skipCsrfUrlInPostApi');
+        $skipUrlSrc = Configure::read('BcApp.skipCsrfUrl');
         foreach($skipUrlSrc as $url) {
             $skipUrl[] = Router::url($url);
         }


### PR DESCRIPTION
現在、API以外ではPOST送信時のCSRFチェックを回避する手段がないので、設定URLによるスキップ判定の優先度を上げています。

独自のtokenで検証するような場合に必要になる想定です。

ご確認お願いします。