### PR TITLE
【ブログ】記事の一括削除を行った際にアイキャッチが削除されない #3004

### DIFF
--- a/plugins/bc-blog/src/Service/BlogPostsService.php
+++ b/plugins/bc-blog/src/Service/BlogPostsService.php
@@ -690,6 +690,7 @@ class BlogPostsService implements BlogPostsServiceInterface
     public function delete(int $id): bool
     {
         $blogPost = $this->BlogPosts->get($id);
+        $this->setupUpload($blogPost->blog_content_id);
         return $this->BlogPosts->delete($blogPost);
     }
 

--- a/plugins/bc-blog/tests/TestCase/Service/BlogPostsServiceTest.php
+++ b/plugins/bc-blog/tests/TestCase/Service/BlogPostsServiceTest.php
@@ -828,7 +828,8 @@ class BlogPostsServiceTest extends BcTestCase
     public function testDelete()
     {
         //データ 生成
-        BlogPostFactory::make(['id' => '1'])->persist();
+        $this->loadFixtureScenario(BlogContentScenario::class, 1, 1, null, 'news1', '/news/');
+        BlogPostFactory::make(['id' => '1', 'blog_content_id' => 1])->persist();
 
         // //存在しているBlogPostIdを削除
         $result = $this->BlogPostsService->delete(1);
@@ -885,6 +886,7 @@ class BlogPostsServiceTest extends BcTestCase
     public function testBatch()
     {
         // データを生成
+        $this->loadFixtureScenario(BlogContentScenario::class, 5, 1, null, 'news1', '/news/');
         BlogPostFactory::make(['id' => '1', 'blog_content_id' => '5', 'title' => 'test blog post batch'])->persist();
         BlogPostFactory::make(['id' => '2', 'blog_content_id' => '5', 'title' => 'test blog post batch'])->persist();
         BlogPostFactory::make(['id' => '3', 'blog_content_id' => '5', 'title' => 'test blog post batch'])->persist();


### PR DESCRIPTION
fix #3004

記事の一括削除時は plugins/bc-blog/src/Controller/Admin/BlogPostsController->beforeFilter 内の

```
$service->setupUpload($blogContentId);
```

が呼び出されず、ファイルのパスの生成がうまくいかずにファイルの削除に失敗しているようでしたので調整しました。

ご確認お願いします。