### PR TITLE
fix #2998 管理画面 テキストエリアに自動で空白文字（改行）が入ってしまう問題を解決

### DIFF
--- a/plugins/baser-core/config/bc_form.php
+++ b/plugins/baser-core/config/bc_form.php
@@ -81,7 +81,7 @@ return [
     'radioWrapper' => '<span class="{{class}}">{{label}}</span>',
     'radioFormGroup' => '<span class="{{groupClass}}">{{input}}</span>',
     // Textarea input element,
-    'textarea' => "<textarea name=\"{{name}}\"{{attrs}}>{{value}}</textarea>",
+    'textarea' => "<textarea name=\"{{name}}\"{{attrs}}>\n{{value}}</textarea>",
     // Container for submit buttons.
     // 'submitContainer' => '<div class="submit">{{content}}</div>' NOTE: formAfterCreateにてデザインが崩れるため一旦コメントアウト
     'submitContainer' => '{{content}}',

--- a/plugins/baser-core/config/bc_form.php
+++ b/plugins/baser-core/config/bc_form.php
@@ -81,7 +81,7 @@ return [
     'radioWrapper' => '<span class="{{class}}">{{label}}</span>',
     'radioFormGroup' => '<span class="{{groupClass}}">{{input}}</span>',
     // Textarea input element,
-    'textarea' => "<textarea name=\"{{name}}\"{{attrs}}>\n{{value}}\n</textarea>",
+    'textarea' => "<textarea name=\"{{name}}\"{{attrs}}>{{value}}</textarea>",
     // Container for submit buttons.
     // 'submitContainer' => '<div class="submit">{{content}}</div>' NOTE: formAfterCreateにてデザインが崩れるため一旦コメントアウト
     'submitContainer' => '{{content}}',


### PR DESCRIPTION
@ryuring 

`<textarea></textarea>`内の改行コード2つを削除しました。
お手数ですが、ご確認お願いできますでしょうか？