### PR TITLE
#3918【プラグイン管理】開発者の表記にbrタグが入ってる＆リンク先がおかしい

### DIFF
--- a/plugins/bc-admin-third/templates/Admin/element/Plugins/index_row_market.php
+++ b/plugins/bc-admin-third/templates/Admin/element/Plugins/index_row_market.php
@@ -39,8 +39,15 @@ use BaserCore\View\AppView;
   </td>
   <td class="bca-table-listup__tbody-td"><?php echo h($data['version']) ?></td>
   <td class="bca-table-listup__tbody-td"><?php echo nl2br(h($data['description'])) ?></td>
-  <td
-    class="bca-table-listup__tbody-td"><?php $this->BcBaser->link($data['author'], $data['authorLink'], ['target' => '_blank', 'escape' => true]) ?></td>
+  <td class="bca-table-listup__tbody-td">
+    <?php
+      if (!empty($data['authorLink'])) {
+        $this->BcBaser->link(strip_tags($data['author']), $data['authorLink'], ['target' => '_blank', 'escape' => true]);
+      } else {
+        echo strip_tags($data['author']);
+      }
+    ?>
+  </td>
   <td class="bca-table-listup__tbody-td" style="width:10%;white-space: nowrap">
     <?php echo $this->BcTime->format($data['created'], 'yyyy-MM-dd') ?><br/>
     <?php echo $this->BcTime->format($data['modified'], 'yyyy-MM-dd') ?>

--- a/plugins/bc-admin-third/templates/Admin/element/Plugins/index_row_market.php
+++ b/plugins/bc-admin-third/templates/Admin/element/Plugins/index_row_market.php
@@ -44,7 +44,7 @@ use BaserCore\View\AppView;
       if (!empty($data['authorLink'])) {
         $this->BcBaser->link(strip_tags($data['author']), $data['authorLink'], ['target' => '_blank', 'escape' => true]);
       } else {
-        echo strip_tags($data['author']);
+        echo h(strip_tags($data['author']));
       }
     ?>
   </td>


### PR DESCRIPTION
@ryuring 
以下修正を追加しました。ご確認お願いします。

- 開発者名内のHTMLタグを削除
- 開発者リンクが設定されていない場合はaタグを出力しない

![image](https://github.com/user-attachments/assets/5fb0c30c-6745-4aa3-ac6d-b07e4dccda8b)
