### PR TITLE
fix #3274 【カスタムコンテンツ設定編集：5.1】オプションの項目：更新日に漢字やひらがな等を入力し保存するとエラーになるがエラー…

### DIFF
--- a/plugins/baser-core/src/Controller/Component/BcAdminContentsComponent.php
+++ b/plugins/baser-core/src/Controller/Component/BcAdminContentsComponent.php
@@ -134,9 +134,7 @@ class BcAdminContentsComponent extends Component
         $controller->setRequest($controller->getRequest()->withAttribute('currentSite', $content->site));
         Router::setRequest($controller->getRequest());
 
-        if (Configure::read('BcContents.autoUpdateContentCreatedDate')) {
-            $content->modified_date = date('Y-m-d H:i:s');
-        }
+
         /* @var \BaserCore\Service\Admin\BcAdminContentsService $bcAdminContentsService */
         $bcAdminContentsService = $this->getService(BcAdminContentsServiceInterface::class);
         if($request->getParam('action') === $this->addAction) {

--- a/plugins/bc-custom-content/src/Service/CustomContentsService.php
+++ b/plugins/bc-custom-content/src/Service/CustomContentsService.php
@@ -175,9 +175,14 @@ class CustomContentsService implements CustomContentsServiceInterface
         if (BcUtil::isOverPostSize()) {
             throw new BcException(__d('baser_core', '送信できるデータ量を超えています。合計で %s 以内のデータを送信してください。', ini_get('post_max_size')));
         }
-        if($postData['custom_table_id']) {
+        if ($postData['custom_table_id']) {
             $options['validate'] = 'withTable';
         }
+
+        if (Configure::read('BcContents.autoUpdateContentCreatedDate') && $entity->content->modified_date == $postData['content']['modified_date']) {
+            $postData['content']['modified_date'] = date('Y-m-d H:i:s');
+        }
+
         $entity = $this->CustomContents->patchEntity($entity, $postData, $options);
         return $this->CustomContents->saveOrFail($entity);
     }


### PR DESCRIPTION
…メッセージが出ない箇所がある

