### PR TITLE
fix #3767 docer-compose.ymlの不要なversion指定を削除

### DIFF
--- a/docker/docker-compose.yml.default
+++ b/docker/docker-compose.yml.default
@@ -1,5 +1,3 @@
-version: '3'
-
 # volumes:
 #  db-volume: # windowsの場合はコメントを外す
 


### PR DESCRIPTION
docer-compose up -dを実行したとき以下のwarningが出ていたため修正しました。
```
WARN[0000] /{baser設置ディレクトリ}/docker/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
```
ご確認お願いします。