### PR TITLE
fix #2570 4系版メールフォームで1フォーム内で複数のファイルタイプを利用すると送信完了前にエラーが起こる動作を改善

### DIFF
--- a/lib/Baser/Lib/BcFileUploader.php
+++ b/lib/Baser/Lib/BcFileUploader.php
@@ -1030,7 +1030,11 @@ class BcFileUploader
      */
     public function setUploadingFiles($files)
     {
-        $this->uploadingFiles = $files;
+		if ($this->uploadingFiles) {
+			$this->uploadingFiles = array_merge($this->uploadingFiles, $files);
+		} else {
+			$this->uploadingFiles = $files;
+		}
     }
 
     /**


### PR DESCRIPTION
issueはこちら。 https://github.com/baserproject/basercms/issues/2570
