### PR TITLE
Cake\ORM\Table::find()の前後にイベントを追加

### DIFF
--- a/plugins/baser-core/src/Model/Table/AppTable.php
+++ b/plugins/baser-core/src/Model/Table/AppTable.php
@@ -120,16 +120,19 @@ class AppTable extends Table
      */
     public function find(string $type = 'all', array $options = []): Query
     {
-        $event = $this->dispatchEvent('AppTable.beforeFind', compact('type', 'options'));
+        // EVENT beforeFind
+        $event = $this->dispatchLayerEvent('beforeFind', compact('type', 'options'));
         if ($event !== false) {
-            if (!empty($event->getData('options'))) {
-                $options = $event->getData('options');
-            }
+            $options = ($event->getResult() === null || $event->getResult() === true) ? $event->getData('options') : $event->getResult();
         }
 
         $result = parent::find($type, $options);
 
-        $this->dispatchEvent('AppTable.afterFind', compact('type', 'options', 'result'));
+        // EVENT afterFind
+        $event = $this->dispatchLayerEvent('afterFind', compact('type', 'options', 'result'));
+        if ($event !== false) {
+            $result = ($event->getResult() === null || $event->getResult() === true) ? $event->getData('result') : $event->getResult();
+        }
 
         return $result;
     }

--- a/plugins/baser-core/src/Model/Table/AppTable.php
+++ b/plugins/baser-core/src/Model/Table/AppTable.php
@@ -13,6 +13,7 @@ namespace BaserCore\Model\Table;
 
 use BaserCore\Utility\BcUtil;
 use Cake\ORM\Association\BelongsToMany;
+use Cake\ORM\Query;
 use Cake\ORM\Table;
 use Cake\I18n\FrozenTime;
 use BaserCore\Annotation\NoTodo;
@@ -106,6 +107,31 @@ class AppTable extends Table
             $options['joinTable'] = $this->addPrefix($options['joinTable']);
         }
         return parent::belongsToMany($associated, $options);
+    }
+
+    /**
+     * findの前後にイベントを追加する
+     *
+     * @param string $type the type of query to perform
+     * @param array<string, mixed> $options An array that will be passed to Query::applyOptions()
+     * @return \Cake\ORM\Query The query builder
+     * @checked
+     * @noTodo
+     */
+    public function find(string $type = 'all', array $options = []): Query
+    {
+        $event = $this->dispatchEvent('AppTable.beforeFind', compact('type', 'options'));
+        if ($event !== false) {
+            if (!empty($event->getData('options'))) {
+                $options = $event->getData('options');
+            }
+        }
+
+        $result = parent::find($type, $options);
+
+        $this->dispatchEvent('AppTable.afterFind', compact('type', 'options', 'result'));
+
+        return $result;
     }
 
     /**


### PR DESCRIPTION
@ryuring 
findの前後にイベントを追加するために、AppTableにCake\ORM\Table::find()をオーバーライドしてイベントを追加しました。
リードレプリカへの接続切り替えなどでの利用を想定しています。

ご確認お願いします。