### PR TITLE
テーマのzipファイル名がテーマ名と異なる場合に追加に失敗する

### DIFF
--- a/plugins/baser-core/src/Service/ThemesService.php
+++ b/plugins/baser-core/src/Service/ThemesService.php
@@ -148,12 +148,11 @@ class ThemesService implements ThemesServiceInterface
         }
         $name = $postData['file']->getClientFileName();
         $postData['file']->moveTo(TMP . $name);
-        $srcDirName = basename($name, '.zip');
         $zip = new BcZip();
         if (!$zip->extract(TMP . $name, TMP)) {
             throw new BcException(__d('baser_core', 'アップロードしたZIPファイルの展開に失敗しました。'));
         }
-
+        $srcDirName = $zip->topArchiveName;
         $dstName = $srcName = Inflector::camelize($srcDirName);
         if (preg_match('/^(.+?)([0-9]+)$/', $srcName, $matches)) {
             $baseName = $matches[1];


### PR DESCRIPTION
issue: https://github.com/baserproject/basercms/issues/3140
こちらのissueの問題、プラグインの方は以下コミットで修正されていたのでテーマの方にも適用しました。
ご確認お願いします。
https://github.com/baserproject/basercms/commit/02fb2787ebc3cbd2c82365fefb775f85af619e4b

