### PR TITLE
ニックネームが設定されていないユーザーを削除する際の表示を調整

### DIFF
--- a/plugins/bc-admin-third/templates/Admin/Users/edit.php
+++ b/plugins/bc-admin-third/templates/Admin/Users/edit.php
@@ -52,7 +52,7 @@ $this->BcAdmin->setHelp('users_form');
         __d('baser_core', '削除'),
         ['action' => 'delete', $user->id],
         ['block' => true,
-          'confirm' => __d('baser_core', '{0} を本当に削除してもいいですか？', $user->name),
+          'confirm' => __d('baser_core', '{0} を本当に削除してもいいですか？', $user->getDisplayName()),
           'class' => 'bca-submit-token button bca-btn bca-actions__item',
           'data-bca-btn-type' => 'delete',
           'data-bca-btn-size' => 'sm']


### PR DESCRIPTION
ユーザー管理から、ニックネームが設定されていないユーザーを削除する際の表示を調整しました。
ご確認お願いします。

<img width="951" alt="userdelete2" src="https://github.com/baserproject/basercms/assets/30764014/8c5e0543-ccb6-46b4-9ab1-beb59c03a272">
