### PR TITLE
fix #3275 baserCMS4系 メールフォームで半角変換を有効にしても全角ハイフンが半角ハイフンにならない問題を解決

### DIFF
--- a/lib/Baser/Plugin/Mail/Model/MailMessage.php
+++ b/lib/Baser/Plugin/Mail/Model/MailMessage.php
@@ -559,6 +559,7 @@ class MailMessage extends MailAppModel
 				}
 				// 全角処理
 				if ($mailField['auto_convert'] === 'CONVERT_ZENKAKU') {
+					$value = str_replace('ー', '-', $value); // 全角ハイフンを半角ハイフンに置換
 					$value = mb_convert_kana($value, 'AK');
 				}
 				// サニタイズ


### PR DESCRIPTION
@ryuring 
cc @kaburk 

こちら、お話させていただきました、メールフォームの半角変換で、

`mb_convert_kana($value, 'a');`

では、全角スペースが半角変換できない問題を解消するためのコミットとなります。

4系の対応となりますが、お手数ですが、ご確認・マージお願いできますでしょうか？