### PR TITLE
fix #2622 basecms4系のBcErrorHandlerがphp5.4に対応していない問題を解決

### DIFF
--- a/lib/Baser/Lib/Error/BcErrorHandler.php
+++ b/lib/Baser/Lib/Error/BcErrorHandler.php
@@ -336,7 +336,8 @@ class BcErrorHandler extends ErrorHandler
 			$rs[] = 'Referer: ' . env('HTTP_REFERER');
 		}
 
-		if (empty(Configure::read('Error.trace'))) {
+		$errorTrace = Configure::read('Error.trace');
+		if (empty($errorTrace)) {
 			return implode("\n", $rs);
 		}
 


### PR DESCRIPTION
version4
empty()判定に関数の戻り値を直接渡してしまっているのが原因のため、該当箇所を調整しています。

@ryuring
@gondoh 
@kaburk 

お手数ですが、ご確認のうえマージをお願いします。