### PR TITLE
fix #3120 カスタムコンテンツを２つ以上トップページなどで一覧表示させるとアイキャッチが取得できない問題を解決

### DIFF
--- a/plugins/bc-custom-content/src/View/Helper/CustomContentHelper.php
+++ b/plugins/bc-custom-content/src/View/Helper/CustomContentHelper.php
@@ -214,7 +214,7 @@ class CustomContentHelper extends CustomContentAppHelper
 
         $customLink = $this->getLink($entry->custom_table_id, $fieldName);
 
-        if (empty($customLink->display_front) || !$customLink->display_front) return '';
+        if (empty($customLink->display_front)) return '';
         /** @var CustomField $field */
         $field = $customLink->custom_field;
 

--- a/plugins/bc-custom-content/src/View/Helper/CustomContentHelper.php
+++ b/plugins/bc-custom-content/src/View/Helper/CustomContentHelper.php
@@ -214,7 +214,7 @@ class CustomContentHelper extends CustomContentAppHelper
 
         $customLink = $this->getLink($entry->custom_table_id, $fieldName);
 
-        if (!$customLink->display_front) return '';
+        if (empty($customLink->display_front) || !$customLink->display_front) return '';
         /** @var CustomField $field */
         $field = $customLink->custom_field;
 


### PR DESCRIPTION
@ryuring 

シンプルにWarning対策を行っています。
お手数ですが、ご確認の上、マージをお願いします。

`Warning (2) : Attempt to read property "display_front" on bool [in /var/www/html/vendor/baserproject/bc-custom-content/src/View/Helper/CustomContentHelper.php, line 217]`