### PR TITLE
fix #4108 [bc-front]ページネーションsimpleのcatchの記載の問題を解決

### DIFF
--- a/plugins/bc-front/templates/element/paginations/simple.php
+++ b/plugins/bc-front/templates/element/paginations/simple.php
@@ -23,7 +23,7 @@
  */
 try {
   $pageCount = $this->Paginator->counter('{{pages}}');
-} catch (\Cake\Core\Exception\CakeException) {
+} catch (\Cake\Core\Exception\CakeException $e) {
   return;
 }
 if (!isset($modules)) {


### PR DESCRIPTION
@ryuring 
取り急ぎ、第二引数を入れれば問題は解消するので、
一旦はそちらで対応しています。

お手数ですが、ご確認の上マージをお願いします。