### PR TITLE
fix #3842 サブサイト（独自ドメイン）で作成したページがエイリアス付きサブサイトと混同される問題を修正

### DIFF
--- a/lib/Baser/Lib/BcSite.php
+++ b/lib/Baser/Lib/BcSite.php
@@ -173,7 +173,7 @@ class BcSite
 			$request = new CakeRequest();
 		}
 		$url = $request->url;
-		$sites = self::findAll();
+		$sites = self::findAll(true);
 		if (!$sites) {
 			return null;
 		}
@@ -292,7 +292,7 @@ class BcSite
 	 *
 	 * @return BcSite[]
 	 */
-	public static function findAll()
+	public static function findAll($reversed = false)
 	{
 		if (!BC_INSTALLED) {
 			return [];
@@ -306,7 +306,17 @@ class BcSite
 		} catch (Exception $e) {
 			return [];
 		}
-		$sites = $Site->find('all', ['recursive' => -1]);
+		if($reversed){
+			$order = [
+				'Site.domain_type' => 'desc'
+			];
+		} else {
+			$order = [];
+		}
+		$sites = $Site->find('all', [
+			'recursive' => -1,
+			'order' => $order
+		]);
 		array_unshift($sites, $Site->getRootMain());
 		self::$_sites = [];
 		foreach($sites as $site) {

--- a/lib/Baser/Lib/BcSite.php
+++ b/lib/Baser/Lib/BcSite.php
@@ -173,7 +173,7 @@ class BcSite
 			$request = new CakeRequest();
 		}
 		$url = $request->url;
-		$sites = self::findAll(true);
+		$sites = self::findAll();
 		if (!$sites) {
 			return null;
 		}
@@ -292,7 +292,7 @@ class BcSite
 	 *
 	 * @return BcSite[]
 	 */
-	public static function findAll($reversed = false)
+	public static function findAll()
 	{
 		if (!BC_INSTALLED) {
 			return [];
@@ -306,17 +306,7 @@ class BcSite
 		} catch (Exception $e) {
 			return [];
 		}
-		if($reversed){
-			$order = [
-				'Site.domain_type' => 'desc'
-			];
-		} else {
-			$order = [];
-		}
-		$sites = $Site->find('all', [
-			'recursive' => -1,
-			'order' => $order
-		]);
+		$sites = $Site->find('all', ['recursive' => -1]);
 		array_unshift($sites, $Site->getRootMain());
 		self::$_sites = [];
 		foreach($sites as $site) {


### PR DESCRIPTION
独自ドメインサブサイトとエイリアス付きサブサイトが存在する時、
独自ドメインで作成したページと、エイリアス付きサブサイトのページが混同されてしまう問題を修正しました。

オプションを付けることによって、発生している問題を解消しつつ、影響範囲を最小限に押さえています。

ご確認お願いします！