### PR TITLE
メール送信前のイベントを追加

### DIFF
--- a/plugins/baser-core/src/Event/BcEventDispatcherTrait.php
+++ b/plugins/baser-core/src/Event/BcEventDispatcherTrait.php
@@ -63,6 +63,10 @@ trait BcEventDispatcherTrait
             $class = str_replace('Helper', '', $class);
             $subject = $this->_View;
             $plugin = method_exists($this->_View, 'getPlugin')? $this->_View->getPlugin() : '';
+        } elseif (is_a($this, 'Cake\Mailer\Mailer')) {
+            $layer = 'Mailer';
+            $classArray = explode('\\', $class);
+            $class = str_replace('Mailer', '', $classArray[count($classArray) - 1]);
         }
         $options = array_merge([
             'modParams' => 0,

--- a/plugins/baser-core/src/Event/BcMailerEventListener.php
+++ b/plugins/baser-core/src/Event/BcMailerEventListener.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * baserCMS :  Based Website Development Project <https://basercms.net>
+ * Copyright (c) NPO baser foundation <https://baserfoundation.org/>
+ *
+ * @copyright     Copyright (c) NPO baser foundation
+ * @link          https://basercms.net baserCMS Project
+ * @since         5.0.0
+ * @license       https://basercms.net/license/index.html MIT License
+ */
+
+namespace BaserCore\Event;
+
+/**
+ * Class BcMailerEventListener
+ *
+ * メーラーイベントリスナー
+ *
+ * Mailerイベントにコールバック処理を登録するための継承用クラス。
+ * events プロパティに配列で、イベント名を登録する。
+ * イベント名についてレイヤー名は省略できる。
+ * コールバック関数はイベント名より .（ドット）をアンダースコアに置き換えた上でキャメルケースに変換したものを
+ * 同クラス内のメソッドとして登録する
+ *
+ * @uses BcMailerEventListener
+ */
+class BcMailerEventListener extends BcEventListener
+{
+
+    /**
+     * レイヤー名
+     *
+     * @var string
+     */
+    public $layer = 'Mailer';
+
+}

--- a/plugins/baser-core/src/Mailer/BcMailer.php
+++ b/plugins/baser-core/src/Mailer/BcMailer.php
@@ -11,6 +11,7 @@
 
 namespace BaserCore\Mailer;
 
+use BaserCore\Event\BcEventDispatcherTrait;
 use BaserCore\Service\SiteConfigsService;
 use BaserCore\Service\SiteConfigsServiceInterface;
 use BaserCore\Utility\BcContainerTrait;
@@ -29,6 +30,14 @@ class BcMailer extends Mailer
      * Trait
      */
     use BcContainerTrait;
+    use BcEventDispatcherTrait;
+
+    /**
+     * プラグイン名
+     *
+     * @var string
+     */
+    protected $plugin = 'BaserCore';
 
     /**
      * Constructor
@@ -83,4 +92,26 @@ class BcMailer extends Mailer
         $this->setTransport($type);
     }
 
+    /**
+     * プラグイン名取得
+     *
+     * @return string
+     */
+    public function getPlugin(): ?string
+    {
+        return $this->plugin;
+    }
+
+    /**
+     * Render content and send email using configured transport.
+     *
+     * @param string $content Content.
+     * @return array
+     * @psalm-return array{headers: string, message: string}
+     */
+    public function deliver(string $content = '')
+    {
+        $this->dispatchLayerEvent('beforeDeliver');
+        return parent::deliver($content);
+    }
 }

--- a/plugins/baser-core/src/Utility/BcEvent.php
+++ b/plugins/baser-core/src/Utility/BcEvent.php
@@ -32,7 +32,7 @@ class BcEvent
     {
         $pluginPath = BcUtil::getPluginPath($plugin);
         // プラグインイベント登録
-        $eventTargets = ['Controller', 'Model', 'View', 'Helper'];
+        $eventTargets = ['Controller', 'Model', 'View', 'Helper', 'Mailer'];
         foreach($eventTargets as $eventTarget) {
             $eventClassName = $plugin . $eventTarget . 'EventListener';
             if (file_exists($pluginPath . 'src' . DS . 'Event' . DS . $eventClassName . '.php')) {


### PR DESCRIPTION
メール送信前のイベントを追加しました。

動機としては、管理画面のパスワード再発行時のメールの内容をカスタマイズすることです。
ご確認お願いします。

利用例

```
<?php

namespace BcBlog\Event;

use BaserCore\Event\BcMailerEventListener;
use Cake\Event\EventInterface;

class BcBlogMailerEventListener extends BcMailerEventListener
{
    public $events = ['BaserCore.PasswordRequest.beforeDeliver'];

    public function baserCorePasswordRequestBeforeDeliver(EventInterface $event)
    {
        $mailer = $event->getSubject();
        $mailer->setFrom(['from@example.com' => '送信者'])
            ->setSubject('メールタイトル')
            ->viewBuilder()
            ->setVars(['var' => 'test']);
    }
}
```
