### PR TITLE
alphaNumericDashUnderscore削除

### DIFF
--- a/plugins/baser-core/src/Model/Validation/BcValidation.php
+++ b/plugins/baser-core/src/Model/Validation/BcValidation.php
@@ -62,20 +62,6 @@ class BcValidation extends Validation
     }
 
     /**
-     * 半角英数字+アンダーバー＋ハイフンのチェック
-     *
-     * @param string $value 確認する値を含む配列。先頭の要素のみチェックされる
-     * @return boolean
-     * @checked
-     * @noTodo
-     * @unitTest
-     */
-    public static function alphaNumericDashUnderscore($value)
-    {
-        return (bool)preg_match('|^[0-9a-zA-Z_-]*$|', $value);
-    }
-
-    /**
      * 削除文字チェック
      *
      * BcUtile::urlencode で、削除される文字のみで構成されているかチェック(結果ブランクになるためnotBlankになる確認)

--- a/plugins/baser-core/tests/TestCase/Model/Validation/BcValidationTest.php
+++ b/plugins/baser-core/tests/TestCase/Model/Validation/BcValidationTest.php
@@ -80,28 +80,21 @@ class BcValidationTest extends BcTestCase
 
     public function alphaNumericPlusDataProvider()
     {
-        return [
-            ['あいうえお', [], false],
-            ['あいうえお', ['あ'], false],
-            ['あいうえお', ['あいうえお'], true],
-            ['あいうえお_', ['あいうえお'], true],
-        ];
-    }
-
-    /**
-     * Test alphaNumericDashUnderscore
-     *
-     * @return void
-     */
-    public function testAlphaNumericDashUnderscore()
-    {
         $alpha = implode('', array_merge(range('a', 'z'), range('A', 'Z')));
         $numeric = implode('', range(0, 9));
         $mark = '-_';
         $allowedChars = $alpha . $numeric . $mark;
 
-        $this->assertEquals(true, $this->BcValidation->alphaNumericDashUnderscore($allowedChars));
-        $this->assertEquals(false, $this->BcValidation->alphaNumericDashUnderscore($allowedChars . '!'));
+        return [
+            ['test', [], true],
+            ['test!', [], false],
+            [$allowedChars, [], true],
+            [$allowedChars . '!', [], false],
+            ['あいうえお', [], false],
+            ['あいうえお', ['あ'], false],
+            ['あいうえお', ['あいうえお'], true],
+            ['あいうえお_', ['あいうえお'], true],
+        ];
     }
 
     /**

--- a/plugins/bc-blog/src/Model/Table/BlogCategoriesTable.php
+++ b/plugins/bc-blog/src/Model/Table/BlogCategoriesTable.php
@@ -106,10 +106,10 @@ class BlogCategoriesTable extends BlogAppTable
             ->requirePresence('name', 'create', __d('baser_core', 'カテゴリ名を入力してください。'))
             ->notEmptyString('name', __d('baser_core', 'カテゴリ名を入力してください。'))
             ->add('name', [
-                'alphaNumericDashUnderscore' => [
-                    'rule' => ['alphaNumericDashUnderscore'],
+                'alphaNumericPlus' => [
+                    'rule' => ['alphaNumericPlus'],
                     'provider' => 'bc',
-                    'message' => __d('baser_core', 'カテゴリ名はは半角英数字とハイフン、アンダースコアのみが利用可能です。')]])
+                    'message' => __d('baser_core', 'カテゴリ名は半角英数字とハイフン、アンダースコアのみが利用可能です。')]])
             ->add('name', [
                 'duplicateBlogCategory' => [
                     'rule' => ['duplicateBlogCategory'],

--- a/plugins/bc-blog/tests/TestCase/Controller/Api/Admin/BlogCategoriesControllerTest.php
+++ b/plugins/bc-blog/tests/TestCase/Controller/Api/Admin/BlogCategoriesControllerTest.php
@@ -194,8 +194,8 @@ class BlogCategoriesControllerTest extends BcTestCase
         $result = json_decode((string)$this->_response->getBody());
         $this->assertEquals('入力エラーです。内容を修正してください。', $result->message);
         $this->assertEquals(
-            'カテゴリ名はは半角英数字とハイフン、アンダースコアのみが利用可能です。',
-            $result->errors->name->alphaNumericDashUnderscore);
+            'カテゴリ名は半角英数字とハイフン、アンダースコアのみが利用可能です。',
+            $result->errors->name->alphaNumericPlus);
     }
 
     /**

--- a/plugins/bc-blog/tests/TestCase/Model/BlogCategoriesTableTest.php
+++ b/plugins/bc-blog/tests/TestCase/Model/BlogCategoriesTableTest.php
@@ -116,14 +116,14 @@ class BlogCategoriesTableTest extends BcTestCase
         $this->assertSame([
             'name' => ['_empty' => 'カテゴリ名を入力してください。'],
         ], $blogCategory->getErrors());
-        // name alphaNumericDashUnderscore　テスト
+        // name alphaNumericPlus　テスト
         $blogCategory = $this->BlogCategoriesTable->newEntity([
             'name' => 'test 123',
             'blog_content_id' => 1,
             'title' => 'test'
         ]);
         $this->assertSame([
-            'name' => ['alphaNumericDashUnderscore' => 'カテゴリ名はは半角英数字とハイフン、アンダースコアのみが利用可能です。'],
+            'name' => ['alphaNumericPlus' => 'カテゴリ名は半角英数字とハイフン、アンダースコアのみが利用可能です。'],
         ], $blogCategory->getErrors());
         // name duplicateBlogCategory　テスト
         BlogCategoryFactory::make([


### PR DESCRIPTION
BcValidationの [alphaNumericPlus](https://github.com/baserproject/basercms/blob/dev-5/plugins/baser-core/src/Model/Validation/BcValidation.php#L42) と [alphaNumericDashUnderscore](https://github.com/baserproject/basercms/blob/dev-5/plugins/baser-core/src/Model/Validation/BcValidation.php#L73C28-L73C54) で役割がかぶるので alphaNumericDashUnderscore を削除しました。
ご確認お願いします。
