### PR TITLE
fix baserproject#3509 baserCMSコアのアップデートがxdebug不足により失敗する事象の修正

### DIFF
--- a/plugins/baser-core/src/Utility/BcComposer.php
+++ b/plugins/baser-core/src/Utility/BcComposer.php
@@ -150,7 +150,7 @@ class BcComposer
      */
     public static function require(string $package, string $version)
     {
-        return self::execCommand("require baserproject/{$package}:{$version} --with-all-dependencies");
+        return self::execCommand("require baserproject/{$package}:{$version} --with-all-dependencies --ignore-platform-req=ext-xdebug");
     }
 
     /**


### PR DESCRIPTION
Issue：#3509