### PR TITLE
fix baserproject#3488 ごみ箱にファイルがある状態でツリー構造チェックを行うと常にエラーになる問題を修正

### DIFF
--- a/plugins/baser-core/src/Service/UtilitiesService.php
+++ b/plugins/baser-core/src/Service/UtilitiesService.php
@@ -105,7 +105,7 @@ class UtilitiesService implements UtilitiesServiceInterface
         $errors = [];
 
         for($i = $min; $i <= $edge; $i++) {
-            $count = $table->find()->where([
+            $count = $table->find()->applyOptions(['withDeleted'])->where([
                 $scope,
                 'OR' => [$left => $i, $right => $i]
             ])->count();


### PR DESCRIPTION
issue：#3488