### PR TITLE
【コンテンツ】レイアウトテンプレートの取得順序変更

### DIFF
--- a/plugins/baser-core/src/Service/Admin/BcAdminContentsService.php
+++ b/plugins/baser-core/src/Service/Admin/BcAdminContentsService.php
@@ -133,7 +133,7 @@ class BcAdminContentsService implements BcAdminContentsServiceInterface
             if (in_array($parentTemplate, $templates)) {
                 unset($templates[$parentTemplate]);
             }
-            $templates = array_merge($templates, ['' => __d('baser_core', '親フォルダの設定に従う') . '（' . $parentTemplate . '）']);
+            $templates = array_merge(['' => __d('baser_core', '親フォルダの設定に従う') . '（' . $parentTemplate . '）'], $templates);
         }
         return $templates;
     }


### PR DESCRIPTION
コンテンツ管理のレイアウトテンプレートの箇所に表示される順番を変更しました。
「親フォルダの設定に従う」が一番下にあったのを、一番上に持ってきています。

一番下にある場合の問題点はコンテンツを作成後、レイアウトテンプレートを特に変更せずに保存ボタンを押すとレイアウトテンプレートが変更されてしまう点となります。

<img width="1394" alt="スクリーンショット_2024-11-22_14_50_11" src="https://github.com/user-attachments/assets/604a9a82-75cf-46d8-adc8-c26ed8adb1d6">

ご確認お願いします。