### PR TITLE
メールフォーム受付期間のpublish_endにバリデーション追加 fix #4000

### DIFF
--- a/plugins/bc-mail/src/Model/Table/MailContentsTable.php
+++ b/plugins/bc-mail/src/Model/Table/MailContentsTable.php
@@ -157,6 +157,23 @@ class MailContentsTable extends MailAppTable
                 ]
             ]);
 
+        // publish_end
+        $validator
+        ->add('publish_end', [
+            'dateTime' => [
+                'rule' => ['dateTime'],
+                'message' => __d('baser_core', '公開終了日に不正な文字列が入っています。')
+            ]
+        ])
+        ->allowEmptyDateTime('publish_end')
+        ->add('publish_end', [
+            'checkDateAfterThan' => [
+                'rule' => ['checkDateAfterThan', 'publish_begin'],
+                'provider' => 'bc',
+                'message' => __d('baser_core', '公開終了日は、公開開始日より新しい日付で入力してください。')
+            ]
+        ]);
+
         // sender_1
         $validator
             ->scalar('sender_1')


### PR DESCRIPTION
@fuchigam1 
お待たせしております...!
こちら修正対応反映しましたのでご確認お願いします。

メールフォーム受付期間の終了日付（publish_end）に開始日付以後であるかのバリデーションが適用されていなかっため追加しました。

ローカル環境にて以下を確認しています
- 終了日付が開始日付以前の場合、エラーが表示され保存できないこと
- 終了日付が開始日付以後の場合（正常系）、正しく保存されること
![Monosnap メールフォーム設定編集 2024-12-03 21-57-48](https://github.com/user-attachments/assets/79f6c5ee-214e-4d84-bb19-257e5d8c6930)
