### PR TITLE
fix #4103 【システム】管理画面ログイン後のリダイレクトが動作していない

### DIFF
--- a/lib/Baser/Controller/UsersController.php
+++ b/lib/Baser/Controller/UsersController.php
@@ -165,7 +165,6 @@ class UsersController extends AppController
 				// EVENT Users.afterLogin
 				$this->dispatchEvent('afterLogin', [
 					'user' => $this->BcAuth->user(),
-					'loginRedirect' => $this->BcAuth->redirect(),
 				]);
 
 				$this->redirect($this->BcAuth->redirectUrl());


### PR DESCRIPTION
issue: https://github.com/baserproject/basercms/issues/4103

UsersController->admin_loginにてAuthComponent->redirectUrlが2回呼び出されており、リダイレクト用のURLが記録されたセッションが削除されてしまっていたようです。

ご確認お願いします。