### PR TITLE
メインサイトの管理画面からサブサイト記事にアクセスするとURLが正しく生成されない問題を解消 #3889

### DIFF
--- a/app/webroot/theme/admin-third/Elements/admin/blog_posts/index_row.php
+++ b/app/webroot/theme/admin-third/Elements/admin/blog_posts/index_row.php
@@ -13,6 +13,8 @@
 /**
  * [ADMIN] ブログ記事 一覧　行
  */
+$url = $this->request->params['Content']['url'] . 'archives/' . $data['BlogPost']['no'];
+$fullUrl = $this->BcBaser->getContentsUrl($url, true, $this->request->params['Site']['use_subdomain']);
 ?>
 
 
@@ -72,7 +74,7 @@
 		<?php $this->BcBaser->link('', ['action' => 'ajax_unpublish', $data['BlogContent']['id'], $data['BlogPost']['id']], ['title' => __d('baser', '非公開'), 'class' => 'btn-unpublish bca-btn-icon', 'data-bca-btn-type' => 'unpublish', 'data-bca-btn-size' => 'lg']) ?>
 		<?php $this->BcBaser->link('', ['action' => 'ajax_publish', $data['BlogContent']['id'], $data['BlogPost']['id']], ['title' => __d('baser', '公開'), 'class' => 'btn-publish bca-btn-icon', 'data-bca-btn-type' => 'publish', 'data-bca-btn-size' => 'lg']) ?>
 		<?php if ($this->Blog->allowPublish($data)): //公開状態であれば 公開ページヘのリンク ?>
-			<?php $this->BcBaser->link('', $this->request->params['Content']['url'] . '/archives/' . $data['BlogPost']['no'], ['title' => __d('baser', '確認'), 'target' => '_blank', 'class' => 'bca-btn-icon', 'data-bca-btn-type' => 'preview', 'data-bca-btn-size' => 'lg']); ?>
+			<?php $this->BcBaser->link('', $fullUrl, ['title' => __d('baser', '確認'), 'target' => '_blank', 'class' => 'bca-btn-icon', 'data-bca-btn-type' => 'preview', 'data-bca-btn-size' => 'lg']); ?>
 		<?php else: // 非公開であればボタンを押せなくする ?>
 			<a title="確認" class="btn bca-btn-icon" data-bca-btn-type="preview" data-bca-btn-size="lg"
 			   data-bca-btn-status="gray"></a>

--- a/lib/Baser/Lib/BcSite.php
+++ b/lib/Baser/Lib/BcSite.php
@@ -297,7 +297,7 @@ class BcSite
 	 *
 	 * @return BcSite[]
 	 */
-	public static function findAll($reversed = false)
+	public static function findAll()
 	{
 		if (!BC_INSTALLED) {
 			return [];

--- a/lib/Baser/Lib/BcSite.php
+++ b/lib/Baser/Lib/BcSite.php
@@ -173,7 +173,7 @@ class BcSite
 			$request = new CakeRequest();
 		}
 		$url = $request->url;
-		$sites = self::findAll();
+		$sites = self::findAll(true);
 		if (!$sites) {
 			return null;
 		}
@@ -292,7 +292,7 @@ class BcSite
 	 *
 	 * @return BcSite[]
 	 */
-	public static function findAll()
+	public static function findAll($reversed = false)
 	{
 		if (!BC_INSTALLED) {
 			return [];
@@ -306,7 +306,17 @@ class BcSite
 		} catch (Exception $e) {
 			return [];
 		}
-		$sites = $Site->find('all', ['recursive' => -1]);
+		if($reversed){
+			$order = [
+				'Site.domain_type' => 'desc'
+			];
+		} else {
+			$order = [];
+		}
+		$sites = $Site->find('all', [
+			'recursive' => -1,
+			'order' => $order
+		]);
 		array_unshift($sites, $Site->getRootMain());
 		self::$_sites = [];
 		foreach($sites as $site) {

--- a/lib/Baser/Lib/BcSite.php
+++ b/lib/Baser/Lib/BcSite.php
@@ -173,7 +173,7 @@ class BcSite
 			$request = new CakeRequest();
 		}
 		$url = $request->url;
-		$sites = self::findAll(true);
+		$sites = self::findAll();
 		if (!$sites) {
 			return null;
 		}
@@ -292,7 +292,7 @@ class BcSite
 	 *
 	 * @return BcSite[]
 	 */
-	public static function findAll($reversed = false)
+	public static function findAll()
 	{
 		if (!BC_INSTALLED) {
 			return [];
@@ -306,17 +306,7 @@ class BcSite
 		} catch (Exception $e) {
 			return [];
 		}
-		if($reversed){
-			$order = [
-				'Site.domain_type' => 'desc'
-			];
-		} else {
-			$order = [];
-		}
-		$sites = $Site->find('all', [
-			'recursive' => -1,
-			'order' => $order
-		]);
+		$sites = $Site->find('all', ['recursive' => -1]);
 		array_unshift($sites, $Site->getRootMain());
 		self::$_sites = [];
 		foreach($sites as $site) {


### PR DESCRIPTION
@ryuring 

メインサイトの管理画面から独自ドメインのサブサイト記事にアクセスすると、
```
{メインサイトドメイン}/{サブサイトドメイン}/記事URL
```
のようにURLが正しく生成されない問題を解消しました。
ご確認お願いします！


<img width="1368" alt="スクリーンショット 2024-10-08 17 29 56" src="https://github.com/user-attachments/assets/1cb8b6c5-c97f-43d8-8688-9a3aed8d331f">
