### PR TITLE
fix #4169 【コンテンツ】エイリアス編集画面からURLを編集しても、公開側URLに反映されない

### DIFF
--- a/lib/Baser/Controller/ContentsController.php
+++ b/lib/Baser/Controller/ContentsController.php
@@ -370,6 +370,7 @@ class ContentsController extends AppController
 				$this->redirect(['action' => 'edit_alias', $id]);
 			}
 			if ($this->Content->save($this->request->data)) {
+				clearDataCache();
 				$srcContent = $this->Content->find('first', ['conditions' => ['Content.id' => $this->request->data['Content']['alias_id']], 'recursive' => -1]);
 				$srcContent = $srcContent['Content'];
 				$message = Configure::read('BcContents.items.' . $srcContent['plugin'] . '.' . $srcContent['type'] . '.title') .


### PR DESCRIPTION
データキャッシュの影響で、エイリアス編集画面からURLを編集しても公開側URLに反映されないようでした。
ご確認お願いします。