### PR TITLE
fix メールフィールド複製時、受信データ用テーブルを作り直す動作となっていることで、保持している受信データを削除している動作を調整

### DIFF
--- a/app/webroot/theme/admin-third/Elements/admin/mail_fields/index_row.php
+++ b/app/webroot/theme/admin-third/Elements/admin/mail_fields/index_row.php
@@ -26,7 +26,7 @@ if (!$data['MailField']['use_field']) {
 		<?php if ($this->BcBaser->isAdminUser()): ?>
 			<?php echo $this->BcForm->input('ListTool.batch_targets.' . $data['MailField']['id'], ['type' => 'checkbox', 'label' => '<span class="bca-visually-hidden">' . __d('baser', 'チェックする') . '</span>', 'class' => 'batch-targets bca-checkbox__input', 'value' => $data['MailField']['id']]) ?>
 		<?php endif ?>
-		<?php if ($sortmode): ?>
+		<?php if (isset($sortmode) && $sortmode): ?>
 			<span class="sort-handle"><i class="bca-btn-icon-text"
 										 data-bca-btn-type="draggable"></i><?php echo __d('baser', 'ドラッグ可能') ?></span>
 			<?php echo $this->BcForm->hidden('Sort.id' . $data['MailField']['id'], ['class' => 'id', 'value' => $data['MailField']['id']]) ?>

--- a/lib/Baser/Plugin/Mail/Controller/MailFieldsController.php
+++ b/lib/Baser/Plugin/Mail/Controller/MailFieldsController.php
@@ -464,7 +464,7 @@ class MailFieldsController extends MailAppController
 			);
 			return;
 		}
-		$this->MailMessage->construction($mailContentId);
+		$this->MailMessage->addMessageField($mailContentId, $result['MailField']['field_name']);
 		$this->set('data', $result);
 	}
 

--- a/lib/Baser/Plugin/Mail/View/Elements/admin/mail_fields/index_row.php
+++ b/lib/Baser/Plugin/Mail/View/Elements/admin/mail_fields/index_row.php
@@ -24,7 +24,7 @@ if (!$data['MailField']['use_field']) {
 
 <tr id="Row<?php echo $count + 1 ?>" <?php echo $class; ?>>
 	<td style="width:25%" class="row-tools">
-		<?php if ($sortmode): ?>
+		<?php if (isset($sortmode) && $sortmode): ?>
 			<span
 				class="sort-handle"><?php $this->BcBaser->img('admin/sort.png', ['alt' => __d('baser', '並び替え')]) ?></span>
 			<?php echo $this->BcForm->hidden('Sort.id' . $data['MailField']['id'], ['class' => 'id', 'value' => $data['MailField']['id']]) ?>


### PR DESCRIPTION
- 副次的な効果として、メールフィールド数が多数（14000件超）、かつphp5.6環境でメッセージテーブルが正しく作成されない場合がある動作を改善
- メールフィールド複製時、debugログにUndefinedが残る動作を改善

