### PR TITLE
カラム指定調整

### DIFF
--- a/plugins/baser-core/src/Model/Table/ContentsTable.php
+++ b/plugins/baser-core/src/Model/Table/ContentsTable.php
@@ -409,7 +409,7 @@ class ContentsTable extends AppTable
         $query = $this->find()->where(['name LIKE' => $name . '%', 'site_root' => false]);
         if (isset($parentId)) $query = $query->andWhere(['parent_id' => $parentId]);
         if ($contentId) {
-            $query = $query->andWhere(['id <>' => $contentId]);
+            $query = $query->andWhere(['Contents.id <>' => $contentId]);
         }
         $datas = $query->select('name')->orderBy('name')->all()->toArray();
         $datas = Hash::extract($datas, '{n}.name');

--- a/plugins/baser-core/src/Model/Table/SitesTable.php
+++ b/plugins/baser-core/src/Model/Table/SitesTable.php
@@ -212,7 +212,7 @@ class SitesTable extends AppTable
      */
     public function getPublishedAll(): ResultSetInterface
     {
-        return $this->find()->where(['status' => true])->all();
+        return $this->find()->where(['Sites.status' => true])->all();
     }
 
     /**
@@ -236,7 +236,7 @@ class SitesTable extends AppTable
 
         $conditions = [];
         if (!is_null($options['status'])) {
-            $conditions = ['status' => $options['status']];
+            $conditions = ['Sites.status' => $options['status']];
         }
 
         if (!is_null($mainSiteId)) {

--- a/plugins/bc-blog/src/Service/BlogCategoriesService.php
+++ b/plugins/bc-blog/src/Service/BlogCategoriesService.php
@@ -119,7 +119,7 @@ class BlogCategoriesService implements BlogCategoriesServiceInterface
         $categories = [];
         foreach ($srcCategories->toArray() as $key => $value) {
             /* @var BlogCategory $category */
-            $category = $this->BlogCategories->find()->where(['id' => $key])->first();
+            $category = $this->BlogCategories->find()->where(['BlogCategories.id' => $key])->first();
             if (!preg_match("/^([_]+)/i", $value, $matches)) {
                 $category->depth = 0;
                 $category->layered_title = $category->title;

--- a/plugins/bc-search-index/src/Model/Behavior/BcSearchIndexManagerBehavior.php
+++ b/plugins/bc-search-index/src/Model/Behavior/BcSearchIndexManagerBehavior.php
@@ -191,7 +191,7 @@ class BcSearchIndexManagerBehavior extends Behavior
         }
 
         if (!empty($searchIndex['content_id'])) {
-            $content = $this->Contents->find()->select(['lft', 'rght'])->where(['id' => $searchIndex['content_id']])->first();
+            $content = $this->Contents->find()->select(['lft', 'rght'])->where(['Contents.id' => $searchIndex['content_id']])->first();
             $searchIndex['lft'] = $content->lft;
             $searchIndex['rght'] = $content->rght;
         } else {


### PR DESCRIPTION
baserのテーブルに関連付けを追加した際に、以下のようなエラーが発生するため修正しました。

```
error: [PDOException] SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'status' in where clause is ambiguous
```

すべての箇所は直せていないので、また見つけ次第PR作成します。
ご確認お願いします。