### PR TITLE
fix #4036 【メール】送信情報をデータベースに保存しない場合にファイルを添付すると送信に失敗する

### DIFF
--- a/plugins/bc-mail/src/Service/Front/MailFrontService.php
+++ b/plugins/bc-mail/src/Service/Front/MailFrontService.php
@@ -248,17 +248,18 @@ class MailFrontService implements MailFrontServiceInterface
                     $sendEmailOptions
                 ]);
             }
-            if ($mailContent->save_info) return;
-            foreach($mailFields as $field) {
-                if ($field->type !== 'file') continue;
-                // 削除フラグをセット
-                $mailMessage->{$field->field_name . '_delete'} = true;
-            }
-            // TODO ucmitz 未検証
-            $mailMessagesTable = TableRegistry::getTableLocator()->get('BcMail.MailMessages');
-            $mailMessagesTable->getFileUploader()->deleteFiles($mailMessage, $mailMessage);
         } catch (\Throwable $e) {
+            if (!$mailContent->save_info) {
+                /** @var MailMessagesService $mailMessagesService */
+                $mailMessagesService = $this->getService(MailMessagesServiceInterface::class);
+                $mailMessagesService->delete($mailMessage->id);
+            }
             throw $e;
+        }
+        if (!$mailContent->save_info) {
+            /** @var MailMessagesService $mailMessagesService */
+            $mailMessagesService = $this->getService(MailMessagesServiceInterface::class);
+            $mailMessagesService->delete($mailMessage->id);
         }
     }
 

--- a/plugins/bc-mail/src/Service/MailMessagesService.php
+++ b/plugins/bc-mail/src/Service/MailMessagesService.php
@@ -143,11 +143,7 @@ class MailMessagesService implements MailMessagesServiceInterface
             $mailFieldsTable = TableRegistry::getTableLocator()->get('BcMail.MailFields');
             $mailFields = $mailFieldsTable->find()->where(['MailFields.mail_content_id' => $mailContent->id, 'MailFields.use_field' => true])->all();
             $this->MailMessages->convertToDb($mailFields, $entity);
-            if ($mailContent->save_info) {
-                return $this->MailMessages->saveOrFail($entity);
-            } else {
-                return $entity;
-            }
+            return $this->MailMessages->saveOrFail($entity);
         }
         throw new PersistenceFailedException($entity, __d('baser_core', '入力エラーです。内容を見直してください。'));
     }


### PR DESCRIPTION
issue: https://github.com/baserproject/basercms/issues/4036

5系版です。
データベースに保存しない設定の場合でも、一度データを保存しメール送信後にデータを削除することで対応しました。
ご確認お願いします。