### PR TITLE
ユーザーメールアドレスの半角チェックを追加

### DIFF
--- a/plugins/baser-core/src/Model/Table/UsersTable.php
+++ b/plugins/baser-core/src/Model/Table/UsersTable.php
@@ -186,6 +186,12 @@ class UsersTable extends AppTable
             ->requirePresence('email', 'create', __d('baser_core', 'Eメールを入力してください。'))
             ->scalar('email')
             ->email('email', true, __d('baser_core', 'Eメールの形式が不正です。'))
+            ->add('email', [
+                'halfText' => [
+                    'rule' => 'halfText',
+                    'provider' => 'bc',
+                    'message' => __d('baser_core', 'Eメールは半角で入力してください。')
+                ]])
             ->maxLength('email', 255, __d('baser_core', 'Eメールは255文字以内で入力してください。'))
             ->notEmptyString('email', __d('baser_core', 'Eメールを入力してください。'))
             ->add('email', [


### PR DESCRIPTION
emailバリデーションが怪しいので半角チェックを追加しました。
ご確認お願いします。

<img width="684" alt="スクリーンショット 2023-06-30 14 41 08" src="https://github.com/baserproject/basercms/assets/30764014/678b1695-0671-45ab-a75d-f8fbeb8d07aa">

１２３@example.com => NG
てすと@example.com => OK