### PR TITLE
BcUploadにアップロード対象のパスのチェックを追加

### DIFF
--- a/plugins/baser-core/src/Model/Behavior/BcUploadBehavior.php
+++ b/plugins/baser-core/src/Model/Behavior/BcUploadBehavior.php
@@ -16,6 +16,7 @@ use BaserCore\Utility\BcFileUploader;
 use Cake\ORM\Behavior;
 use Cake\Event\EventInterface;
 use Cake\Datasource\EntityInterface;
+use Cake\Validation\Validator;
 use BaserCore\Annotation\Note;
 use BaserCore\Annotation\NoTodo;
 use BaserCore\Annotation\Checked;
@@ -150,6 +151,26 @@ class BcUploadBehavior extends Behavior
     {
         if ($entity->getErrors()) {
             $this->BcFileUploader[$this->table()->getAlias()]->rollbackFile($entity);
+        }
+    }
+
+    /**
+     * Build Validator
+     *
+     * @param EventInterface $event
+     * @param Validator $validator
+     * @param string $name
+     */
+    public function buildValidator(EventInterface $event, Validator $validator, $name)
+    {
+        $settings = $this->getSettings();
+        foreach ($settings['fields'] as $field => $fieldSettings) {
+            $validator->add($field, 'checkFilePath', [
+                'rule' => function ($value) {
+                    return (!is_string($value) || !str_contains($value, '../'));
+                },
+                'message' => __d('baser_core', '許可されていないファイルです。')
+            ]);
         }
     }
 

--- a/plugins/baser-core/tests/TestCase/Model/Behavior/BcUploadBehaviorTest.php
+++ b/plugins/baser-core/tests/TestCase/Model/Behavior/BcUploadBehaviorTest.php
@@ -138,7 +138,7 @@ class BcUploadBehaviorTest extends BcTestCase
         $this->table->dispatchEvent('Model.buildValidator',
             ['validator' => $validator, 'name' => 'test']);
         $rules = $this->table->getValidator()->field('eyecatch');
-        $this->assertNotNull($rules['checkDirectoryTraversal']);
+        $this->assertNotNull($rules['checkFilePath']);
     }
 
 

--- a/plugins/baser-core/tests/TestCase/Model/Behavior/BcUploadBehaviorTest.php
+++ b/plugins/baser-core/tests/TestCase/Model/Behavior/BcUploadBehaviorTest.php
@@ -12,6 +12,7 @@ namespace BaserCore\Test\TestCase\Model\Behavior;
 
 use ArrayObject;
 use Cake\ORM\Entity;
+use Cake\Validation\Validator;
 use BaserCore\TestSuite\BcTestCase;
 use BaserCore\Utility\BcContainerTrait;
 use BaserCore\Model\Table\ContentsTable;
@@ -127,6 +128,19 @@ class BcUploadBehaviorTest extends BcTestCase
                 ->getUploadingFiles($data['_bc_upload_id'])
         );
     }
+
+    /**
+     * Build Validator
+     */
+    public function testBuildValidator()
+    {
+        $validator = new Validator();
+        $this->table->dispatchEvent('Model.buildValidator',
+            ['validator' => $validator, 'name' => 'test']);
+        $rules = $this->table->getValidator()->field('eyecatch');
+        $this->assertNotNull($rules['checkDirectoryTraversal']);
+    }
+
 
     /**
      * After save


### PR DESCRIPTION
リクエスト内のファイルのパスに「../」が含まれていると、予期せぬファイルの変更が可能になってしまうため修正しています。
ご確認お願いします。

以下はブログ記事追加の際の例です。

<img width="866" alt="スクリーンショット 2024-01-04 15 52 30" src="https://github.com/baserproject/basercms/assets/30764014/3467e9ef-3081-4536-890a-fdaa40fba442">
