### PR TITLE
fix #4105 5.0.x系にて【お気に入り】お気に入り一覧に別のユーザーのデータまで表示される問題 を解決

### DIFF
--- a/plugins/bc-favorite/src/Service/FavoritesService.php
+++ b/plugins/bc-favorite/src/Service/FavoritesService.php
@@ -12,6 +12,7 @@
 namespace BcFavorite\Service;
 
 use BcFavorite\Model\Table\FavoritesTable;
+use BaserCore\Utility\BcUtil;
 use Cake\Datasource\EntityInterface;
 use Cake\ORM\Exception\PersistenceFailedException;
 use Cake\ORM\Query;
@@ -70,7 +71,12 @@ class FavoritesService implements FavoritesServiceInterface
         if (!empty($queryParams['num'])) {
             $options = ['limit' => $queryParams['num']];
         }
-        $query = $this->Favorites->find('all', $options)->order(['sort']);
+        $query = $this->Favorites->find('all', $options)
+        ->where(
+            ['Favorites.user_id' => BcUtil::loginUser()->id]
+        )
+        ->order(['sort']);
+
         return $query;
     }
 

--- a/plugins/bc-favorite/tests/TestCase/Service/FavoritesServiceTest.php
+++ b/plugins/bc-favorite/tests/TestCase/Service/FavoritesServiceTest.php
@@ -90,6 +90,8 @@ class FavoritesServiceTest extends BcTestCase
      */
     public function testGetIndex(): void
     {
+        $this->loadFixtureScenario(InitAppScenario::class);
+        $this->loginAdmin($this->getRequest());
         $this->loadFixtureScenario(FavoritesScenario::class);
         $result = $this->FavoritesService->getIndex(['num' => 2]);
         $this->assertEquals(2, $result->all()->count());
@@ -144,6 +146,8 @@ class FavoritesServiceTest extends BcTestCase
     public function testDelete()
     {
         $this->loadFixtureScenario(FavoritesScenario::class);
+        $this->loadFixtureScenario(InitAppScenario::class);
+        $this->loginAdmin($this->getRequest());
         $this->FavoritesService->delete(1);
         $users = $this->FavoritesService->getIndex([]);
         $this->assertEquals(5, $users->all()->count());


### PR DESCRIPTION
@ryuring 
すみません。
案件でも対応しているため、
お手数ですが、ご確認の上、5.0.x系にマージをお願いします。