### PR TITLE
fix #1260 （baserCMS4系）【システム】「データのバックアップ」機能を利用するとタイムアウトが発生する問題を解決

### DIFF
--- a/lib/Baser/Controller/ToolsController.php
+++ b/lib/Baser/Controller/ToolsController.php
@@ -271,9 +271,7 @@ class ToolsController extends AppController
 		$Plugin = ClassRegistry::init('Plugin');
 		$plugins = $Plugin->find('all');
 		if ($plugins) {
-			foreach($plugins as $plugin) {
-				$this->_writeBackup($tmpDir . 'plugin' . DS, $plugin['Plugin']['name'], $encoding);
-			}
+			$this->_writeBackup($tmpDir . 'plugin' . DS, 'blog', $encoding);
 		}
 		
 		// ZIP圧縮して出力


### PR DESCRIPTION
・baserCMSのコアのバグでプラグインの数だけ全データを繰り返し取得する仕様になっていたため修正

@ryuring 
昨日のデータメンテナンス→バックアップがタイムアウトになる問題の解消をコミットしました。
お手数ですが、baserCMS 4系にマージをお願いできますでしょうか？

cc @kaburk 