### PR TITLE
fix #3915 初期ユーザー以外のシステム管理ユーザーは自分のユーザー情報を編集しようとすると運営ユーザーしか選択できなくなる問題を解決

### DIFF
--- a/plugins/baser-core/src/Model/Entity/User.php
+++ b/plugins/baser-core/src/Model/Entity/User.php
@@ -118,6 +118,7 @@ class User extends EntityAlias
      */
     public function isAddableToAdminGroup(): bool
     {
+        if ($this->isSuper()) return true;
         return $this->isAdmin();
     }
 

--- a/plugins/baser-core/src/Model/Entity/User.php
+++ b/plugins/baser-core/src/Model/Entity/User.php
@@ -118,7 +118,7 @@ class User extends EntityAlias
      */
     public function isAddableToAdminGroup(): bool
     {
-        return $this->isSuper();
+        return $this->isAdmin();
     }
 
     /**


### PR DESCRIPTION
@ryuring
https://github.com/baserproject/basercms/issues/3915 にも記載した通り、
isAddableToAdminGroup()の記述の内容に対して、「自身がスーパーユーザー」かどうかの判定しか行われていないため、
「自身がシステム管理ユーザー」かどうかの判定に変更しています。

ご確認の上、マージをお願いします。