### PR TITLE
fix #2527 管理画面 ブログ記事一覧のタイトル部分をクリックしても並び順が切り替わらない

### DIFF
--- a/plugins/bc-blog/src/Controller/Admin/BlogPostsController.php
+++ b/plugins/bc-blog/src/Controller/Admin/BlogPostsController.php
@@ -131,7 +131,7 @@ class BlogPostsController extends BlogAdminAppController
         try {
             $this->paginate = [
                 'sortableFields' => [
-                    'BlogCategories.name'
+                    'no', 'name','BlogCategories.name','user_id','posted'
                 ]
             ];
             $entities = $this->paginate($service->getIndex(array_merge(


### PR DESCRIPTION
管理画面 ブログ記事一覧のタイトル部分をクリックしても並び順が切り替わらない