### PR TITLE
fix #4124 【メール】BcMail プラグインのイメージ認証（captcha）で画像が表示されない

### DIFF
--- a/plugins/bc-mail/src/Controller/MailController.php
+++ b/plugins/bc-mail/src/Controller/MailController.php
@@ -357,7 +357,7 @@ class MailController extends MailFrontAppController
      */
     public function captcha(BcCaptchaServiceInterface $service, string $token)
     {
-        $this->viewBuilder()->disableAutoLayout();
+        $this->disableAutoRender();
         $service->render($this->getRequest(), $token);
     }
 


### PR DESCRIPTION

当該Issue(#4124)において再現性のある、「captcha.phpに関するエラーがログ出力される事象」について
Controller側の自動レンダリングを停止し、Action名と同じView「captcha.php」を参照しないよう
修正しております。
（$service->renderによりkcaptcha側で生成された画像データのみが直接レスポンスとして返却される）