### PR TITLE
fix #2987 BcBaserHelper::getThemeUrl()でサブサイトに設定しているテーマURLが取得できない動作を修正

### DIFF
--- a/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
+++ b/lib/Baser/Test/Case/View/Helper/BcBaserHelperTest.php
@@ -1967,6 +1967,12 @@ class BcBaserHelperTest extends BaserTestCase
 		$this->siteConfig['theme'] = 'nada-icons';
 		$expects = $this->BcBaser->request->webroot . 'theme' . '/' . $this->siteConfig['theme'] . '/';
 		$this->assertEquals($expects, $this->BcBaser->getThemeUrl());
+
+		if (!empty($this->BcBaser->request->params['Site']['theme'])) {
+			$theme = $this->BcBaser->request->params['Site']['theme'];
+		}
+		$expects = $this->BcBaser->request->webroot . 'theme' . '/' . $theme . '/';
+		$this->assertEquals($expects, $this->BcBaser->getThemeUrl());
 	}
 
 	/**

--- a/lib/Baser/View/Helper/BcBaserHelper.php
+++ b/lib/Baser/View/Helper/BcBaserHelper.php
@@ -2454,7 +2454,11 @@ END_FLASH;
 	 */
 	public function getThemeUrl()
 	{
-		return $this->request->webroot . 'theme' . '/' . $this->siteConfig['theme'] . '/';
+		$theme = $this->siteConfig['theme'];
+		if ($this->theme) {
+			$theme = $this->theme;
+		}
+		return $this->request->webroot . 'theme' . DS . $theme . DS;
 	}
 
 	/**


### PR DESCRIPTION
issueはこちらです。 https://github.com/baserproject/basercms/issues/2987
可能な際に取込み検討をよろしくお願いします。
