### PR TITLE
ルールが存在するアクセスルールグループの削除を制限

### DIFF
--- a/plugins/baser-core/src/Service/Admin/PermissionGroupsAdminService.php
+++ b/plugins/baser-core/src/Service/Admin/PermissionGroupsAdminService.php
@@ -63,10 +63,16 @@ class PermissionGroupsAdminService extends PermissionGroupsService implements Pe
         if($userGroupId) {
             $currentUserGroup = $this->UserGroups->get($userGroupId);
         }
+        $isDeletable = false;
+        if ($entity->id) {
+            $isDeletable = !$this->PermissionGroups->Permissions
+                ->exists(['Permissions.permission_group_id' => $entity->id]);
+        }
         return [
             'entity' => $entity,
             'userGroupTitle' => $currentUserGroup->title?? __d('baser_core', 'ゲスト'),
-            'userGroupId' => $currentUserGroup->id ?? "0"
+            'userGroupId' => $currentUserGroup->id ?? '0',
+            'isDeletable' => $isDeletable,
         ];
     }
 

--- a/plugins/bc-admin-third/templates/Admin/PermissionGroups/edit.php
+++ b/plugins/bc-admin-third/templates/Admin/PermissionGroups/edit.php
@@ -69,16 +69,18 @@ $this->BcAdmin->addAdminMainBodyHeaderLinks([
     ]) ?>
   </div>
   <div class="bca-actions__sub">
-      <?= $this->BcAdminForm->postLink(
-        __d('baser_core', '削除'),
-        ['action' => 'delete', $userGroupId, $entity->id],
-        ['block' => true,
-          'confirm' => __d('baser_core', '{0} を本当に削除してもいいですか？', $entity->name),
-          'class' => 'bca-submit-token button bca-btn bca-actions__item',
-          'data-bca-btn-type' => 'delete',
-          'data-bca-btn-size' => 'sm'
-        ]
-      ) ?>
+      <?php if ($isDeletable): ?>
+        <?= $this->BcAdminForm->postLink(
+          __d('baser_core', '削除'),
+          ['action' => 'delete', $userGroupId, $entity->id],
+          ['block' => true,
+            'confirm' => __d('baser_core', '{0} を本当に削除してもいいですか？', $entity->name),
+            'class' => 'bca-submit-token button bca-btn bca-actions__item',
+            'data-bca-btn-type' => 'delete',
+            'data-bca-btn-size' => 'sm'
+          ]
+        ) ?>
+      <?php endif ?>
   </div>
 </div>
 

--- a/plugins/bc-admin-third/templates/Admin/element/PermissionGroups/form.php
+++ b/plugins/bc-admin-third/templates/Admin/element/PermissionGroups/form.php
@@ -108,6 +108,7 @@
     </tr>
 <?php endif ?>
 
+    <?php /* ?>
     <tr>
       <th class="col-head bca-form-table__label"><?php echo $this->BcAdminForm->label('status', __d('baser_core', '利用状態')) ?></th>
       <td class="col-input bca-form-table__input">
@@ -115,6 +116,7 @@
         <?php echo $this->BcAdminForm->error('status') ?>
       </td>
     </tr>
+    <?php */ ?>
   </table>
 </div>
 


### PR DESCRIPTION
issue: https://github.com/baserproject/basercms/issues/3203 対応のため、まずは表示のみ対応を行いました。
ご確認をお願いします。

- ルールが存在するアクセスルールグループの削除ボタンを非表示
- アクセスルールグループの利用状態欄を非表示