### PR TITLE
fix #4159 【メール】setMailContentメソッドがまともに動かない問題を解決

### DIFF
--- a/plugins/bc-mail/src/View/Helper/MailHelper.php
+++ b/plugins/bc-mail/src/View/Helper/MailHelper.php
@@ -78,12 +78,24 @@ class MailHelper extends Helper
         if (isset($this->currentMailContent)) {
             return;
         }
-        if ($mailContentId) {
-            $MailContent = ClassRegistry::init('BcMail.MailContent');
-            $MailContent->reduceAssociations([]);
-            $this->currentMailContent = Hash::extract($MailContent->read(null, $mailContentId), 'MailContent');
-        } elseif ($this->_View->get('mailContent')) {
+        if ($this->_View->get('mailContent')) {
             $this->currentMailContent = $this->_View->get('mailContent');
+        } else {
+            // _ViewからmailContentをget出来ない場合、$mailContentsからfindする
+            if (!$mailContentId) {
+                $params = $this->_View->getRequest()->getAttribute('params');
+                if (!empty($params['plugin']) && !empty($params['entityId']) && $params['plugin'] == 'BcMail') {
+                    $mailContentId = $params['entityId'];
+                } else {
+                    return;
+                }
+            }
+            $MailContent = TableRegistry::getTableLocator()->get('BcMail.MailContents');
+            $this->currentMailContent = $MailContent->find('all')
+                ->where([
+                    'MailContents.id' => $mailContentId,
+                ])
+                ->first();
         }
     }
 


### PR DESCRIPTION
@ryuring 
すみません。これを直さないと
送信完了画面も受付中止画面もMailContentが取得できず、
https://github.com/baserproject/basercms/issues/4158
などの改修が出来ないため、
先行して、こちらのマージをお願いします。