### PR TITLE
管理画面エラー画面からリンク切れファイルを削除

### DIFF
--- a/plugins/bc-admin-third/templates/Admin/layout/error.php
+++ b/plugins/bc-admin-third/templates/Admin/layout/error.php
@@ -10,7 +10,6 @@
     'vendor/jquery-ui/jquery-ui.min',
     'vendor/jquery.timepicker',
     'admin/style',
-    '../js/admin/vendors/jquery.jstree-3.3.8/themes/proton/style.min',
   ]) ?>
   <?php echo $this->fetch('css') ?>
   <?php $this->BcBaser->js([
@@ -21,7 +20,6 @@
     'vendor/jquery-ui-1.11.4.min.js',
     'vendor/i18n/ui.datepicker-ja',
     'vendor/jquery.timepicker',
-    'admin/functions',
   ]) ?>
   <?php echo $this->fetch('script') ?>
 </head>


### PR DESCRIPTION
管理画面のエラーページに存在しないファイルへのリンクが含まれていたので削除しました。
ご確認をお願いします。

<img width="1378" alt="error" src="https://github.com/baserproject/basercms/assets/30764014/006038b8-749e-494a-a098-04bf5f6ebab6">