### PR TITLE
ブログの子カテゴリの表示を調整

### DIFF
--- a/plugins/bc-blog/src/Service/BlogCategoriesService.php
+++ b/plugins/bc-blog/src/Service/BlogCategoriesService.php
@@ -129,7 +129,7 @@ class BlogCategoriesService implements BlogCategoriesServiceInterface
             }
             $category->layered_title = sprintf(
                 "%s└%s",
-                str_replace('_', '&nbsp;&nbsp;&nbsp;&nbsp;', $matches[1]),
+                str_replace('_', '　', $matches[1]),
                 $category->title
             );
             $category->depth = strlen($matches[1]);
@@ -173,7 +173,7 @@ class BlogCategoriesService implements BlogCategoriesServiceInterface
                 foreach ($parents as $key => $parent) {
                     if (preg_match("/^([_]+)/i", $parent, $matches)) {
                         $parent = preg_replace("/^[_]+/i", '', $parent);
-                        $prefix = str_replace('_', '　　　', $matches[1]);
+                        $prefix = str_replace('_', '　', $matches[1]);
                         $parent = $prefix . '└' . $parent;
                     }
                     $controlSources['parent_id'][$key] = $parent;

--- a/plugins/bc-blog/tests/TestCase/Service/BlogCategoriesServiceTest.php
+++ b/plugins/bc-blog/tests/TestCase/Service/BlogCategoriesServiceTest.php
@@ -123,7 +123,7 @@ class BlogCategoriesServiceTest extends \BaserCore\TestSuite\BcTestCase
 
         BlogCategoryFactory::make(['id' => 60, 'blog_content_id' => 29, 'title' => '_test'])->persist();
         $categories = $this->BlogCategories->getTreeIndex(29, []);
-        $this->assertEquals('&nbsp;&nbsp;&nbsp;&nbsp;└_test', $categories[0]->layered_title);
+        $this->assertEquals('　└_test', $categories[0]->layered_title);
     }
 
     /**
@@ -155,10 +155,10 @@ class BlogCategoriesServiceTest extends \BaserCore\TestSuite\BcTestCase
             [
                 'parent_id',
                 ['conditions' => ['BlogCategories.status' => 1], 'blogContentId' => 19],
-                [59 => 'test', 60 => '　　　└test']
+                [59 => 'test', 60 => '　└test']
             ],
-            ['parent_id',['blogContentId' => 19], [59 => 'test', 60 => '　　　└test']],
-            ['parent_id', ['blogContentId' => 19, 'excludeParentId' => 59], [60 => '　　　└test']],
+            ['parent_id',['blogContentId' => 19], [59 => 'test', 60 => '　└test']],
+            ['parent_id', ['blogContentId' => 19, 'excludeParentId' => 59], [60 => '　└test']],
         ];
     }
 


### PR DESCRIPTION
管理画面のブログカテゴリ一覧の表示崩れとブログカテゴリ追加・編集画面の表示の調整を行いました。
ご確認お願いします。

## 変更前

<img width="1077" alt="1-1" src="https://github.com/baserproject/basercms/assets/30764014/59c1c1f8-250e-43ed-bc0b-10e42cefcd09">
<img width="1077" alt="1-2" src="https://github.com/baserproject/basercms/assets/30764014/612bf08a-c9c4-416f-89f4-d155d1c39f57">

## 変更後

<img width="1075" alt="2-1" src="https://github.com/baserproject/basercms/assets/30764014/0a9b27a2-0c46-47bc-8aa6-1b8e0a9be925">
<img width="1076" alt="2-2" src="https://github.com/baserproject/basercms/assets/30764014/c3e77482-4169-4150-a5ea-79650c44ab21">
