### PR TITLE
管理者以外でログインしている場合に一括処理用のチェックボックスが表示される

### DIFF
--- a/plugins/bc-admin-third/templates/Admin/element/Contents/index_list_table.php
+++ b/plugins/bc-admin-third/templates/Admin/element/Contents/index_list_table.php
@@ -52,7 +52,9 @@ $this->BcBaser->js('admin/contents/index_table.bundle');
   <thead class="bca-table-listup__thead">
   <tr>
     <th class="list-tool bca-table-listup__thead-th bca-table-listup__thead-th--select" title="<?php echo __d('baser_core', '一括選択') ?>">
-      <?php echo $this->BcAdminForm->control('checkall', ['type' => 'checkbox', 'label' => ' ', 'title' => __d('baser_core', '一括選択')]) ?>
+      <?php if ($this->BcBaser->isAdminUser()): ?>
+        <?php echo $this->BcAdminForm->control('checkall', ['type' => 'checkbox', 'label' => ' ', 'title' => __d('baser_core', '一括選択')]) ?>
+      <?php endif ?>
     </th>
     <th class="bca-table-listup__thead-th">
       <?php echo $this->Paginator->sort('id',

--- a/plugins/bc-admin-third/templates/plugin/BcBlog/Admin/element/BlogCategories/index_list.php
+++ b/plugins/bc-admin-third/templates/plugin/BcBlog/Admin/element/BlogCategories/index_list.php
@@ -47,7 +47,9 @@ $this->BcListTable->setColumnNumber(6);
   <thead class="bca-table-listup__thead">
   <tr>
     <th class="list-tool bca-table-listup__thead-th bca-table-listup__thead-th--select" title="<?php echo __d('baser_core', '一括選択') ?>">
-      <?php echo $this->BcAdminForm->control('checkall', ['type' => 'checkbox', 'label' => ' ', 'title' => __d('baser_core', '一括選択')]) ?>
+      <?php if ($this->BcBaser->isAdminUser()): ?>
+        <?php echo $this->BcAdminForm->control('checkall', ['type' => 'checkbox', 'label' => ' ', 'title' => __d('baser_core', '一括選択')]) ?>
+      <?php endif ?>
     </th>
     <th class="bca-table-listup__thead-th"><?php echo __d('baser_core', 'No') ?></th>
     <th class="bca-table-listup__thead-th"><?php echo __d('baser_core', 'カテゴリ名') ?></th>

--- a/plugins/bc-admin-third/templates/plugin/BcBlog/Admin/element/BlogComments/index_list.php
+++ b/plugins/bc-admin-third/templates/plugin/BcBlog/Admin/element/BlogComments/index_list.php
@@ -44,7 +44,9 @@ $this->BcBaser->js('BcBlog.admin/blog_comments/index.bundle', false);
   <thead class="bca-table-listup__thead ">
   <tr>
     <th class="list-tool bca-table-listup__thead-th bca-table-listup__thead-th--select" title="<?php echo __d('baser_core', '一括選択') ?>">
-      <?php echo $this->BcAdminForm->control('checkall', ['type' => 'checkbox', 'label' => ' ', 'title' => __d('baser_core', '一括選択')]) ?>
+      <?php if ($this->BcBaser->isAdminUser()): ?>
+        <?php echo $this->BcAdminForm->control('checkall', ['type' => 'checkbox', 'label' => ' ', 'title' => __d('baser_core', '一括選択')]) ?>
+      <?php endif ?>
     </th>
     <th class="bca-table-listup__thead-th">
       <?php

--- a/plugins/bc-admin-third/templates/plugin/BcBlog/Admin/element/BlogPosts/index_list.php
+++ b/plugins/bc-admin-third/templates/plugin/BcBlog/Admin/element/BlogPosts/index_list.php
@@ -56,7 +56,9 @@ $this->BcListTable->setColumnNumber(9);
   <thead class="bca-table-listup__thead">
   <tr>
     <th class="list-tool bca-table-listup__thead-th bca-table-listup__thead-th--select" title="<?php echo __d('baser_core', '一括選択') ?>">
-      <?php echo $this->BcAdminForm->control('checkall', ['type' => 'checkbox', 'label' => ' ', 'title' => __d('baser_core', '一括選択')]) ?>
+      <?php if ($this->BcBaser->isAdminUser()): ?>
+        <?php echo $this->BcAdminForm->control('checkall', ['type' => 'checkbox', 'label' => ' ', 'title' => __d('baser_core', '一括選択')]) ?>
+      <?php endif ?>
     </th>
     <th class="bca-table-listup__thead-th"><?php // No ?>
       <?php echo $this->Paginator->sort('no', [

--- a/plugins/bc-admin-third/templates/plugin/BcBlog/Admin/element/BlogTags/index_list.php
+++ b/plugins/bc-admin-third/templates/plugin/BcBlog/Admin/element/BlogTags/index_list.php
@@ -42,7 +42,9 @@ $this->BcListTable->setColumnNumber(5);
   <thead class="bca-table-listup__thead">
   <tr>
     <th class="list-tool bca-table-listup__thead-th bca-table-listup__thead-th--select" title="<?php echo __d('baser_core', '一括選択') ?>">
-      <?php echo $this->BcAdminForm->control('checkall', ['type' => 'checkbox', 'label' => ' ', 'title' => __d('baser_core', '一括選択')]) ?>
+      <?php if ($this->BcBaser->isAdminUser()): ?>
+        <?php echo $this->BcAdminForm->control('checkall', ['type' => 'checkbox', 'label' => ' ', 'title' => __d('baser_core', '一括選択')]) ?>
+      <?php endif ?>
     </th>
     <th class="bca-table-listup__thead-th">
       <?php

--- a/plugins/bc-admin-third/templates/plugin/BcMail/Admin/element/MailFields/index_list.php
+++ b/plugins/bc-admin-third/templates/plugin/BcMail/Admin/element/MailFields/index_list.php
@@ -50,7 +50,9 @@ $this->BcListTable->setColumnNumber(8);
   <thead class="bca-table-listup__thead">
   <tr>
     <th class="list-tool bca-table-listup__thead-th bca-table-listup__thead-th--select" title="<?php echo __d('baser_core', '一括選択') ?>">
-      <?php echo $this->BcAdminForm->control('checkall', ['type' => 'checkbox', 'label' => ' ', 'title' => __d('baser_core', '一括選択')]) ?>
+      <?php if ($this->BcBaser->isAdminUser()): ?>
+        <?php echo $this->BcAdminForm->control('checkall', ['type' => 'checkbox', 'label' => ' ', 'title' => __d('baser_core', '一括選択')]) ?>
+      <?php endif ?>
       <?php if (!$this->request->getQuery('sortmode')): ?>
         <?php $this->BcBaser->link(
           '<i class="bca-btn-icon-text" data-bca-btn-type="draggable"></i>' . __d('baser_core', '並び替え'),

--- a/plugins/bc-admin-third/templates/plugin/BcSearchIndex/Admin/element/SearchIndexes/index_list.php
+++ b/plugins/bc-admin-third/templates/plugin/BcSearchIndex/Admin/element/SearchIndexes/index_list.php
@@ -41,7 +41,9 @@ $this->BcListTable->setColumnNumber(9);
   <thead class="bca-table-listup__thead">
   <tr>
     <th class="list-tool bca-table-listup__thead-th bca-table-listup__thead-th--select" title="<?php echo __d('baser_core', '一括選択') ?>">
-      <?php echo $this->BcAdminForm->control('checkall', ['type' => 'checkbox', 'label' => ' ', 'title' => __d('baser_core', '一括選択')]) ?>
+      <?php if ($this->BcBaser->isAdminUser()): ?>
+        <?php echo $this->BcAdminForm->control('checkall', ['type' => 'checkbox', 'label' => ' ', 'title' => __d('baser_core', '一括選択')]) ?>
+      <?php endif ?>
     </th>
     <th class="bca-table-listup__thead-th">No</th>
     <th class="bca-table-listup__thead-th"><?php echo __d('baser_core', 'タイプ') ?><br><?php echo __d('baser_core', 'タイトル') ?>

--- a/plugins/bc-admin-third/templates/plugin/BcWidgetArea/Admin/element/WidgetAreas/index_list.php
+++ b/plugins/bc-admin-third/templates/plugin/BcWidgetArea/Admin/element/WidgetAreas/index_list.php
@@ -49,7 +49,9 @@ $this->BcListTable->setColumnNumber(6);
   <thead class="bca-table-listup__thead">
   <tr class="">
     <th class="list-tool bca-table-listup__thead-th bca-table-listup__thead-th--select" title="<?php echo __d('baser_core', '一括選択') ?>">
-      <?php echo $this->BcAdminForm->control('checkall', ['type' => 'checkbox', 'label' => ' ', 'title' => __d('baser_core', '一括選択')]) ?>
+      <?php if ($this->BcBaser->isAdminUser()): ?>
+        <?php echo $this->BcAdminForm->control('checkall', ['type' => 'checkbox', 'label' => ' ', 'title' => __d('baser_core', '一括選択')]) ?>
+      <?php endif ?>
     </th>
     <th class="bca-table-listup__thead-th">No</th>
     <th class="bca-table-listup__thead-th"><?php echo __d('baser_core', 'ウィジェットエリア名') ?></th>


### PR DESCRIPTION
一括処理用のボタンは表示されていないため、動作しないチェックボックスが表示されていたため非表示にしました。
受信メール一覧だけは、管理者以外でも一括処理用のボタンが表示されていたためそのままにしています。
ご確認お願いします。

<img width="1238" alt="スクリーンショット_2024-01-09_13_37_13" src="https://github.com/baserproject/basercms/assets/30764014/1dbef5a6-461e-4bcd-88d1-9c0b37b71d00">