### PR TITLE
fix #3095 複数のブログが有るサイトで特定のブログで、 同じ記事IDの記事が３つ並んで表示される問題を解決

### DIFF
--- a/plugins/bc-blog/src/Service/BlogPostsService.php
+++ b/plugins/bc-blog/src/Service/BlogPostsService.php
@@ -339,7 +339,7 @@ class BlogPostsService implements BlogPostsServiceInterface
         if ($params['author']) {
             $conditions = $this->createAuthorCondition($conditions, $params['author']);
         }
-        return $query->where($conditions);
+        return $query->where($conditions)->distinct('BlogPosts.id');
     }
 
     /**


### PR DESCRIPTION
BlogPostsService に　distinctメソッドを入れました。

return $query->where($conditions)->distinct('BlogPosts.id');
（BlogPost.idの重複をさせない）
