### PR TITLE
addAdminMainBodyHeaderLinks()で外部リンクを設定できるように修正 fix #4030

### DIFF
--- a/plugins/bc-admin-third/templates/Admin/element/main_body_header_links.php
+++ b/plugins/bc-admin-third/templates/Admin/element/main_body_header_links.php
@@ -35,7 +35,7 @@ if (!isset($mainBodyHeaderLinks)) {
   if (empty($link['class'])) {
     $link['class'] = 'bca-btn';
   }
-  if (empty($link['data-bca-btn-type'])) {
+  if (empty($link['data-bca-btn-type']) && !empty($url['action'])) {
     $link['data-bca-btn-type'] = $url['action'];
   }
   if (empty($link['data-bca-btn-size'])) {


### PR DESCRIPTION
@ryuring 
お待たせしています...!
アドバイスいただいた通り、以下修正を追加しました。
actionの指定がない場合`data-bca-btn-type` を指定せずボタンを出力するようになります。

以下を確認しています
- actionを指定しない（外部リンクを指定する）場合でもボタンが出力され、クリックで正しく遷移できる
- actionを指定した（既存処理の）場合でもボタンが出力され、クリックで正しく遷移できる