### PR TITLE
fix ##4099 5.0.x系にて、カスタムコンテンツ一覧表示件数が管理画面通りにならない問題を解決

### DIFF
--- a/plugins/bc-custom-content/src/Controller/CustomContentController.php
+++ b/plugins/bc-custom-content/src/Controller/CustomContentController.php
@@ -65,7 +65,10 @@ class CustomContentController extends BcFrontAppController
 
         $this->set($service->getViewVarsForIndex(
             $customContent,
-            $this->paginate($service->getCustomEntries($customContent, $this->getRequest()->getQueryParams()))
+            $this->paginate(
+                $service->getCustomEntries($customContent, $this->getRequest()->getQueryParams()),
+                ['limit' => $customContent->list_count]
+            )
         ));
         $this->setRequest($this->getRequest()->withParsedBody($this->getRequest()->getQueryParams()));
         $this->render($service->getIndexTemplate($customContent));


### PR DESCRIPTION
@ryuring 

本来であれば

```
        $this->set($service->getViewVarsForIndex(
            $customContent,
            $this->paginate(
                $service->getCustomEntries($customContent, $this->getRequest()->getQueryParams()),
                ['limit' => $customContent->list_count,
                    'sort' => $customContent->list_order,
                    'direction' => $customContent->list_direction
                ]
            )
        ));
```
のほうが望ましいのですが、一旦5.1.xと同様に

```
        $this->set($service->getViewVarsForIndex(
            $customContent,
            $this->paginate(
                $service->getCustomEntries($customContent, $this->getRequest()->getQueryParams()),
                ['limit' => $customContent->list_count]
            )
        ));
```
としています。
お手数ですが、ご確認の上、5.0.xへとマージお願いします。