### PR TITLE
fix #2996 【baserCMS5系】BcArrayHelperがBcBlogなどで使用できない問題を解決

### DIFF
--- a/plugins/baser-core/src/View/AppView.php
+++ b/plugins/baser-core/src/View/AppView.php
@@ -55,6 +55,7 @@ class AppView extends View
         $this->loadHelper('BaserCore.BcContents');
         $this->loadHelper('BaserCore.BcPage');
         $this->loadHelper('BaserCore.BcBaser');
+        $this->loadHelper('BaserCore.BcArray');
         $this->loadHelper('BaserCore.BcUpload');
         $this->loadHelper('BaserCore.BcToolbar');
         $this->loadHelper('Paginator');


### PR DESCRIPTION
@ryuring 

こちら調整しましたので、お手数ですが、ご確認お願いできますでしょうか？