### PR TITLE
fix #2706 [メールフォーム]4系版メールフォームで、フィールドタイプがカレンダーで任意入力、拡張入力チェックに「日付チェック」を…

### DIFF
--- a/lib/Baser/Plugin/Mail/Model/MailMessage.php
+++ b/lib/Baser/Plugin/Mail/Model/MailMessage.php
@@ -336,7 +336,7 @@ class MailMessage extends MailAppModel
 						$this->invalidate($field_name, __('日付の形式が無効です。'));
 					}
 				}
-				if (is_string($data['MailMessage'][$field_name])) {
+				if (is_string($data['MailMessage'][$field_name]) && $data['MailMessage'][$field_name]) {
 					// カレンダー入力利用時は yyyy/mm/dd で入ってくる
 					// yyyy/mm/dd 以外の文字列入力も可能であり、そうした際は日付データとして 1970-01-01 となるため認めない
 					$inputValue = date('Y-m-d', strtotime($data['MailMessage'][$field_name]));


### PR DESCRIPTION
issueはこちらです https://github.com/baserproject/basercms/issues/2706
可能な際に取込み検討お願いします

