### PR TITLE
fix #3882 [要望]baserCMS4系で使用していたときのパスワードが引き継げない問題を解決

### DIFF
--- a/config/.env.example
+++ b/config/.env.example
@@ -34,6 +34,8 @@ export USE_CORE_ADMIN_API="false"
 export SHOW_TEST_METHOD="false"
 ## プロキシサーバーを利用するかどうか（SSL判定に利用）
 export TRUST_PROXY="false"
+## 4系のパスワード暗号化を使用する場合は下記のコメントアウトを外す
+# export HASH_TYPE="sha1"
 
 # Uncomment these to define cache configuration via environment variables.
 #export CACHE_DURATION="+2 minutes"

--- a/config/.env.example
+++ b/config/.env.example
@@ -34,8 +34,9 @@ export USE_CORE_ADMIN_API="false"
 export SHOW_TEST_METHOD="false"
 ## プロキシサーバーを利用するかどうか（SSL判定に利用）
 export TRUST_PROXY="false"
-## 4系のパスワード暗号化を使用する場合は下記のコメントアウトを外す
+## 4系のパスワード暗号化を使用する場合は下記のコメントアウトを外し4系で利用していたセキュリティーソルトを設定する
 # export HASH_TYPE="sha1"
+# export SECURITY_SALT=""
 
 # Uncomment these to define cache configuration via environment variables.
 #export CACHE_DURATION="+2 minutes"

--- a/plugins/baser-core/config/setting.php
+++ b/plugins/baser-core/config/setting.php
@@ -328,6 +328,11 @@ return [
         'twoFactorAuthenticationCodeAllowTime' => 10,
 
         /**
+         * 4系のパスワードでログインする際に、新しいハッシュアルゴリズムでハッシュ化するかどうか
+         */
+        'needsPasswordRehash' => true,
+
+        /**
          * エディタ
          */
         'editors' => [

--- a/plugins/baser-core/src/Controller/Admin/UsersController.php
+++ b/plugins/baser-core/src/Controller/Admin/UsersController.php
@@ -91,10 +91,11 @@ class UsersController extends BcAdminAppController
                 $this->BcMessage->setInfo(__d('baser_core', 'ようこそ、{0}さん。', $user->getDisplayName()));
 
                 // baserCMS4系のパスワードでログインした場合、新しいハッシュアルゴリズムでパスワードをハッシュし直す
-                if ($this->request->getAttribute('authentication')
-                    ->identifiers()
-                    ->get('Password')
-                    ->needsPasswordRehash()
+                if (Configure::read('BcApp.needsPasswordRehash') &&
+                    $this->request->getAttribute('authentication')
+                        ->identifiers()
+                        ->get('Password')
+                        ->needsPasswordRehash()
                 ) {
                     try {
                         $password = $this->getRequest()->getData('password');

--- a/plugins/baser-core/src/Controller/Admin/UsersController.php
+++ b/plugins/baser-core/src/Controller/Admin/UsersController.php
@@ -89,6 +89,24 @@ class UsersController extends BcAdminAppController
                     $this->response = $service->setCookieAutoLoginKey($this->response, $user->id);
                 }
                 $this->BcMessage->setInfo(__d('baser_core', 'ようこそ、{0}さん。', $user->getDisplayName()));
+
+                // baserCMS4系のパスワードでログインした場合、新しいハッシュアルゴリズムでパスワードをハッシュし直す
+                if ($this->request->getAttribute('authentication')
+                    ->identifiers()
+                    ->get('Password')
+                    ->needsPasswordRehash()
+                ) {
+                    try {
+                        $password = $this->getRequest()->getData('password');
+                        $service->update($user, [
+                            'password_1' => $password,
+                            'password_2' => $password
+                        ]);
+                    } catch (PersistenceFailedException) {
+                        // バリデーションでパスワードの更新に失敗した場合はスルーする
+                    }
+                }
+
                 return $this->redirect($target);
             } else {
                 $this->BcMessage->setError(__d('baser_core', 'Eメール、または、パスワードが間違っています。'));


### PR DESCRIPTION
@ryuring 

.env にて

`export HASH_TYPE="sha1"`
を追記し、
`export SECURITY_SALT="４系のときのSECURITY_SALT"`
とすることで、旧パスワードのDBを持ってきてそのまま使うことができるようになります。

よろしくお願いします。