### PR TITLE
fix #2680 admin-thirdテーマ、フッターデザイン表示切り替えの条件分岐を修正。

### DIFF
--- a/app/webroot/theme/admin-third/Elements/admin/footer.php
+++ b/app/webroot/theme/admin-third/Elements/admin/footer.php
@@ -15,8 +15,8 @@
  */
 ?>
 <div id="Footer" class="bca-footer"
-	 data-loggedin="<?php if (BcUtil::isAdminUser()): ?>true<?php else: ?>false<?php endif; ?>">
-	<?php if (BcUtil::isAdminUser()): //ログイン後 ?>
+	 data-loggedin="<?php $user = BcUtil::loginUser(); ?><?php if ($user): ?>true<?php else: ?>false<?php endif; ?>">
+	<?php $user = BcUtil::loginUser(); ?><?php if ($user): //ログイン後 ?>
 		<div class="bca-footer__inner--full">
 			<div class="bca-footer__main">
 				<div class="bca-footer__baser-version">baserCMS <strong><?php echo h($baserVersion) ?></strong></div>


### PR DESCRIPTION
[fix](https://github.com/baserproject/basercms/commit/35324229a6ec0c940a59e9874c8870d65defe529) https://github.com/baserproject/basercms/issues/2680
admin-thirdテーマ、フッターデザイン表示切り替えの条件分岐が admins縛りになっているのをログインユーザーに変更。

`<?php if (BcUtil::isAdminUser()): ?>`
↓
`<?php $user = BcUtil::loginUser(); ?><?php if ($user): ?>`

ご確認、お願いします。