### PR TITLE
ブログでスラッグを使用するとリダイレクトループになる

### DIFF
--- a/plugins/bc-blog/src/Model/Table/BlogPostsTable.php
+++ b/plugins/bc-blog/src/Model/Table/BlogPostsTable.php
@@ -842,7 +842,7 @@ class BlogPostsTable extends BlogAppTable
         } else {
             $conditions = array_merge_recursive(
                 $conditions,
-                ['BlogPosts.name' => rawurldecode($no)]
+                ['BlogPosts.name' => $no]
             );
         }
         $entity = $this->find()->where($conditions)

--- a/plugins/bc-blog/src/Service/Front/BlogFrontService.php
+++ b/plugins/bc-blog/src/Service/Front/BlogFrontService.php
@@ -355,6 +355,9 @@ class BlogFrontService implements BlogFrontServiceInterface
     {
         $isPreview = (bool)$request->getQuery('preview');
         $no = $request->getParam('pass.0');
+        if (is_string($no)) {
+            $no = rawurldecode($no);
+        }
         $post = $editLink = null;
         if($isPreview) {
             if($no) {

--- a/plugins/bc-blog/tests/Scenario/MultiSiteBlogPostScenario.php
+++ b/plugins/bc-blog/tests/Scenario/MultiSiteBlogPostScenario.php
@@ -118,7 +118,7 @@ class MultiSiteBlogPostScenario implements FixtureScenarioInterface
             'id' => 1,
             'user_id' => 1,
             'blog_content_id' => 6,
-            'blog_category_id' => 6,
+            'blog_category_id' => null,
             'no' => 3,
             'name' => 'release',
             'title' => 'プレスリリース',
@@ -169,6 +169,26 @@ class MultiSiteBlogPostScenario implements FixtureScenarioInterface
             'no' => 3,
             'name' => 'release',
             'title' => 'プレスリリース',
+            'status' => 1,
+            'exclude_search' => 0,
+        ])->persist();
+        BlogPostFactory::make([
+            'id' => 7,
+            'blog_content_id' => 6,
+            'blog_category_id' => null,
+            'no' => 4,
+            'name' => '日本語スラッグ',
+            'title' => '日本語スラッグ記事タイトル',
+            'status' => 1,
+            'exclude_search' => 0,
+        ])->persist();
+        BlogPostFactory::make([
+            'id' => 8,
+            'blog_content_id' => 6,
+            'blog_category_id' => null,
+            'no' => 5,
+            'name' => null,
+            'title' => 'スラッグがない記事',
             'status' => 1,
             'exclude_search' => 0,
         ])->persist();

--- a/plugins/bc-blog/tests/TestCase/Controller/BlogControllerTest.php
+++ b/plugins/bc-blog/tests/TestCase/Controller/BlogControllerTest.php
@@ -27,6 +27,7 @@ use BcBlog\Test\Factory\BlogContentFactory;
 use BcBlog\Test\Factory\BlogPostBlogTagFactory;
 use BcBlog\Test\Factory\BlogPostFactory;
 use BcBlog\Test\Factory\BlogTagFactory;
+use BcBlog\Test\Scenario\MultiSiteBlogPostScenario;
 use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Event\Event;
 use Cake\TestSuite\IntegrationTestTrait;
@@ -226,12 +227,27 @@ class BlogControllerTest extends BcTestCase
      */
     public function test_posts()
     {
-        $this->markTestIncomplete('このテストはまだ実装されていません。');
-        //準備
+        $this->loadFixtureScenario(MultiSiteBlogPostScenario::class);
 
-        //正常系実行
+        // スラッグが設定されている記事
+        $this->get('/news/archives/release');
+        $this->assertResponseOk();
+        $this->get('/news/archives/3');
+        $this->assertRedirect('/news/archives/release');
 
-        //異常系実行
+        // 日本語のスラッグが設定されている記事
+        $this->get('/news/archives/' . rawurlencode('日本語スラッグ'));
+        $this->assertResponseOk();
+        $this->get('/news/archives/4');
+        $this->assertRedirect('/news/archives/' . rawurlencode('日本語スラッグ'));
+
+        // スラッグが設定されていない記事
+        $this->get('/news/archives/5');
+        $this->assertResponseOk();
+
+        // 404
+        $this->get('/news/archives/9999');
+        $this->assertResponseCode(404);
 
 
     }

--- a/plugins/bc-blog/tests/TestCase/Model/BlogPostsTableTest.php
+++ b/plugins/bc-blog/tests/TestCase/Model/BlogPostsTableTest.php
@@ -734,7 +734,6 @@ class BlogPostsTableTest extends BcTestCase
         $this->assertEquals($rs->title, 'プレスリリース');
         $this->assertNotNull($rs->blog_comments);
         $this->assertNotNull($rs->blog_tags);
-        $this->assertNotNull($rs->blog_category);
         $this->assertNotNull($rs->user);
         $this->assertNotNull($rs->blog_content);
         $this->assertNotNull($rs->blog_content->content);
@@ -745,6 +744,12 @@ class BlogPostsTableTest extends BcTestCase
         //戻る値を確認
         $this->assertEquals($rs->no, 4);
         $this->assertEquals($rs->title, 'スマホサイトリリース');
+
+        // 日本語スラッグ
+        $rs = $this->BlogPostsTable->getPublishByNo(6, '日本語スラッグ', true);
+        $this->assertEquals($rs->title, '日本語スラッグ記事タイトル');
+        $rs = $this->BlogPostsTable->getPublishByNo(6, '日本語スラッグ', false);
+        $this->assertEquals($rs->title, '日本語スラッグ記事タイトル');
 
         //サービスクラス
         $blogPostsService = $this->getService(BlogPostsServiceInterface::class);


### PR DESCRIPTION
issue: https://github.com/baserproject/basercms/issues/4149

BlogFrontService->getViewVarsForSingle にてスラッグがマルチバイトだと、URLから渡された値とDBの値との判定に失敗していたため修正しています。
URLから取得したスラッグをrawurldecodeするようにしています。

これだけだと、getViewVarsForSingleから呼び出されているBlogPostsTable->getPublishByNoにて重複したrawurldecodeが発生するため、こちらは削除しています。

また、マルチバイトのスラッグが設定された記事へアクセスするテストも追加しています。

ご確認お願いします。
