### PR TITLE
アクセスルールグループ編集 該当するアクセスルール一覧へのリンクを追加

### DIFF
--- a/plugins/bc-admin-third/templates/Admin/PermissionGroups/edit.php
+++ b/plugins/bc-admin-third/templates/Admin/PermissionGroups/edit.php
@@ -56,6 +56,17 @@ $this->BcAdmin->addAdminMainBodyHeaderLinks([
         'data-bca-btn-width' => 'lg',
         'id' => 'BtnSave']
     ) ?>
+    <?php echo $this->BcHtml->link(__d('baser_core', 'アクセスルール一覧に移動'), [
+      'controller' => 'Permissions',
+      'action' => 'index',
+      $userGroupId,
+      '?' => [
+        'permission_group_type' => $entity->type,
+        'permission_group_id' => $entity->id,
+      ],
+    ], [
+      'class' => 'bca-btn bca-actions__item',
+    ]) ?>
   </div>
   <div class="bca-actions__sub">
       <?= $this->BcAdminForm->postLink(


### PR DESCRIPTION
今まで、アクセスルールグループ編集画面を開いているときにルールを並び替えようと思った場合は以下のような遷移が必要だったため、リンクを追加しています。
ご確認お願いします。

- 「一覧に戻る」をクリック
- 画面下部の「アクセスルール一覧に移動」をクリック
- 検索で「アクセスルールグループ」を指定