### PR TITLE
Themeの読み込み順変更。bc_form.phpをsetting.phpで変更できるように。

### DIFF
--- a/plugins/baser-core/config/setting.php
+++ b/plugins/baser-core/config/setting.php
@@ -418,6 +418,16 @@ return [
         'enableRootRoutes' => false,
 
         /**
+         * bc_formのテンプレートを指定
+         * config/bc_form.phpを差し替える         
+         *  プラグイン記法 (プラグイン名.テンプレート名)
+         */
+        //basercms/plugins/baser-core/src/View/AppView.php
+        'AppFormTemplate' => 'BaserCore.bc_form',
+        //basercms/plugins/baser-core/src/View/BcAdminAppView.php
+        'AdminFormTemplate' => 'BaserCore.bc_form',
+
+        /**
          * システムナビ
          *
          * 初期状態で表示するメニューは、`Contents` キー配下に定義し、「設定」内に格納する場合は、`Systems` キー配下に定義する

--- a/plugins/baser-core/src/BaserCorePlugin.php
+++ b/plugins/baser-core/src/BaserCorePlugin.php
@@ -151,7 +151,7 @@ class BaserCorePlugin extends BcPlugin implements AuthenticationServiceProviderI
         }
 
         /**
-         * プラグインロード
+         * テーマ・プラグインロード
          */
         if (!filter_var(env('USE_DEBUG_KIT', true), FILTER_VALIDATE_BOOLEAN)) {
             // 明示的に指定がない場合、DebugKitは重すぎるのでデバッグモードでも利用しない
@@ -164,19 +164,19 @@ class BaserCorePlugin extends BcPlugin implements AuthenticationServiceProviderI
         }
 
         if (BcUtil::isTest()) $app->addPlugin('CakephpFixtureFactories');
-        $app->addPlugin('Authentication');
-        $app->addPlugin('Migrations');
 
-        $plugins = BcUtil::getEnablePlugins();
-        if ($plugins) {
-            foreach($plugins as $plugin) {
-                if (BcUtil::includePluginClass($plugin->name)) {
-                    $this->loadPlugin($app, $plugin->name, $plugin->priority);
-                }
-            }
-        }
-
-        $this->addTheme($app);
+        // 利用可能なテーマを取得
+        $themes = $this->getAvailableThemes();
+        // プラグインを追加する前にテーマが保有するプラグインのパスをセット
+        $this->setupThemePlugin($themes);
+        // テーマが保有するプラグインも含めてプラグインを読み込む
+        $this->addPlugin($app);
+        // ======================================================
+        // テーマはプラグインの後に読み込む
+        // テーマもプラグインとして扱う場合があるため、
+        // その場合に、テーマでプラグインの設定等を上書きできるようにする
+        // ======================================================
+        $this->addTheme($app, $themes);
 
         /**
          * デフォルトテンプレートを設定する
@@ -195,47 +195,96 @@ class BaserCorePlugin extends BcPlugin implements AuthenticationServiceProviderI
     }
 
     /**
+     * プラグインを追加する
+     * @param PluginApplicationInterface $app
+     * @return void
+     * @checked
+     * @noTodo
+     */
+    public function addPlugin(PluginApplicationInterface $app): void
+    {
+        $app->addPlugin('Authentication');
+        $app->addPlugin('Migrations');
+
+        $plugins = BcUtil::getEnablePlugins();
+        if(!$plugins) return;
+        foreach($plugins as $plugin) {
+            if (!BcUtil::includePluginClass($plugin->name)) continue;
+            $this->loadPlugin($app, $plugin->name, $plugin->priority);
+        }
+    }
+
+    /**
      * テーマを追加する
-     *
-     * テーマ内のプラグインも追加する
      *
      * @param PluginApplicationInterface $application
      * @noTodo
      * @checked
      */
-    public function addTheme(PluginApplicationInterface $application)
+    public function addTheme(PluginApplicationInterface $application, array $themes): void
     {
         $application->addPlugin(Inflector::camelize(Configure::read('BcApp.coreAdminTheme'), '-'));
         $application->addPlugin(Inflector::camelize(Configure::read('BcApp.coreFrontTheme'), '-'));
         if (!BcUtil::isInstalled()) return;
-        $sitesTable = TableRegistry::getTableLocator()->get('BaserCore.Sites');
-        try {
-            $sites = $sitesTable->find()->where(['Sites.status' => true]);
-        } catch (MissingConnectionException) {
-            return;
-        }
 
-        $path = [];
-        foreach($sites as $site) {
-            if ($site->theme) {
-                if(!BcUtil::includePluginClass($site->theme)) continue;
-                try {
-                    $application->addPlugin($site->theme);
-                    $pluginPath = CorePlugin::path($site->theme) . 'plugins' . DS;
-                    if (!is_dir($pluginPath)) continue;
-                    $path[] = $pluginPath;
-                } catch (MissingPluginException $e) {
-                    $this->log($e->getMessage());
-                }
+        foreach($themes as $theme) {
+            if(!BcUtil::includePluginClass($theme)) continue;
+            try {
+                $application->addPlugin($theme);
+            } catch (MissingPluginException $e) {
+                $this->log($e->getMessage());
             }
         }
-        // テーマプラグインを追加
+    }
+
+    /**
+     * テーマが保有するプラグインのパスを追加する
+     * @param array $themes
+     * @return void
+     * @checked
+     * @noTodo
+     */
+    public function setupThemePlugin(array $themes): void
+    {
+        if (!BcUtil::isInstalled()) return;
+        if(!$themes) return;
+        foreach($themes as $theme) {
+            $pluginsPath = CorePlugin::path($theme) . 'plugins' . DS;
+            if (!is_dir($pluginsPath)) continue;
+            $path[] = $pluginsPath;
+        }
         if($path) {
             Configure::write('App.paths.plugins', array_merge(
                 Configure::read('App.paths.plugins'),
                 $path
             ));
         }
+    }
+
+    /**
+     * 利用可能なテーマを取得する
+     * @return array
+     * @checked
+     * @noTodo
+     */
+    public function getAvailableThemes(): array
+    {
+        if (!BcUtil::isInstalled()) return [];
+        $sitesTable = TableRegistry::getTableLocator()->get('BaserCore.Sites');
+        try {
+            $sites = $sitesTable->find()->where(['Sites.status' => true]);
+        } catch (MissingConnectionException) {
+            return [];
+        }
+        $themes = [];
+        foreach($sites as $site) {
+            if ($site->theme) {
+                if (!is_dir(CorePlugin::path($site->theme))) continue;
+                if(in_array($site->theme, $themes)) continue;
+                $themes[] = $site->theme;
+            }
+        }
+        return $themes;
     }
 
     /**

--- a/plugins/baser-core/src/BaserCorePlugin.php
+++ b/plugins/baser-core/src/BaserCorePlugin.php
@@ -167,8 +167,6 @@ class BaserCorePlugin extends BcPlugin implements AuthenticationServiceProviderI
         $app->addPlugin('Authentication');
         $app->addPlugin('Migrations');
 
-        $this->addTheme($app);
-
         $plugins = BcUtil::getEnablePlugins();
         if ($plugins) {
             foreach($plugins as $plugin) {
@@ -177,6 +175,8 @@ class BaserCorePlugin extends BcPlugin implements AuthenticationServiceProviderI
                 }
             }
         }
+
+        $this->addTheme($app);
 
         /**
          * デフォルトテンプレートを設定する

--- a/plugins/baser-core/src/View/AppView.php
+++ b/plugins/baser-core/src/View/AppView.php
@@ -16,6 +16,7 @@ use BaserCore\View\Helper\BcTimeHelper;
 use BaserCore\View\Helper\BcToolbarHelper;
 use BaserCore\View\Helper\BcUploadHelper;
 use Cake\View\View;
+use Cake\Core\Configure;
 use BaserCore\Annotation\NoTodo;
 use BaserCore\Annotation\Checked;
 use BaserCore\Annotation\UnitTest;
@@ -53,7 +54,7 @@ class AppView extends View
     {
         parent::initialize();
         $this->addHelper('BaserCore.BcTime');
-        $this->addHelper('BaserCore.BcForm', ['templates' => 'BaserCore.bc_form']);
+        $this->addHelper('BaserCore.BcForm', ['templates' => Configure::read('BcApp.AppFormTemplate')]);
         $this->addHelper('BaserCore.BcAdmin');
         $this->addHelper('BaserCore.BcContents');
         $this->addHelper('BaserCore.BcPage');

--- a/plugins/baser-core/src/View/BcAdminAppView.php
+++ b/plugins/baser-core/src/View/BcAdminAppView.php
@@ -56,7 +56,7 @@ class BcAdminAppView extends AppView
     public function initialize(): void
     {
         parent::initialize();
-        $this->addHelper('BaserCore.BcAdminForm', ['templates' => 'BaserCore.bc_form']);
+        $this->addHelper('BaserCore.BcAdminForm', ['templates' => Configure::read('BcApp.AdminFormTemplate')]);
         $this->addHelper('BaserCore.BcAuth');
         $this->addHelper('BaserCore.BcText');
         $this->addHelper('BaserCore.BcContents');

--- a/plugins/baser-core/tests/TestCase/BaserCorePluginTest.php
+++ b/plugins/baser-core/tests/TestCase/BaserCorePluginTest.php
@@ -42,7 +42,7 @@ use BaserCore\Command\UpdateCommand;
  * Class PluginTest
  * @property BaserCorePlugin $Plugin
  */
-class PluginTest extends BcTestCase
+class BaserCorePluginTest extends BcTestCase
 {
     use ScenarioAwareTrait;
 

--- a/plugins/bc-mail/config/setting.php
+++ b/plugins/bc-mail/config/setting.php
@@ -154,6 +154,13 @@ return [
             ['name' => 'email', 'title' => 'Eメールアドレス'],
             ['name' => 'impp', 'title' => 'インスタントメッセージングプロトコルの端点'],
             ['name' => 'on', 'title' => '自動設定'],
-        ]
+        ],
+        /**
+         * bc_formのテンプレートを指定
+         * config/bc_form.phpを差し替える         
+         *  プラグイン記法 (プラグイン名.テンプレート名)
+         * basercms/plugins/bc-mail/src/View/MailFrontAppView.php
+         */
+        'formTemplate' => 'BaserCore.bc_form'
     ]
 ];

--- a/plugins/bc-mail/src/View/MailFrontAppView.php
+++ b/plugins/bc-mail/src/View/MailFrontAppView.php
@@ -11,6 +11,7 @@
 
 namespace BcMail\View;
 
+use Cake\Core\Configure;
 use BaserCore\View\BcFrontAppView;
 use BaserCore\Annotation\UnitTest;
 use BaserCore\Annotation\NoTodo;
@@ -39,7 +40,7 @@ class MailFrontAppView extends BcFrontAppView
         parent::initialize();
         $this->addHelper('BcMail.Mail');
         $this->addHelper('BcMail.Mailfield');
-        $this->addHelper('BcMail.Mailform', ['templates' => 'BaserCore.bc_form']);
+        $this->addHelper('BcMail.Mailform', ['templates' => Configure::read('BcMail.formTemplate')]);
     }
 
 }


### PR DESCRIPTION
１）Themeのconfig/setting.phpが、Pluginの後に読み込まれて上書きされるため、Themeが最後に読み込まれるように、addThemeの位置を変更。

２）config/bc_form.phpの読み込むファイルを、Plugin/Themeのconfig/setting.phpで変更できるように、setting.phpに設定値を追加。

追加した設定値は以下3つ
```
BcApp.AdminFormTemplate
BcApp.AppFormTemplate
BcMail.formTemplate
```

デフォルトの設置値
```php
'BaserCore.bc_form'
```

それぞれ以下のViewファイルに対応
```
BcApp.AdminFormTemplate -> BcAdminAppView
BcApp.AppFormTemplate -> AppView
BcMail.formTemplate -> MailFrontAppView （フロントのbc-mailに対応）
```


独自Plugin/Themeのconfig/setting.phpで次のように書いて、
```php
return [
    'BcMail' => [
        'formTemplate' => 'ThemeName.bc_form'
    ],
];
```
baser-core/config/bc_form.phpを、独自Plugin/Themeのconfig/bc_form.phpへコピーして、内容を書き換える。
