### PR TITLE
【アップローダー】サブフォルダコンテンツにて、ブログなどアイキャッチ画像をクリックすると表示に失敗する fix #4136

### DIFF
--- a/lib/Baser/View/Helper/BcAppHelper.php
+++ b/lib/Baser/View/Helper/BcAppHelper.php
@@ -99,6 +99,9 @@ class BcAppHelper extends Helper
 		} else {
 			$webPath = Router::url('/' . $asset[0]);
 		}
+		if (strpos($asset[0], DS) !== 0) {
+			$webPath = DS . $webPath;
+		}
 		// <<<
 
 		$file = $asset[0];


### PR DESCRIPTION
対策コミットになります。ご確認お願いいたします。