### PR TITLE
fix #4072 [要望] 画像をアップロードすると元画像より容量が大きくなる事がある問題を解決

### DIFF
--- a/config/app_local.example.php
+++ b/config/app_local.example.php
@@ -91,4 +91,6 @@ return [
             'url' => env('EMAIL_TRANSPORT_DEFAULT_URL', null),
         ],
     ],
+    // thmbnailの解像度を変更する場合
+    // 'resizeResolution' => 72,
 ];

--- a/plugins/baser-core/src/Vendor/Imageresizer.php
+++ b/plugins/baser-core/src/Vendor/Imageresizer.php
@@ -129,6 +129,12 @@ class Imageresizer
             @unlink($savePath);
         }
 
+        // ConfigのresizeResolutionの値があって、デフォルト（96dpi）より小さい場合、解像度を上書きする
+        $resizeResolution = \Cake\Core\Configure::read('resizeResolution');
+        if (!empty($resizeResolution) && (int) $resizeResolution < 96 ){
+            imageresolution($newImage, $resizeResolution, $resizeResolution);
+        }
+
         switch($image_type) {
             case IMAGETYPE_GIF:
                 if ($savePath) {


### PR DESCRIPTION
@ryuring 
一応、元の値より大きくなることを防ぐ目的で、96未満の数値を入れたときのみ、解像度を上書きするようにしています。
（app_local.phpにコメントアウトで設定の文言を入れています。）
ご確認お願いします。