### PR TITLE
JWT認証時にプレフィックスチェック

### DIFF
--- a/plugins/baser-core/src/Controller/Api/BcApiController.php
+++ b/plugins/baser-core/src/Controller/Api/BcApiController.php
@@ -62,7 +62,7 @@ class BcApiController extends AppController
     {
         if ($result->isValid()) {
             $request = Router::getRequest();
-            return BcApiUtil::createAccessToken($result->getData()->id, $request->getParam('prefix')?? 'Admin');
+            return BcApiUtil::createAccessToken($result->getData()->id, $request->getParam('prefix')?? 'Api/Admin');
         } else {
             return [];
         }

--- a/plugins/baser-core/src/Identifier/Resolver/PrefixOrmResolver.php
+++ b/plugins/baser-core/src/Identifier/Resolver/PrefixOrmResolver.php
@@ -40,6 +40,10 @@ class PrefixOrmResolver extends OrmResolver implements ResolverInterface
             }
         }
 
+        if ($prefix !== $this->_config['prefix']) {
+            return null;
+        }
+
         $table = $this->getTableLocator()->get($this->_config['userModel']);
 
         $query = $table->query();

--- a/plugins/baser-core/src/Plugin.php
+++ b/plugins/baser-core/src/Plugin.php
@@ -368,7 +368,7 @@ class Plugin extends BcPlugin implements AuthenticationServiceProviderInterface
                 $this->setupSessionAuth($service, $authSetting);
                 break;
             case 'Jwt':
-                $this->setupJwtAuth($service, $authSetting);
+                $this->setupJwtAuth($service, $authSetting, $prefix);
                 if($prefix === 'Api/Admin' && BcUtil::isSameReferrerAsCurrent()) {
                     // セッションを持っている場合もログイン状態とみなす
                     $service->loadAuthenticator('Authentication.Session', [
@@ -439,7 +439,7 @@ class Plugin extends BcPlugin implements AuthenticationServiceProviderInterface
      * @param array $authSetting
      * @return AuthenticationService
      */
-    public function setupJwtAuth(AuthenticationService $service, array $authSetting)
+    public function setupJwtAuth(AuthenticationService $service, array $authSetting, string $prefix)
     {
         if (Configure::read('Jwt.algorithm') === 'HS256') {
             $secretKey = Security::getSalt();
@@ -462,7 +462,8 @@ class Plugin extends BcPlugin implements AuthenticationServiceProviderInterface
             'resolver' => [
                 'className' => 'BaserCore.PrefixOrm',
                 'userModel' => $authSetting['userModel'],
-                'finder' => $authSetting['finder']?? 'available'
+                'finder' => $authSetting['finder']?? 'available',
+                'prefix' => $prefix,
             ],
         ]);
         $service->loadAuthenticator('Authentication.Form', [

--- a/plugins/baser-core/src/Utility/BcApiUtil.php
+++ b/plugins/baser-core/src/Utility/BcApiUtil.php
@@ -31,7 +31,7 @@ class BcApiUtil
      * @unitTest
      * @noTodo
      */
-    public static function createAccessToken(int $userId, string $prefix = 'Admin')
+    public static function createAccessToken(int $userId, string $prefix = 'Api/Admin')
     {
         $algorithm = Configure::read('Jwt.algorithm');
         $privateKey = file_get_contents(Configure::read('Jwt.privateKeyPath'));


### PR DESCRIPTION
JWTのトークン生成時に指定したプレフィックスと、認証時のプレフィックスが一致しないと認証が通らないように制限を追加しました。

例えば今までは、以下のどちらの方法で生成したトークンでも管理画面のAPIの認証が通っていました。

```
\BaserCore\Utility\BcApiUtil::createAccessToken(1, 'Api/Admin');
\BaserCore\Utility\BcApiUtil::createAccessToken(1, 'Test');
```

ご確認お願いします。