### PR TITLE
fix #3099ブログカテゴリアーカイブページや年別一覧ページなどでカテゴリや記事タイトルがパンくずやtitleタグに正しく反映されない…

### DIFF
--- a/plugins/baser-core/src/View/Helper/BcBaserHelper.php
+++ b/plugins/baser-core/src/View/Helper/BcBaserHelper.php
@@ -646,6 +646,10 @@ class BcBaserHelper extends Helper
      */
     public function getContentsTitle()
     {
+        // ブログアーカイブ一覧のときはカテゴリ名や年などがタイトルに
+        if ($this->isBlogArchive() || $this->isBlogSingle()) {
+            return($this->getBlogTitle());
+        }
         return $this->_View->fetch('title');
     }
 

--- a/plugins/bc-blog/src/View/Helper/BcBlogBaserHelper.php
+++ b/plugins/bc-blog/src/View/Helper/BcBlogBaserHelper.php
@@ -58,6 +58,7 @@ class BcBlogBaserHelper extends Helper implements BcPluginBaserHelperInterface
             'isBlogYear' => ['Blog', 'isYear'],
             'isBlogSingle' => ['Blog', 'isSingle'],
             'isBlogHome' => ['Blog', 'isHome'],
+            'isBlogArchive' => ['Blog', 'isArchive'],
             'getBlogs' => ['Blog', 'getContents'],
             'isBlog' => ['Blog', 'isBlog'],
             'getBlogCategories' => ['Blog', 'getCategories'],

--- a/plugins/bc-blog/src/View/Helper/BlogHelper.php
+++ b/plugins/bc-blog/src/View/Helper/BlogHelper.php
@@ -254,6 +254,33 @@ class BlogHelper extends Helper
      */
     public function getTitle()
     {
+        if ($this->isArchive()) { // ブログ 各絞り込み一覧
+            $archiveType = $this->getBlogArchiveType();
+            switch ($archiveType) {
+                case 'category':
+                    return $this->_View->get('blogCategory')->title;
+                    break;
+                case 'tag':
+                    return $this->_View->get('blogTag')->name;
+                    break;
+                case 'yearly':
+                    return $this->_View->get('year').'年';
+                    break;
+                case 'monthly':
+                    return $this->_View->get('year').'年 '. $this->_View->get('month').'月';
+                    break;
+                case 'daily':
+                    return $this->_View->get('year').'年 '. $this->_View->get('month').'月 '. $this->_View->get('day').'日';
+                    break;
+                case 'author':
+                    return $this->_View->get('author')->real_name_1. ' '. $this->_View->get('author')->real_name_2;
+                    break;
+                default:
+                    break;
+            }
+        } elseif ($this->isSingle()) { // ブログ記事
+            return $this->_View->get('post')->title;
+        }
         return $this->currentContent->title;
     }
 


### PR DESCRIPTION
…問題を解決

