### PR TITLE
fix baserproject#3599 CSVファイルの"0"がnullとして読み込まれてしまう事象を修正

### DIFF
--- a/plugins/baser-core/src/Service/BcDatabaseService.php
+++ b/plugins/baser-core/src/Service/BcDatabaseService.php
@@ -724,7 +724,7 @@ class BcDatabaseService implements BcDatabaseServiceInterface
             }
             $values = [];
             foreach($record as $key => $value) {
-                if(!$value) {
+                if($value === '') {
                     $values[$head[$key]] = null;
                 } else {
                     $values[$head[$key]] = $value;


### PR DESCRIPTION
#3599 のプルリクです。

CSVの読み込み処理を見る限り、「””,」(空文字)と「,」(カンマだけ)の場合どちらも配列では「""」になっているので、
明示的にnullを代入するのは配列の中身が「""」(空文字)の場合だけで良いかと思ってますが、いかがでしょうか。