### PR TITLE
fix #2189 BcValidation::checkDateの調査

### DIFF
--- a/plugins/baser-core/src/Model/Table/ContentsTable.php
+++ b/plugins/baser-core/src/Model/Table/ContentsTable.php
@@ -193,26 +193,22 @@ class ContentsTable extends AppTable
                 ]
             ]);
         $validator
-            ->dateTime('self_publish_begin')
-            ->allowEmptyDateTime('self_publish_begin')
             ->add('self_publish_begin', [
-                'checkDate' => [
-                    'rule' => ['checkDate'],
-                    'provider' => 'bc',
+                'dateTime' => [
+                    'rule' => ['dateTime'],
                     'message' => __d('baser_core', '公開開始日に不正な文字列が入っています。')
                 ]
-            ]);
+            ])
+            ->allowEmptyDateTime('self_publish_begin');
 
         $validator
-            ->dateTime('self_publish_end')
-            ->allowEmptyDateTime('self_publish_end')
             ->add('self_publish_end', [
-                'checkDate' => [
-                    'rule' => ['checkDate'],
-                    'provider' => 'bc',
+                'dateTime' => [
+                    'rule' => ['dateTime'],
                     'message' => __d('baser_core', '公開終了日に不正な文字列が入っています。')
                 ]
             ])
+            ->allowEmptyDateTime('self_publish_end')
             ->add('self_publish_end', [
                 'checkDateAfterThan' => [
                     'rule' => ['checkDateAfterThan', 'self_publish_begin'],
@@ -221,26 +217,22 @@ class ContentsTable extends AppTable
                 ]
             ]);
         $validator
-            ->dateTime('created_date')
-            ->requirePresence('created_date', 'create', __d('baser_core', '作成日がありません。'))
-            ->notEmptyDateTime('created_date', __d('baser_core', '作成日が空になってます。'))
             ->add('created_date', [
-                'checkDate' => [
-                    'rule' => ['checkDate'],
-                    'provider' => 'bc',
+                'dateTime' => [
+                    'rule' => ['dateTime'],
                     'message' => __d('baser_core', '作成日が正しくありません。')
                 ]
-            ]);
+            ])
+            ->requirePresence('created_date', 'create', __d('baser_core', '作成日がありません。'))
+            ->notEmptyDateTime('created_date', __d('baser_core', '作成日が空になってます。'));
         $validator
-            ->datetime('modified_date')
-            ->notEmptyDateTime('modified_date', __d('baser_core', '更新日が空になってます。'), 'update')
             ->add('modified_date', [
-                'checkDate' => [
-                    'rule' => ['checkDate'],
-                    'provider' => 'bc',
+                'dateTime' => [
+                    'rule' => ['dateTime'],
                     'message' => __d('baser_core', '更新日が正しくありません。')
                 ]
-            ]);
+            ])
+            ->notEmptyDateTime('modified_date', __d('baser_core', '更新日が空になってます。'), 'update');
         return $validator;
     }
 
@@ -342,19 +334,8 @@ class ContentsTable extends AppTable
             if (isset($content['name'])) {
                 $content['name'] = BcUtil::urlencode(mb_substr($content['name'], 0, 230, 'UTF-8'));
             }
-            if (!empty($content['self_publish_begin'])) {
-                $content['self_publish_begin'] = new FrozenTime($content['self_publish_begin']);
-            }
-            if (!empty($content['self_publish_end'])) {
-                $content['self_publish_end'] = new FrozenTime($content['self_publish_end']);
-            }
             if (empty($content['modified_date'])) {
                 $content['modified_date'] = FrozenTime::now();
-            } else {
-                $content['modified_date'] = new FrozenTime($content['modified_date']);
-            }
-            if (!empty($content['created_date'])) {
-                $content['created_date'] = new FrozenTime($content['created_date']);
             }
         }
         // name の 重複チェック＆リネーム

--- a/plugins/baser-core/src/Model/Validation/BcValidation.php
+++ b/plugins/baser-core/src/Model/Validation/BcValidation.php
@@ -423,21 +423,6 @@ class BcValidation extends Validation
     }
 
     /**
-     * 日付の正当性チェック
-     *
-     * @param string $value 確認する値
-     * @return boolean
-     * @checked
-     * @noTodo
-     * @unitTest
-     */
-    public static function checkDate($value)
-    {
-        if (!$value instanceof FrozenTime) return false;
-        return true;
-    }
-
-    /**
      * 日時チェック
      * - 開始日時が終了日時より過去の場合、true を返す
      *

--- a/plugins/baser-core/tests/TestCase/Controller/Admin/PreviewControllerTest.php
+++ b/plugins/baser-core/tests/TestCase/Controller/Admin/PreviewControllerTest.php
@@ -81,7 +81,7 @@ class PreviewControllerTest extends BcTestCase
         $page->contents = "<p>test</p>";
         $page->title = "testView title";
         $page->content['title'] = "testView title";
-        $page->content['created_date'] = date('Y-m-d');
+        $page->content['created_date'] = date('Y-m-d H:i:s');
 
         $this->enableCsrfToken();
         $this->post('/baser/admin/baser-core/preview/view?url=https://localhost/&preview=default', $page->toArray());

--- a/plugins/baser-core/tests/TestCase/Model/Validation/BcValidationTest.php
+++ b/plugins/baser-core/tests/TestCase/Model/Validation/BcValidationTest.php
@@ -421,30 +421,6 @@ class BcValidationTest extends BcTestCase
     }
 
     /**
-     * Test CheckDate
-     *
-     * @param string $value
-     * @param boolean $expect
-     * @return void
-     * @dataProvider checkDateDataProvider
-     */
-    public function testCheckDate($value, $expect)
-    {
-        $result = $this->BcValidation->checkDate($value);
-        $this->assertEquals($expect, $result);
-    }
-
-    public function checkDateDataProvider()
-    {
-        return [
-            [FrozenTime::now(), true],
-            [new FrozenTime('2015-01-01'), true],
-            ['', false],
-            ['2015-01-01 00:00:00', false],
-        ];
-    }
-
-    /**
      * Test checkDateRange
      *
      * @return void

--- a/plugins/bc-blog/src/Model/Table/BlogPostsTable.php
+++ b/plugins/bc-blog/src/Model/Table/BlogPostsTable.php
@@ -166,15 +166,13 @@ class BlogPostsTable extends BlogAppTable
                 ]
             ]);
         $validator
-            ->dateTime('publish_begin')
-            ->allowEmptyDateTime('publish_begin')
             ->add('publish_begin', [
-                'checkDate' => [
-                    'rule' => ['checkDate'],
-                    'provider' => 'bc',
+                'dateTime' => [
+                    'rule' => ['dateTime'],
                     'message' => __d('baser_core', '公開開始日の形式が不正です。')
                 ]
             ])
+            ->allowEmptyDateTime('publish_begin')
             ->add('publish_begin', [
                 'checkDateRange' => [
                     'rule' => ['checkDateRange', ['publish_begin', 'publish_end']],
@@ -183,25 +181,21 @@ class BlogPostsTable extends BlogAppTable
                 ]
             ]);
         $validator
-            ->dateTime('publish_end')
-            ->allowEmptyDateTime('publish_end')
             ->add('publish_end', [
-                'checkDate' => [
-                    'rule' => ['checkDate'],
-                    'provider' => 'bc',
+                'dateTime' => [
+                    'rule' => ['dateTime'],
                     'message' => __d('baser_core', '公開終了日の形式が不正です。')
                 ]
-            ]);
+            ])
+            ->allowEmptyDateTime('publish_end');
         $validator
-            ->dateTime('posted')
-            ->notEmptyString('posted', __d('baser_core', '投稿日を入力してください。'))
             ->add('posted', [
-                'checkDate' => [
-                    'rule' => ['checkDate'],
-                    'provider' => 'bc',
+                'dateTime' => [
+                    'rule' => ['dateTime'],
                     'message' => __d('baser_core', '投稿日の形式が不正です。')
                 ]
-            ]);
+            ])
+            ->notEmptyDateTime('posted', __d('baser_core', '投稿日を入力してください。'));;
         $validator
             ->integer('user_id')
             ->notEmptyString('user_id', __d('baser_core', '投稿者を選択してください。'));

--- a/plugins/bc-blog/src/Service/BlogPostsService.php
+++ b/plugins/bc-blog/src/Service/BlogPostsService.php
@@ -539,9 +539,6 @@ class BlogPostsService implements BlogPostsServiceInterface
             ));
         }
         $postData['no'] = $this->BlogPosts->getMax('no', ['BlogPosts.blog_content_id' => $postData['blog_content_id']]) + 1;
-        if (!empty($postData['posted'])) $postData['posted'] = new FrozenTime($postData['posted']);
-        if (!empty($postData['publish_begin'])) $postData['publish_begin'] = new FrozenTime($postData['publish_begin']);
-        if (!empty($postData['publish_end'])) $postData['publish_end'] = new FrozenTime($postData['publish_end']);
         $blogPost = $this->BlogPosts->patchEntity($this->BlogPosts->newEmptyEntity(), $postData);
         return $this->BlogPosts->saveOrFail($blogPost);
     }
@@ -566,9 +563,6 @@ class BlogPostsService implements BlogPostsServiceInterface
                 ini_get('post_max_size')
             ));
         }
-        if (!empty($postData['posted'])) $postData['posted'] = new FrozenTime($postData['posted']);
-        if (!empty($postData['publish_begin'])) $postData['publish_begin'] = new FrozenTime($postData['publish_begin']);
-        if (!empty($postData['publish_end'])) $postData['publish_end'] = new FrozenTime($postData['publish_end']);
         $blogPost = $this->BlogPosts->patchEntity($post, $postData);
         return $this->BlogPosts->saveOrFail($blogPost);
     }

--- a/plugins/bc-blog/src/Service/Front/BlogFrontService.php
+++ b/plugins/bc-blog/src/Service/Front/BlogFrontService.php
@@ -32,7 +32,6 @@ use BaserCore\Annotation\NoTodo;
 use BaserCore\Annotation\Checked;
 use Cake\ORM\ResultSet;
 use Cake\ORM\TableRegistry;
-use Cake\I18n\FrozenTime;
 
 /**
  * BlogFrontService
@@ -397,9 +396,6 @@ class BlogFrontService implements BlogFrontServiceInterface
             if ($request->getQuery('preview') === 'draft') {
                 $postArray['detail'] = $postArray['detail_draft'];
             }
-            if (!empty($postArray['posted'])) $postArray['posted'] = new FrozenTime($postArray['posted']);
-            if (!empty($postArray['publish_begin'])) $postArray['publish_begin'] = new FrozenTime($postArray['publish_begin']);
-            if (!empty($postArray['publish_end'])) $postArray['publish_end'] = new FrozenTime($postArray['publish_end']);
 
             $vars['post'] = $this->BlogPostsService->BlogPosts->patchEntity(
                 $vars['post'] ?? $this->BlogPostsService->BlogPosts->newEmptyEntity(),

--- a/plugins/bc-blog/tests/TestCase/Model/BlogPostsTableTest.php
+++ b/plugins/bc-blog/tests/TestCase/Model/BlogPostsTableTest.php
@@ -156,12 +156,12 @@ class BlogPostsTableTest extends BcTestCase
         //草稿欄
         $this->assertEquals('草稿欄でスクリプトの入力は許可されていません。', current($errors['detail_draft']));
         //公開開始日
-        $this->assertEquals('公開開始日の形式が不正です。', $errors['publish_begin']['checkDate']);
+        $this->assertEquals('公開開始日の形式が不正です。', $errors['publish_begin']['dateTime']);
         $this->assertEquals('公開期間が不正です。', $errors['publish_begin']['checkDateRange']);
         //公開終了日
-        $this->assertEquals('公開終了日の形式が不正です。', $errors['publish_end']['checkDate']);
+        $this->assertEquals('公開終了日の形式が不正です。', $errors['publish_end']['dateTime']);
         //投稿日
-        $this->assertEquals('投稿日の形式が不正です。', $errors['posted']['checkDate']);
+        $this->assertEquals('投稿日の形式が不正です。', $errors['posted']['dateTime']);
         //アイキャッチ画像
         $this->assertEquals('許可されていないファイルです。', $errors['eyecatch']['fileExt']);
     }

--- a/plugins/bc-blog/tests/TestCase/Service/BlogPostsServiceTest.php
+++ b/plugins/bc-blog/tests/TestCase/Service/BlogPostsServiceTest.php
@@ -708,7 +708,7 @@ class BlogPostsServiceTest extends BcTestCase
             'title' => 'title of post 3',
             'posted' => '2021-11-01 00:00:00',
             'publish_begin' => '2021-10-01 00:00:00',
-            'publish_end' => '9999-11-30 23:59:59'
+            'publish_end' => '2100-11-30 23:59:59'
         ];
         // サービスメソッドを呼ぶ
         $result = $this->BlogPostsService->update(BlogPostFactory::get(1), $postData);
@@ -716,7 +716,7 @@ class BlogPostsServiceTest extends BcTestCase
         $this->assertEquals("title of post 3", $result["title"]);
         $this->assertEquals("2021-11-01 00:00:00", $result["posted"]->i18nFormat('yyyy-MM-dd HH:mm:ss'));
         $this->assertEquals("2021-10-01 00:00:00", $result["publish_begin"]->i18nFormat('yyyy-MM-dd HH:mm:ss'));
-        $this->assertEquals("9999-11-30 23:59:59", $result["publish_end"]->i18nFormat('yyyy-MM-dd HH:mm:ss'));
+        $this->assertEquals("2100-11-30 23:59:59", $result["publish_end"]->i18nFormat('yyyy-MM-dd HH:mm:ss'));
 
         // titleがない時を確認すること
         $postData = [


### PR DESCRIPTION
issue: https://github.com/baserproject/basercms/issues/2189

cakeのdateTimeバリデーションと重複しているBcValidation::checkDateの削除を行いました。
また、このルールへの対応のためだけに必要な日時の変換処理も削除しています。

```
# 例
if (!empty($postData['posted'])) $postData['posted'] = new FrozenTime($postData['posted']);
```

ご確認をお願いします。