### PR TITLE
テーブル名にmysiteなどのprefixがついている場合アクセスルールの追加ができない問題を修正

### DIFF
--- a/plugins/baser-core/src/Model/Table/PermissionsTable.php
+++ b/plugins/baser-core/src/Model/Table/PermissionsTable.php
@@ -127,7 +127,7 @@ class PermissionsTable extends AppTable
     public function validationPlain($validator)
     {
         $collection = ConnectionManager::get('default')->getSchemaCollection();
-        $columns = $collection->describe('permissions')->columns();
+        $columns = $collection->describe($this->getTable())->columns();
         $required = ['user_group_id'];
 
         $validator


### PR DESCRIPTION
ご確認お願いします。