### PR TITLE
#3881 カスタムコンテンツ：エラーメッセージに情報不足な部分がある：エラーメッセージ修正

### DIFF
--- a/plugins/baser-core/src/Utility/BcAbstractDetector.php
+++ b/plugins/baser-core/src/Utility/BcAbstractDetector.php
@@ -77,6 +77,7 @@ abstract class BcAbstractDetector
      * @return BcAbstractDetector|null
      * @checked
      * @noTodo
+     * @unitTest
      */
     public static function find($name)
     {

--- a/plugins/baser-core/tests/TestCase/Utility/BcAbstractDetectorTest.php
+++ b/plugins/baser-core/tests/TestCase/Utility/BcAbstractDetectorTest.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * baserCMS :  Based Website Development Project <https://basercms.net>
+ * Copyright (c) NPO baser foundation <https://baserfoundation.org/>
+ *
+ * @copyright     Copyright (c) NPO baser foundation
+ * @link          https://basercms.net baserCMS Project
+ * @since         5.0.0
+ * @license       https://basercms.net/license/index.html MIT License
+ */
+
+namespace BaserCore\Test\TestCase\Utility;
+
+use BaserCore\TestSuite\BcTestCase;
+use BaserCore\Utility\BcAgent;
+use Cake\Core\Configure;
+
+/**
+ * Class BcAbstractDetector
+ *
+ */
+class BcAbstractDetectorTest extends BcTestCase
+{
+
+    /**
+     * set up
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    /**
+     * tearDown
+     *
+     * @return void
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    /**
+     * test find
+     */
+    public function testFind()
+    {
+        Configure::write("BcApp.smartphone", true);
+
+        //Configureにnameがある場合、
+        $rs = BcAgent::find('smartphone');
+        $this->assertEquals('smartphone', $rs->name);
+        $this->assertEquals('device', $rs->type);
+
+        //Configureにnameがない場合、
+        $this->assertNull(BcAgent::find('test'));
+    }
+
+    /**
+     * test findAll
+     */
+    public function testFindAll()
+    {
+        $this->markTestIncomplete('このテストは、まだ実装されていません。');
+    }
+
+    /**
+     * test findCurrent
+     */
+    public function testFindCurrent()
+    {
+        $this->markTestIncomplete('このテストは、まだ実装されていません。');
+    }
+}


### PR DESCRIPTION
カスタムコンテンツでのフィールド編集にて、
ファイル拡張子チェックのエラーメッセージの末尾に「jpg,pdf」といった具体例を表示するような修正になります。

あわせてtestコードの文言も修正しています。
<img width="774" alt="image 4" src="https://github.com/user-attachments/assets/b73f7e4a-a634-4147-a21e-70079f9c9bec">

@ryuring @fuchigam1 
ご確認おねがいします。（ReviwerとAssignneを私の方で変更できなかったためメンションでのご案内失礼します）