### PR TITLE
BcMailerをコマンドから実行した際にエラーになる問題を修正

### DIFF
--- a/plugins/baser-core/src/Mailer/BcMailer.php
+++ b/plugins/baser-core/src/Mailer/BcMailer.php
@@ -53,7 +53,7 @@ class BcMailer extends Mailer
     {
         parent::__construct($config);
         $request = Router::getRequest();
-        $site = $request->getAttribute('currentSite');
+        $site = $request ? $request->getAttribute('currentSite') : null;
         $this->setEmailTransport();
         if ($site) $this->viewBuilder()
             ->setTheme($site->theme)


### PR DESCRIPTION
@ryuring 
コマンドからBcMailerを実行する際に、Requestが取得できない場合でも getAttribute() を呼び出そうとしてエラーとなるため、修正しました。

ご確認お願いします。
