### PR TITLE
bccolumテーマのグローバルメニューの挙動に関する不具合解消

### DIFF
--- a/lib/Baser/View/Helper/BcBaserHelper.php
+++ b/lib/Baser/View/Helper/BcBaserHelper.php
@@ -1774,7 +1774,24 @@ EOD;
 	{
 		if (!$id) {
 			$Content = ClassRegistry::init('Content');
-			$siteRoot = $Content->getSiteRoot($this->request->params['Content']['site_id']);
+			if (isset($this->request->params['Content']['site_id'])) {
+				$siteRoot = $Content->getSiteRoot($this->request->params['Content']['site_id']);
+			} else {
+				$siteRoots = $Content->find('all', [
+					'conditions' => [
+						'Content.site_root' => true
+					], 'recursive' => -1]);
+				foreach ($siteRoots as $key => $siteRoot) {
+					if ($key === 0){
+						$siteRootSub = $siteRoot;
+						continue;
+					}
+					if (strpos($this->request->here, $siteRoot["Content"]["url"]) !== false) {
+						break;
+					}
+					$siteRoot = $siteRootSub;
+				}
+			}
 			$id = $siteRoot['Content']['id'];
 		}
 		$options = array_merge([


### PR DESCRIPTION
https://github.com/baserproject/basercms/issues/1868#ref-commit-c20a3ce
上記issueを解消しました。

エラーページでサイトIDが参照できていな方ので、参照できるようにしエラー解消しました。
ご確認お願いいたします。