### PR TITLE
fix #3745 テーマテンプレートの編集設定の名称にブレがあるのを修正

### DIFF
--- a/plugins/baser-core/src/Model/Table/AppTable.php
+++ b/plugins/baser-core/src/Model/Table/AppTable.php
@@ -110,42 +110,6 @@ class AppTable extends Table
     }
 
     /**
-     * findの前後にイベントを追加する
-     *
-     * @param string $type the type of query to perform
-     * @param array<string, mixed> $options An array that will be passed to Query::applyOptions()
-     * @return \Cake\ORM\Query The query builder
-     * @checked
-     * @noTodo
-     * @unitTest
-     */
-    public function find(string $type = 'all', mixed ...$args): Query
-    {
-        // EVENT beforeFind
-        $event = $this->dispatchLayerEvent('beforeFind', [
-            'type' => $type,
-            'options' => $args // 後方互換のため options として渡す
-        ]);
-        if ($event !== false) {
-            $args = ($event->getResult() === null || $event->getResult() === true) ? $event->getData('options') : $event->getResult();
-        }
-
-        $result = parent::find($type, ...$args);
-
-        // EVENT afterFind
-        $event = $this->dispatchLayerEvent('afterFind', [
-            'type' => $type,
-            'options' => $args,
-            'result' => $result
-        ]);
-        if ($event !== false) {
-            $result = ($event->getResult() === null || $event->getResult() === true) ? $event->getData('result') : $event->getResult();
-        }
-
-        return $result;
-    }
-
-    /**
      * テーブル名にプレフィックスを追加する
      *
      * $this->getConnection()->config() を利用するとユニットテストで問題が発生するため、BcUtil::getCurrentDbConfig()を利用する

--- a/plugins/baser-core/tests/TestCase/Model/Table/AppTableTest.php
+++ b/plugins/baser-core/tests/TestCase/Model/Table/AppTableTest.php
@@ -245,50 +245,6 @@ class AppTableTest extends BcTestCase
     }
 
     /**
-     * test beforeFind
-     * @return void
-     */
-    public function testBeforeFind()
-    {
-        ContentFolderFactory::make(2)->persist();
-        $this->entryEventToMock(self::EVENT_LAYER_MODEL, 'BaserCore.ContentFolders.beforeFind', function(Event $event) {
-            $event->setData('options', ['limit' => 1]);
-        });
-        $contentFolders = $this->getTableLocator()->get('BaserCore.ContentFolders');
-        $this->assertEquals(1, $contentFolders->find()->all()->count());
-    }
-
-    /**
-     * test afterFind
-     * @return void
-     */
-    public function testAfterFind()
-    {
-        ContentFolderFactory::make(2)->persist();
-        $this->entryEventToMock(self::EVENT_LAYER_MODEL, 'BaserCore.ContentFolders.afterFind', function(Event $event) {
-            $event->setData('result', $event->getData('result')->limit(1));
-        });
-        $contentFolders = $this->getTableLocator()->get('BaserCore.ContentFolders');
-        $this->assertEquals(1, $contentFolders->find()->all()->count());
-    }
-
-    /**
-     * test find()
-     */
-    public function testFind()
-    {
-        PluginFactory::make(['name' => 'plugin1'])->persist();
-        PluginFactory::make(['name' => 'plugin2'])->persist();
-
-        $this->App = $this->getTableLocator()->get('BaserCore.Plugins');
-        //fill all
-        $this->assertEquals(2, $this->App->find()->all()->count());
-
-        //limit = 1
-        $this->assertEquals(1, $this->App->find('all', ['limit' => 1])->all()->count());
-    }
-
-    /**
      * testSortdown
      * @return void
      */


### PR DESCRIPTION
`plugins/bc-theme-file/src/Controller/Admin/ThemeFilesController.php`
に参照されない変数が使われていたので、修正しました。

plugins/bc-theme-file/config/setting.phpの
```'BcThemeFile.allowedThemeEdit' => false```
でも、URLを打ち込むとテーマ編集画面に入れていましたが、今回の修正で入れないようになったことを確認しました。

ご確認お願いします！