### PR TITLE
fix #2904 [baserCMS4系]メールフォーム セレクトボックスの選択肢の末尾に半角スペースが入っていると、確認画面で選択が外…

### DIFF
--- a/lib/Baser/Plugin/Mail/View/Helper/MailfieldHelper.php
+++ b/lib/Baser/Plugin/Mail/View/Helper/MailfieldHelper.php
@@ -70,7 +70,7 @@ class MailfieldHelper extends AppHelper
 				$values = explode("\n", str_replace('|', "\n", $data['source']));
 				$source = [];
 				foreach($values as $value) {
-					$source[$value] = $value;
+					$source[trim($value)] = trim($value);
 				}
 				return $source;
 			}


### PR DESCRIPTION
…れる問題を解決

@ryuring 
@kaburk 
@gondoh 

単純に選択肢読み込み時にtrim()で最初および最後から空白文字を取り除くだけで行けそうです。
こちらご確認お願いできますでしょうか？

