### PR TITLE
fix #4067 Cookie（csrfToken）にsecure属性が付かない問題を解決

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -64,6 +64,12 @@ class Application extends BaseApplication
      */
     public function middleware(MiddlewareQueue $middlewareQueue): MiddlewareQueue
     {
+        $csrfProtectionMiddlewareOptions = ['httponly' => true];
+        //リクエストがhttpsならcsrfTokenにもsecureヘッダを付与
+        $sessionConfig = (array)Configure::read('Session');
+        if (!empty($sessionConfig['ini']['session.cookie_secure']) || ini_get('session.cookie_secure') == 1) {
+            $csrfProtectionMiddlewareOptions['secure'] =  true;
+        }
         $middlewareQueue
             // Catch any exceptions in the lower layers,
             // and make an error page/response
@@ -87,9 +93,7 @@ class Application extends BaseApplication
 
             // Cross Site Request Forgery (CSRF) Protection Middleware
             // https://book.cakephp.org/5/en/security/csrf.html#cross-site-request-forgery-csrf-middleware
-            ->add(new CsrfProtectionMiddleware([
-                'httponly' => true,
-            ]));
+            ->add(new CsrfProtectionMiddleware($csrfProtectionMiddlewareOptions));
 
         return $middlewareQueue;
     }

--- a/src/Application.php
+++ b/src/Application.php
@@ -66,8 +66,8 @@ class Application extends BaseApplication
     {
         $csrfProtectionMiddlewareOptions = ['httponly' => true];
         //リクエストがhttpsならcsrfTokenにもsecureヘッダを付与
-        $sessionConfig = (array)Configure::read('Session');
-        if (!empty($sessionConfig['ini']['session.cookie_secure']) || ini_get('session.cookie_secure') == 1) {
+        $sessionConfig = (array) Configure::read('Session');
+        if (!empty($sessionConfig['ini']['session.cookie_secure']) || (int) ini_get('session.cookie_secure') === 1) {
             $csrfProtectionMiddlewareOptions['secure'] =  true;
         }
         $middlewareQueue


### PR DESCRIPTION
@ryuring 
@seto1 

BASERCMSクッキーにsecure属性がつく場合は、csrfTokenにもsecure属性がつくように調整しました。
ご確認ください。


php.iniでsession.cookie_secure = 1になっていても、csrfTokenにはsecure属性がつかないので、
BASERCMSクッキーにsecure属性がつくときと同じ条件で、secure属性がつくように調整しました。
（cakePHPの仕様でSessionは.envにHTTPSパラメータを追記するとサーバーの状態に関係なくsecure属性がつくようになります。それも引き継ぐようにしています。）