### PR TITLE
fix #2484 アップロードファイル一覧で表示件数リンクが正しく機能しない動作を修正

### DIFF
--- a/plugins/bc-admin-third/templates/Admin/element/list_num.php
+++ b/plugins/bc-admin-third/templates/Admin/element/list_num.php
@@ -47,7 +47,7 @@ if ($links) {
 
 
 <?php if ($link): ?>
-  <dl class="list-num bca-list-num">
+  <dl class="list-num bca-list-num page-numbers">
     <dt class="bca-list-num__title"><?php echo __d('baser_core', '表示件数') ?></dt>
     <dd class="bca-list-num__data"><?php echo $link ?></dd>
   </dl>


### PR DESCRIPTION
issueはこちら https://github.com/baserproject/basercms/issues/2484

uploader_list.js 内で表示件数指定するリンクに対してjsイベントはってますが、そちらが ```.page-numbers a``` に対するものため、正しくjs動作イベントが発火してないのが原因です。

