### PR TITLE
ファイルのアップロードに失敗した状態でfileExtバリデーションを実行するとエラーになる

### DIFF
--- a/plugins/baser-core/src/Model/Validation/BcValidation.php
+++ b/plugins/baser-core/src/Model/Validation/BcValidation.php
@@ -271,6 +271,9 @@ class BcValidation extends Validation
         } elseif(is_array($file)) {
             $fileName = $file['name'];
             $type = $file['type'];
+            if ($file['error']) {
+                return __d('baser_core', 'ファイルのアップロードに失敗したため、拡張子の判定に失敗しました。');
+            }
         } else {
             $fileName = $file;
             $type = null;


### PR DESCRIPTION
以下のissueに関連するのですが、upload_max_filesizeよりもファイルサイズが大きく、post_max_sizeよりもファイルサイズが小さいファイルをアップするとエラーになります。
https://github.com/baserproject/basercms/issues/4112

ブログのアイキャッチやメールのファイルフィールドにて確認しています。

BcValidation::fileExt内のpathinfoを呼び出しているところでエラーになっているようです。
そのため、アップロードしたファイルに問題がある場合はそこで処理を止めるようにしています。

ご確認お願いします。