### PR TITLE
ブログ 投稿者別記事一覧URL変更

### DIFF
--- a/plugins/bc-blog/src/Controller/BlogController.php
+++ b/plugins/bc-blog/src/Controller/BlogController.php
@@ -149,7 +149,7 @@ class BlogController extends BlogFrontAppController
      *
      * ### URL例
      * - カテゴリ別記事一覧： /news/archives/category/category-name
-     * - 作成者別記事一覧： /news/archives/author/author-name
+     * - 作成者別記事一覧： /news/archives/author/user-id
      * - タグ別記事一覧： /news/archives/tag/tag-name
      * - 年別記事一覧： /news/archives/date/2022
      * - 月別記事一覧： /news/archives/date/2022/12
@@ -198,15 +198,15 @@ class BlogController extends BlogFrontAppController
 
             case 'author':
                 if (count($pass) > 2) $this->notFound();
-                $author = isset($pass[1])? $pass[1] : '';
+                $userId = isset($pass[1]) ? (int) $pass[1] : '';
                 $this->set($service->getViewVarsForArchivesByAuthor(
-                    $this->paginate($blogPostsService->getIndexByAuthor($author, array_merge([
+                    $this->paginate($blogPostsService->getIndexByAuthor($userId, array_merge([
                         'status' => 'publish',
                         'blog_content_id' => $blogContent->id,
                         'direction' => $blogContent->list_direction,
                         'draft' => false
                     ], $this->getRequest()->getQueryParams())), ['limit' => $blogContent->list_count]),
-                    $author,
+                    $userId,
                     $blogContent
                 ));
                 break;

--- a/plugins/bc-blog/src/Service/BlogPostsService.php
+++ b/plugins/bc-blog/src/Service/BlogPostsService.php
@@ -242,7 +242,6 @@ class BlogPostsService implements BlogPostsServiceInterface
             'site_id' => null,
             'category' => null,
             'keyword' => null,
-            'author' => null,
             'tag' => null,
             'year' => null,
             'month' => null,
@@ -341,10 +340,6 @@ class BlogPostsService implements BlogPostsServiceInterface
         // キーワード
         if ($params['keyword']) {
             $conditions = $this->createKeywordCondition($conditions, $params['keyword']);
-        }
-        // 作成者
-        if ($params['author']) {
-            $conditions = $this->createAuthorCondition($conditions, $params['author']);
         }
         return $query->where($conditions);
     }
@@ -535,23 +530,6 @@ class BlogPostsService implements BlogPostsServiceInterface
                 if ($day) $conditions["strftime('%d',BlogPosts.posted)"] = sprintf('%02d', $day);
                 break;
         }
-        return $conditions;
-    }
-
-    /**
-     * 作成者の条件を作成する
-     *
-     * @param array $conditions
-     * @param string $author
-     * @return array
-     * @checked
-     * @noTodo
-     * @unitTest
-     */
-    public function createAuthorCondition($conditions, $author)
-    {
-        $user = $this->BlogPosts->Users->find()->where(['Users.name' => $author])->first();
-        $conditions['BlogPosts.user_id'] = $user->id;
         return $conditions;
     }
 
@@ -809,16 +787,16 @@ class BlogPostsService implements BlogPostsServiceInterface
     /**
      * 著者別記事一覧を取得
      *
-     * @param string $author
+     * @param int $userId
      * @param array $options
      * @return Query
      * @checked
      * @noTodo
      * @unitTest
      */
-    public function getIndexByAuthor(string $author, array $options = [])
+    public function getIndexByAuthor(int $userId, array $options = [])
     {
-        $options['author'] = $author;
+        $options['user_id'] = $userId;
         return $this->getIndex($options);
     }
 

--- a/plugins/bc-blog/src/Service/BlogPostsServiceInterface.php
+++ b/plugins/bc-blog/src/Service/BlogPostsServiceInterface.php
@@ -200,14 +200,14 @@ interface BlogPostsServiceInterface
     /**
      * 著者別記事一覧を取得
      *
-     * @param string $author
+     * @param int $userId
      * @param array $options
      * @return Query
      * @checked
      * @noTodo
      * @unitTest
      */
-    public function getIndexByAuthor(string $author, array $options = []);
+    public function getIndexByAuthor(int $userId, array $options = []);
 
     /**
      * タグ別記事一覧を取得

--- a/plugins/bc-blog/src/Service/Front/BlogFrontService.php
+++ b/plugins/bc-blog/src/Service/Front/BlogFrontService.php
@@ -249,17 +249,17 @@ class BlogFrontService implements BlogFrontServiceInterface
     /**
      * 著者別アーカイブ一覧の view 用変数を取得する
      * @param ResultSet|PaginatedResultSet $posts
-     * @param string $author
+     * @param int $userId
      * @param BlogContent $blogContent
      * @return array
      * @checked
      * @noTodo
      * @unitTest
      */
-    public function getViewVarsForArchivesByAuthor(ResultSet|PaginatedResultSet $posts, string $author, BlogContent $blogContent): array
+    public function getViewVarsForArchivesByAuthor(ResultSet|PaginatedResultSet $posts, int $userId, BlogContent $blogContent): array
     {
         $usersTable = TableRegistry::getTableLocator()->get('BaserCore.Users');
-        $author = $usersTable->find('available')->where(['Users.name' => $author])->first();
+        $author = $usersTable->find('available')->where(['Users.id' => $userId])->first();
         if (!$author) {
             throw new NotFoundException();
         }

--- a/plugins/bc-blog/src/Service/Front/BlogFrontServiceInterface.php
+++ b/plugins/bc-blog/src/Service/Front/BlogFrontServiceInterface.php
@@ -83,14 +83,14 @@ interface BlogFrontServiceInterface
 
     /**
      * 著者別アーカイブ一覧の view 用変数を取得する
-     * @param ResultSet $posts
-     * @param string $author
+     * @param ResultSet|PaginatedResultSet $posts
+     * @param int $userId
      * @return array
      * @checked
      * @noTodo
      * @unitTest
      */
-    public function getViewVarsForArchivesByAuthor(ResultSet $posts, string $author, BlogContent $blogContent): array;
+    public function getViewVarsForArchivesByAuthor(ResultSet|PaginatedResultSet $posts, int $userId, BlogContent $blogContent): array;
 
     /**
      * タグ別アーカイブ一覧の view 用変数を取得する

--- a/plugins/bc-blog/tests/TestCase/Controller/BlogControllerTest.php
+++ b/plugins/bc-blog/tests/TestCase/Controller/BlogControllerTest.php
@@ -195,7 +195,7 @@ class BlogControllerTest extends BcTestCase
         $this->assertEquals('release', $vars['blogCategory']->name);
         $this->assertEquals('post1', $vars['posts']->toArray()[0]->name);
         //type = 'author'
-        $this->get('/news/archives/author/name');
+        $this->get('/news/archives/author/1');
         $this->assertResponseOk();
         $vars = $this->_controller->viewBuilder()->getVars();
         $this->assertEquals('author', $vars['blogArchiveType']);

--- a/plugins/bc-blog/tests/TestCase/Service/BlogPostsServiceTest.php
+++ b/plugins/bc-blog/tests/TestCase/Service/BlogPostsServiceTest.php
@@ -412,18 +412,6 @@ class BlogPostsServiceTest extends BcTestCase
     }
 
     /**
-     * 作成者の条件を作成する
-     */
-    public function testCreateAuthorCondition()
-    {
-        //データ　生成
-        UserFactory::make(['id' => 1, 'name' => 'test name', 'email' => 'test_name@gmail.com'])->persist();
-        //戻り値を確認
-        $result = $this->BlogPostsService->createAuthorCondition([], "test name");
-        $this->assertEquals($result["BlogPosts.user_id"], 1);
-    }
-
-    /**
      * 並び替え設定を生成する
      */
     public function testCreateOrder()
@@ -965,7 +953,7 @@ class BlogPostsServiceTest extends BcTestCase
 
         // サービスメソッドを呼ぶ
         // test author1 の記事を取得、id昇順
-        $result = $this->BlogPostsService->getIndexByAuthor('test author1', [
+        $result = $this->BlogPostsService->getIndexByAuthor(2, [
             'direction' => 'ASC',
             'order' => 'id',
         ]);
@@ -984,7 +972,7 @@ class BlogPostsServiceTest extends BcTestCase
 
         // サービスメソッドを呼ぶ
         // 記事が存在しない
-        $result = $this->BlogPostsService->getIndexByAuthor('test author3', []);
+        $result = $this->BlogPostsService->getIndexByAuthor(4, []);
 
         // 戻り値を確認
         // 指定した author の記事が存在しない

--- a/plugins/bc-blog/tests/TestCase/Service/Front/BlogFrontServiceTest.php
+++ b/plugins/bc-blog/tests/TestCase/Service/Front/BlogFrontServiceTest.php
@@ -511,7 +511,7 @@ class BlogFrontServiceTest extends BcTestCase
         // サービスメソッドを呼ぶ
         $result = $this->BlogFrontService->getViewVarsForArchivesByAuthor(
             $blogPostsService->getIndex([])->all(),
-            'name',
+            1,
             $blogContentsService->get(1)
         );
 
@@ -533,7 +533,7 @@ class BlogFrontServiceTest extends BcTestCase
         $this->expectException("Cake\Http\Exception\NotFoundException");
         $this->BlogFrontService->getViewVarsForArchivesByAuthor(
             $blogPostsService->getIndex([])->all(),
-            'author name test',
+            999,
             $blogContentsService->get(1)
         );
     }

--- a/plugins/bc-front/templates/plugin/BcBlog/element/widget/blog_author_archives.php
+++ b/plugins/bc-front/templates/plugin/BcBlog/element/widget/blog_author_archives.php
@@ -47,7 +47,7 @@ $baseCurrentUrl = $this->BcBaser->getBlogContentsUrl($id) . 'archives/author/';
 			<?php foreach ($authors as $author): ?>
 				<?php
 				$class = ['bs-widget-list__item'];
-				if ($this->getRequest()->getPath() === $baseCurrentUrl . $author->name) {
+				if ($this->getRequest()->getPath() === $baseCurrentUrl . $author->id) {
 					$class[] = 'current';
 				}
 				if ($view_count) {
@@ -57,14 +57,10 @@ $baseCurrentUrl = $this->BcBaser->getBlogContentsUrl($id) . 'archives/author/';
 				}
 				?>
 				<li class="<?php echo implode(' ', $class) ?>">
-				  <?php if($author->name): ?>
-            <?php $this->BcBaser->link($title, $baseCurrentUrl . $author->name, [
-              'escape' => true,
-              'class' => 'bs-widget-list__item-title'
-            ]) ?>
-          <?php else: ?>
-            <?php echo $title ?>
-          <?php endif ?>
+          <?php $this->BcBaser->link($title, $baseCurrentUrl . $author->id, [
+            'escape' => true,
+            'class' => 'bs-widget-list__item-title'
+          ]) ?>
 				</li>
 			<?php endforeach; ?>
 		</ul>


### PR DESCRIPTION
issue: https://github.com/baserproject/basercms/issues/3244

ブログの投稿者別記事一覧のURLのキーをアカウント名からユーザーIDに変更しました。
ご確認お願いします。

変更前: https://trial.basercms.net/news/archives/author/demo
変更後: https://trial.basercms.net/news/archives/author/2

APIの方は現状で以下の形式のため対応不要でした。
/baser/api/bc-blog/blog_posts.json?user_id=2