### PR TITLE
fix #2930 テーマ設定のテーマカラーにエラーメッセージ追加

### DIFF
--- a/plugins/baser-core/src/Model/Validation/BcValidation.php
+++ b/plugins/baser-core/src/Model/Validation/BcValidation.php
@@ -600,4 +600,18 @@ class BcValidation extends Validation
         return (preg_replace("/( |　)/", '', $string) !== '');
     }
 
+    /**
+     * 16進数カラーコードチェック
+     *
+     * @param string $value 対象となる値
+     * @return bool
+     * @checked
+     * @notodo
+     * @unitTest
+     */
+    public static function hexColorPlus($value): bool
+    {
+        return preg_match('/\A([0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})\z/i', $value);
+    }
+
 }

--- a/plugins/baser-core/tests/TestCase/Model/Validation/BcValidationTest.php
+++ b/plugins/baser-core/tests/TestCase/Model/Validation/BcValidationTest.php
@@ -618,4 +618,31 @@ class BcValidationTest extends BcTestCase
         $this->assertTrue($result);
     }
 
+    /**
+     * test hexColorPlus
+     *
+     * @param string $value
+     * @param boolean $expect
+     * @return void
+     * @dataProvider hexColorPlusDataProvider
+     */
+    public function testHexColorPlus($value, $expect)
+    {
+        $result = $this->BcValidation->hexColorPlus($value);
+        $this->assertEquals($expect, $result);
+    }
+
+    public function hexColorPlusDataProvider()
+    {
+        return [
+            ['000', true],
+            ['0fF', true],
+            ['123f', true],
+            ['123abc', true],
+            ['1234abcd', true],
+            ['black', false],
+            ['#000', false]
+        ];
+    }
+
 }

--- a/plugins/bc-admin-third/templates/plugin/BcThemeConfig/Admin/ThemeConfigs/index.php
+++ b/plugins/bc-admin-third/templates/plugin/BcThemeConfig/Admin/ThemeConfigs/index.php
@@ -66,6 +66,10 @@ $this->BcAdmin->setHelp('theme_configs_form');
       　
       <small>[<?php echo __d('baser_core', 'テキストホバー') ?>]</small>
       #<?php echo $this->BcAdminForm->control('color_hover', ['type' => 'text', 'size' => 6, 'class' => 'bca-textbox__input color-picker']) ?>
+      <?php echo $this->BcAdminForm->error('color_main') ?>
+      <?php echo $this->BcAdminForm->error('color_sub') ?>
+      <?php echo $this->BcAdminForm->error('color_link') ?>
+      <?php echo $this->BcAdminForm->error('color_hover') ?>
     </td>
   </tr>
   <tr>

--- a/plugins/bc-theme-config/src/Model/Table/ThemeConfigsTable.php
+++ b/plugins/bc-theme-config/src/Model/Table/ThemeConfigsTable.php
@@ -75,6 +75,50 @@ class ThemeConfigsTable extends AppTable
      */
     public function validationKeyValue(Validator $validator): Validator
     {
+        // color_main
+        $validator
+            ->allowEmptyString('color_main')
+            ->add('color_main', [
+                'hexColorPlus' => [
+                    'rule' => 'hexColorPlus',
+                    'provider' => 'bc',
+                    'message' => __d('baser_core', 'メインはカラーコードを入力してください。')
+                ]
+            ]);
+
+        // color_sub
+        $validator
+            ->allowEmptyString('color_sub')
+            ->add('color_sub', [
+                'hexColorPlus' => [
+                    'rule' => 'hexColorPlus',
+                    'provider' => 'bc',
+                    'message' => __d('baser_core', 'サブはカラーコードを入力してください。')
+                ]
+            ]);
+
+        // color_link
+        $validator
+            ->allowEmptyString('color_link')
+            ->add('color_link', [
+                'hexColorPlus' => [
+                    'rule' => 'hexColorPlus',
+                    'provider' => 'bc',
+                    'message' => __d('baser_core', 'テキストリンクはカラーコードを入力してください。')
+                ]
+            ]);
+
+        // color_hover
+        $validator
+            ->allowEmptyString('color_hover')
+            ->add('color_hover', [
+                'hexColorPlus' => [
+                    'rule' => 'hexColorPlus',
+                    'provider' => 'bc',
+                    'message' => __d('baser_core', 'テキストホバーはカラーコードを入力してください。')
+                ]
+            ]);
+
         // logo
         $validator->add('logo', [
             'fileExt' => [

--- a/plugins/bc-theme-config/src/Model/Table/ThemeConfigsTable.php
+++ b/plugins/bc-theme-config/src/Model/Table/ThemeConfigsTable.php
@@ -82,7 +82,7 @@ class ThemeConfigsTable extends AppTable
                 'hexColorPlus' => [
                     'rule' => 'hexColorPlus',
                     'provider' => 'bc',
-                    'message' => __d('baser_core', 'メインはカラーコードを入力してください。')
+                    'message' => __d('baser_core', 'メインのカラーコードの形式が間違っています。')
                 ]
             ]);
 
@@ -93,7 +93,7 @@ class ThemeConfigsTable extends AppTable
                 'hexColorPlus' => [
                     'rule' => 'hexColorPlus',
                     'provider' => 'bc',
-                    'message' => __d('baser_core', 'サブはカラーコードを入力してください。')
+                    'message' => __d('baser_core', 'サブのカラーコードの形式が間違っています。')
                 ]
             ]);
 
@@ -104,7 +104,7 @@ class ThemeConfigsTable extends AppTable
                 'hexColorPlus' => [
                     'rule' => 'hexColorPlus',
                     'provider' => 'bc',
-                    'message' => __d('baser_core', 'テキストリンクはカラーコードを入力してください。')
+                    'message' => __d('baser_core', 'テキストリンクのカラーコードの形式が間違っています。')
                 ]
             ]);
 
@@ -115,7 +115,7 @@ class ThemeConfigsTable extends AppTable
                 'hexColorPlus' => [
                     'rule' => 'hexColorPlus',
                     'provider' => 'bc',
-                    'message' => __d('baser_core', 'テキストホバーはカラーコードを入力してください。')
+                    'message' => __d('baser_core', 'テキストホバーのカラーコードの形式が間違っています。')
                 ]
             ]);
 

--- a/plugins/bc-theme-config/tests/TestCase/Model/Table/ThemeConfigTest.php
+++ b/plugins/bc-theme-config/tests/TestCase/Model/Table/ThemeConfigTest.php
@@ -87,6 +87,10 @@ class ThemeConfigTest extends BcTestCase
     {
         $validator = $this->ThemeConfigsTable->getValidator('keyValue');
         $errors = $validator->validate([
+            'color_main' => 'color',
+            'color_sub' => 'color',
+            'color_link' => 'color',
+            'color_hover' => 'color',
             'logo' => 'logo.ppp',
             'main_image_1' => 'logo.ppp',
             'main_image_2' => 'logo.ppp',
@@ -94,6 +98,14 @@ class ThemeConfigTest extends BcTestCase
             'main_image_4' => 'logo.ppp',
             'main_image_5' => 'logo.ppp',
         ]);
+        $this->assertArrayHasKey('color_main', $errors);
+        $this->assertEquals('メインはカラーコードを入力してください。', current($errors['color_main']));
+        $this->assertArrayHasKey('color_sub', $errors);
+        $this->assertEquals('サブはカラーコードを入力してください。', current($errors['color_sub']));
+        $this->assertArrayHasKey('color_link', $errors);
+        $this->assertEquals('テキストリンクはカラーコードを入力してください。', current($errors['color_link']));
+        $this->assertArrayHasKey('color_hover', $errors);
+        $this->assertEquals('テキストホバーはカラーコードを入力してください。', current($errors['color_hover']));
         $this->assertArrayHasKey('logo', $errors);
         $this->assertEquals('許可されていないファイルです。', current($errors['logo']));
         $this->assertArrayHasKey('main_image_1', $errors);

--- a/plugins/bc-theme-config/tests/TestCase/Model/Table/ThemeConfigTest.php
+++ b/plugins/bc-theme-config/tests/TestCase/Model/Table/ThemeConfigTest.php
@@ -99,13 +99,13 @@ class ThemeConfigTest extends BcTestCase
             'main_image_5' => 'logo.ppp',
         ]);
         $this->assertArrayHasKey('color_main', $errors);
-        $this->assertEquals('メインはカラーコードを入力してください。', current($errors['color_main']));
+        $this->assertEquals('メインのカラーコードの形式が間違っています。', current($errors['color_main']));
         $this->assertArrayHasKey('color_sub', $errors);
-        $this->assertEquals('サブはカラーコードを入力してください。', current($errors['color_sub']));
+        $this->assertEquals('サブのカラーコードの形式が間違っています。', current($errors['color_sub']));
         $this->assertArrayHasKey('color_link', $errors);
-        $this->assertEquals('テキストリンクはカラーコードを入力してください。', current($errors['color_link']));
+        $this->assertEquals('テキストリンクのカラーコードの形式が間違っています。', current($errors['color_link']));
         $this->assertArrayHasKey('color_hover', $errors);
-        $this->assertEquals('テキストホバーはカラーコードを入力してください。', current($errors['color_hover']));
+        $this->assertEquals('テキストホバーのカラーコードの形式が間違っています。', current($errors['color_hover']));
         $this->assertArrayHasKey('logo', $errors);
         $this->assertEquals('許可されていないファイルです。', current($errors['logo']));
         $this->assertArrayHasKey('main_image_1', $errors);


### PR DESCRIPTION
管理画面テーマ設定のテーマカラーにてカラーコード以外の任意の文字列も保存できる為、下記の処理を追加いたしました。

1. BcValidation に16進数カラーコード判定のバリデーションを追加
1. 管理画面テーマ設定でテーマカラーにバリデーションを追加

カラーコードのバリデーションには CakePHP の `hexColor` もあるものの6桁以外も判定できるように BcValidation に追加しております。3桁、4桁、6桁、8桁を許容するようにしました。

ご確認よろしくお願いいたします！