### PR TITLE
認証失敗時のリダイレクト先の調整

### DIFF
--- a/plugins/baser-core/src/Controller/AppController.php
+++ b/plugins/baser-core/src/Controller/AppController.php
@@ -175,7 +175,9 @@ class AppController extends BaseController
                 }
                 // リファラが存在する場合はリファラにリダイレクトする
                 // $this->referer() で判定した場合、リファラがなくてもトップのURLが返却されるため ServerRequest で判定
-                if ($this->getRequest()->getEnv('HTTP_REFERER')) {
+                if ($this->getRequest()->getEnv('HTTP_REFERER') &&
+                    $this->getRequest()->getAttribute('here') !== $this->referer()
+                ) {
                     $url = $this->referer();
                 } else {
                     $url = Configure::read("BcPrefixAuth.{$prefix}.loginRedirect");


### PR DESCRIPTION
管理画面で認証失敗時に無限ループになる場合があるため修正しています。ご確認お願いします。

■再現方法

- 管理画面にログイン
- 管理画面内のダッシュボード以外のページにアクセス
- Cookieを消す
- 管理画面内のダッシュボード以外のページにアクセス