### PR TITLE
fix #4126 【コンテンツ】5.0.x にてレイアウトテンプレートの取得順序がおかしくなる問題を解決

### DIFF
--- a/plugins/baser-core/src/Service/Admin/BcAdminContentsService.php
+++ b/plugins/baser-core/src/Service/Admin/BcAdminContentsService.php
@@ -133,7 +133,7 @@ class BcAdminContentsService implements BcAdminContentsServiceInterface
             if (in_array($parentTemplate, $templates)) {
                 unset($templates[$parentTemplate]);
             }
-            $templates = array_merge($templates, ['' => __d('baser_core', '親フォルダの設定に従う') . '（' . $parentTemplate . '）']);
+            $templates = array_merge(['' => __d('baser_core', '親フォルダの設定に従う') . '（' . $parentTemplate . '）'], $templates);
         }
         return $templates;
     }


### PR DESCRIPTION
@ryuring 
@seto1 

修正方法は
https://github.com/baserproject/basercms/pull/4040/commits/9a296d9056c527f390e0d8f0fc7eb8753ddd6d8d
と全く同じです。

こちらで、正常動作になることを確認しました。

お手数ですが、ご確認の上、マージをお願いできますでしょうか？