### PR TITLE
fix #2816 fix #2945 フォームのファイルフィールドの問題を修正

### DIFF
--- a/plugins/baser-core/src/Utility/BcFileUploader.php
+++ b/plugins/baser-core/src/Utility/BcFileUploader.php
@@ -493,6 +493,11 @@ class BcFileUploader
         $uploadInfo['uploadable'] = true;
         $uploadInfo['ext'] = BcUtil::decodeContent($fileType, $fileName);
         $uploadedFile[$fieldName] = $uploadInfo;
+
+        // 一時ファイルを一度に複数扱う場合に1ファイルしかアップロードされない問題への対応
+        // 例: メールフォームのファイルフィールドなど
+        $uploadedFile = array_merge($this->getUploadingFiles($data['_bc_upload_id']), $uploadedFile);
+
         $this->setUploadingFiles($uploadedFile, $data['_bc_upload_id']);
         return true;
     }

--- a/plugins/baser-core/src/View/Helper/BcUploadHelper.php
+++ b/plugins/baser-core/src/View/Helper/BcUploadHelper.php
@@ -157,6 +157,10 @@ class BcUploadHelper  extends Helper
             $basePath = '/baser-core/uploads/tmp/';
         }
 
+        if (is_array($value)) {
+            return false;
+        }
+
         /* ファイルのパスを取得 */
         /* 画像の場合はサイズを指定する */
         if (isset($settings['saveDir'])) {

--- a/plugins/bc-mail/src/Service/MailMessagesService.php
+++ b/plugins/bc-mail/src/Service/MailMessagesService.php
@@ -120,14 +120,13 @@ class MailMessagesService implements MailMessagesServiceInterface
      */
     public function create(EntityInterface $mailContent, $postData)
     {
-        if (!$postData instanceof EntityInterface) {
-            // newEntity() だと配列が消えてしまうため、エンティティクラスで直接変換
-            $entity = new MailMessage($postData, ['source' => 'BcMail.MailMessages']);
-        } else {
-            $entity = $postData;
+        $entity = $this->MailMessages->newEntity($postData);
+        foreach ($postData as $postKey => $postValue) {
+            if (is_array($postValue)) {
+                $entity->$postKey = $postValue;
+            }
         }
-        $validateEntity = $this->MailMessages->patchEntity($this->MailMessages->newEmptyEntity(), $entity->toArray());
-        if (!$validateEntity->getErrors()) {
+        if (!$entity->getErrors()) {
             $mailFieldsTable = TableRegistry::getTableLocator()->get('BcMail.MailFields');
             $mailFields = $mailFieldsTable->find()->where(['MailFields.mail_content_id' => $mailContent->id, 'MailFields.use_field' => true])->all();
             $this->MailMessages->convertToDb($mailFields, $entity);


### PR DESCRIPTION
以下のissueに対応を行いました。ご確認をお願いします。

> メールプラグインにおけるファイルフィールドを利用した場合ファイルが保存されない
> https://github.com/baserproject/basercms/issues/2816
> 【フォーム】フォームのバリデーションエラーが発生した際にファイルフィールド欄に「Array」と表示される
> https://github.com/baserproject/basercms/issues/2945

変更点は以下です。

- plugins/baser-core/src/Utility/BcFileUploader.php
    - 一時ファイルを一度に複数扱う場合に同じ_bc_upload_idのデータが上書きされてしまうため対応
- plugins/baser-core/src/View/Helper/BcUploadHelper.php
    - 値が配列の場合にはファイルへのリンクを出力しない
    - 4系の場合を参考に配列の場合の処理を別途記載したほうがいいかも
        - https://github.com/baserproject/basercms/blob/dev-4/lib/Baser/View/Helper/BcUploadHelper.php#L90
- plugins/bc-mail/src/Service/MailMessagesService.php
    - new MailMessageだとBcUploadBehavior->beforeMarshalが実行されてないためnewEntityを使用するよう変更
    - MailMessageテーブルのbeforeMarshal・afterMarshalで配列に対応する形に変更したほうがよりよさそう
