### PR TITLE
fix #2505 BcUpload 前回と異なる拡張子のファイルをアップロードすると前回のファイルが削除されない

### DIFF
--- a/plugins/baser-core/src/Model/Behavior/BcUploadBehavior.php
+++ b/plugins/baser-core/src/Model/Behavior/BcUploadBehavior.php
@@ -159,7 +159,7 @@ class BcUploadBehavior extends Behavior
     public function afterSave(EventInterface $event, EntityInterface $entity)
     {
         if ($entity->id && !empty($this->oldEntity[$this->table()->getAlias()])) {
-            $this->BcFileUploader[$this->table()->getAlias()]->deleteExistingFiles($entity);
+            $this->BcFileUploader[$this->table()->getAlias()]->deleteExistingFiles($this->oldEntity[$this->table()->getAlias()]);
         }
         $this->BcFileUploader[$this->table()->getAlias()]->saveFiles($entity);
         if ($entity->id && !empty($this->oldEntity[$this->table()->getAlias()])) {


### PR DESCRIPTION
issue: https://github.com/baserproject/basercms/issues/2505

deleteExistingFilesにはoldEntityを渡す必要があるので修正しました。

参考: 4系
https://github.com/baserproject/basercms/blob/dev-4/lib/Baser/Model/Behavior/BcUploadBehavior.php#L211

ご確認お願いします。