### PR TITLE
fix #3128 ブログ記事編集画面内の「新しいカテゴリを追加」ポップアップ内のヘルプ文言をエラーメッセージ内容と同じに調整

### DIFF
--- a/plugins/bc-admin-third/templates/plugin/BcBlog/Admin/element/BlogPosts/popup_blog_category.php
+++ b/plugins/bc-admin-third/templates/plugin/BcBlog/Admin/element/BlogPosts/popup_blog_category.php
@@ -31,7 +31,7 @@
       <div class="bca-helptext">
         <ul>
           <li><?php echo __d('baser_core', 'URLに利用されます') ?></li>
-          <li><?php echo __d('baser_core', '半角のみで入力してください') ?></li>
+          <li><?php echo __d('baser_core', 'カテゴリ名は半角英数字とハイフン、アンダースコアのみ入力可能です') ?></li>
           <li><?php echo __d('baser_core', '空の場合はカテゴリタイトルから値が自動で設定されます') ?></li>
         </ul>
       </div>


### PR DESCRIPTION
issueはこちら https://github.com/baserproject/basercms/issues/3128
可能な際に取込み検討お願いします
