### PR TITLE
BcText::stripScriptTagを削除

### DIFF
--- a/plugins/baser-core/src/Utility/BcText.php
+++ b/plugins/baser-core/src/Utility/BcText.php
@@ -20,27 +20,4 @@ use BaserCore\Annotation\UnitTest;
  */
 class BcText
 {
-
-    /**
-     * 文字列よりスクリプトタグを除去する
-     *
-     * @param string $value
-     * @return string
-     * @checked
-     * @noTodo
-     * @unitTest
-     */
-    public static function stripScriptTag($value)
-    {
-        $allows = [
-            'a', 'abbr', 'address', 'area', 'b', 'blockquote', 'body', 'br', 'button', 'caption', 'cite', 'code',
-            'col', 'colgroup', 'dd', 'del', 'dfn', 'div', 'dl', 'dt', 'em', 'fieldset', 'form', 'h1', 'h2', 'h3',
-            'h4', 'h5', 'h6', 'hr', 'i', 'iframe', 'img', 'input', 'ins', 'kbd', 'label', 'legend', 'li', 'link',
-            'map', 'meta', 'noscript', 'object', 'ol', 'optgroup', 'option', 'p', 'pre', 'q', 'samp', 'select',
-            'small', 'span', 'strong', 'sub', 'sup', 'table', 'tbody', 'td', 'textarea', 'tfoot', 'th', 'thead',
-            'title', 'tr', 'ul', 'var', 'style'
-        ];
-        return strip_tags($value, '<' . implode('><', $allows) . '>');
-    }
-
 }

--- a/plugins/baser-core/tests/TestCase/Utility/BcTextTest.php
+++ b/plugins/baser-core/tests/TestCase/Utility/BcTextTest.php
@@ -19,30 +19,4 @@ use BaserCore\Utility\BcText;
  */
 class BcTextTest extends BcTestCase
 {
-
-	/**
-	 * test stripScriptTag
-	 * @return void
-	 * @dataProvider stripScriptTagDataProvider
-	 */
-	public function testStripScriptTag($content, $expect)
-	{
-		$result = BcText::stripScriptTag($content);
-		$this->assertEquals($expect, $result, 'scriptタグを削除できません。');
-	}
-
-	public function stripScriptTagDataProvider()
-	{
-		return [
-			[
-				'content' => '<script>hoge</script>',
-				'expect' => 'hoge'
-			],
-			[
-				'content' => '<a href="http://hoge.com" class="bca-action">hoge<script>hoge</script></a>',
-				'expect' => '<a href="http://hoge.com" class="bca-action">hogehoge</a>'
-			]
-		];
-	}
-
 }

--- a/plugins/bc-blog/src/Model/Table/BlogContentsTable.php
+++ b/plugins/bc-blog/src/Model/Table/BlogContentsTable.php
@@ -49,6 +49,16 @@ class BlogContentsTable extends BlogAppTable
         $validator->integer('id')
             ->allowEmptyString('id', null, 'create');
 
+        $validator
+            ->scalar('description')
+            ->add('description', [
+                'containsScript' => [
+                    'rule' => ['containsScript'],
+                    'provider' => 'bc',
+                    'message' => __d('baser_core', '説明文でスクリプトの入力は許可されていません。')
+                ]
+            ]);
+
         $validator->scalar('list_count')
             ->notEmptyString('list_count', __d('baser_core', '一覧表示件数を入力してください。'))
             ->range('list_count', [0, 101], __d('baser_core', '一覧表示件数は100までの数値で入力してください。'))

--- a/plugins/bc-blog/src/View/Helper/BlogHelper.php
+++ b/plugins/bc-blog/src/View/Helper/BlogHelper.php
@@ -278,7 +278,7 @@ class BlogHelper extends Helper
      */
     public function description()
     {
-        echo BcText::stripScriptTag($this->getDescription());
+        echo $this->getDescription();
     }
 
     /**

--- a/plugins/bc-mail/src/Model/Table/MailContentsTable.php
+++ b/plugins/bc-mail/src/Model/Table/MailContentsTable.php
@@ -139,6 +139,17 @@ class MailContentsTable extends MailAppTable
             ->scalar('redirect_url')
             ->maxLength('redirect_url', 255, __d('baser_core', 'リダイレクトURLは255文字以内で入力してください。'));
 
+        // description
+        $validator
+            ->scalar('description')
+            ->add('description', [
+                'containsScript' => [
+                    'rule' => ['containsScript'],
+                    'provider' => 'bc',
+                    'message' => __d('baser_core', '説明文でスクリプトの入力は許可されていません。')
+                ]
+            ]);
+
         // sender_1
         $validator
             ->scalar('sender_1')

--- a/plugins/bc-mail/src/View/Helper/MailHelper.php
+++ b/plugins/bc-mail/src/View/Helper/MailHelper.php
@@ -172,7 +172,7 @@ class MailHelper extends Helper
      */
     public function description()
     {
-        echo BcText::stripScriptTag($this->getDescription());
+        echo $this->getDescription();
     }
 
     /**


### PR DESCRIPTION
BcText::stripScriptTagはスクリプトを除去する関数として不完全なため削除しました。
代わりにBcValidation::containsScriptで保存時にチェックするようにしています。
ご確認お願いします。