### PR TITLE
fix #4162 ブログ】getBlogPosts()をデフォルトのままで使うと非公開記事まで取得されてしまう問題を解決

### DIFF
--- a/plugins/bc-blog/src/View/Helper/BlogHelper.php
+++ b/plugins/bc-blog/src/View/Helper/BlogHelper.php
@@ -1717,10 +1717,6 @@ class BlogHelper extends Helper
             'data' => [],
         ], $options);
 
-        if ($options['preview'] === false) {
-            $options['status'] = 'publish';
-        }
-
         if (!$contentsName && empty($options['contentsTemplate'])) {
             throw new BcException(__d('baser_core', '$contentsName を省略時は、contentsTemplate オプションで、コンテンツテンプレート名を指定してください。'));
         }
@@ -1779,6 +1775,10 @@ class BlogHelper extends Helper
             'limit' => $num
         ], $options);
 
+        if ($options['preview'] === false) {
+            $options['status'] = 'publish';
+        }
+        
         $options = $this->parseContentName($contentsName, $options);
         return $this->getService(BlogPostsServiceInterface::class)->getIndex($options);
     }


### PR DESCRIPTION
@ryuring 
こちら、ISSUEに記述した通り、
BlogHelperの `posts()` の中の

```
        if ($options['preview'] === false) {
            $options['status'] = 'publish';
        }
```
を `getPosts()` に移動することで対応しています。

ご確認の上、問題なさそうでしたら、マージをお願いします。