### PR TITLE
fix #3523 【システム】管理画面ログイン後のリダイレクトが動作していない 

### DIFF
--- a/plugins/baser-core/src/Controller/AppController.php
+++ b/plugins/baser-core/src/Controller/AppController.php
@@ -34,6 +34,7 @@ use Cake\Http\Exception\ForbiddenException;
 use Cake\Http\Exception\NotFoundException;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
+use Cake\Routing\Router;
 use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
 use Psr\Http\Message\ResponseInterface;
@@ -169,15 +170,10 @@ class AppController extends BaseController
                     } else {
                         $this->BcMessage->setError(__d('baser_core', '実行した操作は許可されていません。'));
                     }
-                }
-                // リファラが存在する場合はリファラにリダイレクトする
-                // $this->referer() で判定した場合、リファラがなくてもトップのURLが返却されるため ServerRequest で判定
-                if ($this->getRequest()->getEnv('HTTP_REFERER') &&
-                    $this->getRequest()->getAttribute('here') !== $this->referer()
-                ) {
-                    $url = $this->referer();
-                } else {
                     $url = Configure::read("BcPrefixAuth.{$prefix}.loginRedirect");
+                } else {
+                    $url = Router::url(Configure::read("BcPrefixAuth.{$prefix}.loginAction"))
+                        . '?redirect=' . urlencode(Router::url());
                 }
                 return $this->redirect($url);
             }


### PR DESCRIPTION
以下のissueに対応しました。ご確認お願いします。
https://github.com/baserproject/basercms/issues/3523

変更内容

- 権限が無いページにアクセスした際のリダイレクト処理を調整
    - ログイン時: loginRedirect
    - 非ログイン時: loginAction + 現在のURLをredirectパラメーターとする
- リファラへのリダイレクトが存在すると、以下の条件で無限ループになるため削除
    - 未ログイン状態で、アクセスルールで禁止されたページからログインする

権限が無いページへのリンクは表示されないはずなのでリファラへのリダイレクトは不要ではないかと思います。
また、非ログイン時のリダイレクトは無くても動きますがちょっと怖いので残してます。