### PR TITLE
fix #2969 ブログとコンテンツのアイキャッチのファイル形式バリデーションを追加

### DIFF
--- a/plugins/baser-core/src/Model/Table/ContentsTable.php
+++ b/plugins/baser-core/src/Model/Table/ContentsTable.php
@@ -193,6 +193,13 @@ class ContentsTable extends AppTable
                     'provider' => 'bc',
                     'message' => __d('baser_core', 'ファイルのアップロードに失敗しました。')
                 ]
+            ])
+            ->add('eyecatch', [
+                'fileExt' => [
+                    'rule' => ['fileExt', ['gif', 'jpg', 'jpeg', 'jpe', 'jfif', 'png']],
+                    'provider' => 'bc',
+                    'message' => __d('baser_core', '許可されていないファイルです。')
+                ]
             ]);
         $validator
             ->add('self_publish_begin', [

--- a/plugins/bc-blog/src/Model/Table/BlogPostsTable.php
+++ b/plugins/bc-blog/src/Model/Table/BlogPostsTable.php
@@ -208,7 +208,7 @@ class BlogPostsTable extends BlogAppTable
                     'message' => __d('baser_core', 'ファイルのアップロード制限を超えています。')
                 ]
             ])
-            ->add('eyecatch', [
+            ->add('eye_catch', [
                 'fileExt' => [
                     'rule' => ['fileExt', ['gif', 'jpg', 'jpeg', 'jpe', 'jfif', 'png']],
                     'provider' => 'bc',

--- a/plugins/bc-blog/tests/TestCase/Model/BlogPostsTableTest.php
+++ b/plugins/bc-blog/tests/TestCase/Model/BlogPostsTableTest.php
@@ -143,7 +143,7 @@ class BlogPostsTableTest extends BcTestCase
             'publish_begin' => '2022-02-29',            //公開開始日
             'publish_end' => '2022-02-29',              //公開終了日
             'posted' => '2022-02-29',                   //投稿日
-            'eyecatch' => 'a.aa',                   //アイキャッチ画像
+            'eye_catch' => 'a.aa',                   //アイキャッチ画像
         ]);
 
         //戻り値を確認
@@ -163,7 +163,7 @@ class BlogPostsTableTest extends BcTestCase
         //投稿日
         $this->assertEquals('投稿日の形式が不正です。', $errors['posted']['dateTime']);
         //アイキャッチ画像
-        $this->assertEquals('許可されていないファイルです。', $errors['eyecatch']['fileExt']);
+        $this->assertEquals('許可されていないファイルです。', $errors['eye_catch']['fileExt']);
     }
 
     /**


### PR DESCRIPTION
fix #2969

ブログ・コンテンツのアイキャッチに画像のみ受け付けるよう調整しました。
ご確認をお願いします