### PR TITLE
fix #2638 baserCMS4系　php８でビューキャッシュが生成されない問題を解決

### DIFF
--- a/lib/Baser/Controller/Component/BcContentsComponent.php
+++ b/lib/Baser/Controller/Component/BcContentsComponent.php
@@ -247,7 +247,7 @@ class BcContentsComponent extends Component
 					$controller->helpers[] = 'BcCache';
 					// php 8系では'+5 min'など、string型で指定されていた場合、5分後と判定されない問題を解消
 					$cacheTime = $controller->Content->getCacheTime($controller->request->params['Content']);
-					$controller->cacheAction = is_numeric($cacheTime) ? $cacheTime : strtotime($cacheTime);
+					$controller->cacheAction = is_numeric($cacheTime) ? $cacheTime : strtotime($cacheTime) - time();
 				}
 			}
 		}

--- a/lib/Baser/Controller/Component/BcContentsComponent.php
+++ b/lib/Baser/Controller/Component/BcContentsComponent.php
@@ -247,7 +247,7 @@ class BcContentsComponent extends Component
 					$controller->helpers[] = 'BcCache';
 					// php 8系では'+5 min'など、string型で指定されていた場合、5分後と判定されない問題を解消
 					$cacheTime = $controller->Content->getCacheTime($controller->request->params['Content']);
-					$controller->cacheAction = $cacheTime = is_numeric($cacheTime) ? $cacheTime : strtotime($cacheTime);
+					$controller->cacheAction = is_numeric($cacheTime) ? $cacheTime : strtotime($cacheTime);
 				}
 			}
 		}

--- a/lib/Baser/Controller/Component/BcContentsComponent.php
+++ b/lib/Baser/Controller/Component/BcContentsComponent.php
@@ -245,7 +245,9 @@ class BcContentsComponent extends Component
 				//	CakePHP3では、ビューキャッシュは廃止となる為、別の方法に移行する
 				if ($this->useViewCache && !BcUtil::loginUser('admin') && !isConsole() && !empty($controller->request->params['Content'])) {
 					$controller->helpers[] = 'BcCache';
-					$controller->cacheAction = $controller->Content->getCacheTime($controller->request->params['Content']);
+					// php 8系では'+5 min'など、string型で指定されていた場合、5分後と判定されない問題を解消
+					$cacheTime = $controller->Content->getCacheTime($controller->request->params['Content']);
+					$controller->cacheAction = $cacheTime = is_numeric($cacheTime) ? $cacheTime : strtotime($cacheTime);
 				}
 			}
 		}


### PR DESCRIPTION
・php 8系では'+5 min'など、string型で指定されていた場合、5分後と判定されないため、numeric型以外はstrtotimeで型を変更する処理を入れた

@ryuring 
@gondoh 
@kaburk 

お手数ですが、ご確認お願いします