### PR TITLE
fix #2991 baserCMS 5系 blogPosts()でカテゴリの指定を行うとエラーになる問題を解決

### DIFF
--- a/plugins/bc-blog/src/Service/BlogPostsService.php
+++ b/plugins/bc-blog/src/Service/BlogPostsService.php
@@ -358,15 +358,19 @@ class BlogPostsService implements BlogPostsServiceInterface
         array $conditions,
         string $category,
         int $blogContentId = null,
-        string $contentUrl = null,
+        $contentUrl = null,
         bool $force = false)
     {
         $categoryConditions = ['BlogCategories.name' => $category];
         if ($blogContentId) {
             $categoryConditions['BlogCategories.blog_content_id'] = $blogContentId;
         } elseif ($contentUrl) {
-            $entityIdData = $this->BlogPosts->BlogContents->Contents->find('all', ['Contents.url' => $contentUrl])->first();
-            $categoryConditions['BlogCategories.blog_content_id'] = $entityIdData->entity_id;
+            $entityIdData = $this->BlogPosts->BlogContents->Contents->find('all', [['Contents.url' => $contentUrl]])->toList();
+            if (!empty($entityIdData)) {
+                $categoryConditions['BlogCategories.blog_content_id'] = Hash::extract($entityIdData, '{n}.entity_id');
+            } else {
+                $categoryConditions['BlogCategories.blog_content_id'] = [];
+            }
         } elseif (!$force) {
             trigger_error(__d('baser_core', 'blog_content_id を指定してください。'), E_USER_WARNING);
         }

--- a/plugins/bc-blog/src/Service/BlogPostsService.php
+++ b/plugins/bc-blog/src/Service/BlogPostsService.php
@@ -375,7 +375,7 @@ class BlogPostsService implements BlogPostsServiceInterface
                     $categoryConditions['BlogCategories.blog_content_id IN'] = Hash::extract($entityIdData, '{n}.entity_id');
                 }
             } else {
-                $entityIdData = $this->BlogPosts->BlogContents->Contents->find('all', ['Contents.url' => $contentUrl])->first();
+                $entityIdData = $this->BlogPosts->BlogContents->Contents->find('all', ['conditions' => ['Contents.url' => $contentUrl]])->first();
                 $categoryConditions['BlogCategories.blog_content_id'] = $entityIdData->entity_id;
             }
         } elseif (!$force) {


### PR DESCRIPTION
@ryuring 
こちらが先程の修正箇所となります。
ループでfindを繰り返すと重くなりそうだったので、findメソッドを変更して、
Hash::extractにてentity_idの配列にしています。