### PR TITLE
contentHeader/contentFooter イベント修正

### DIFF
--- a/plugins/baser-core/src/View/Helper/BcBaserHelper.php
+++ b/plugins/baser-core/src/View/Helper/BcBaserHelper.php
@@ -1281,18 +1281,18 @@ class BcBaserHelper extends Helper
     public function content()
     {
         /*** contentHeader ***/
-        $this->dispatchLayerEvent('contentHeader', null, ['layer' => 'View', 'class' => '', 'plugin' => '']);
+        $this->dispatchLayerEvent('contentHeader', [], ['layer' => 'View', 'class' => '', 'plugin' => '']);
 
         /*** Controller.contentHeader ***/
-        $this->dispatchLayerEvent('contentHeader', null, ['layer' => 'View', 'class' => $this->getView()->getName()]);
+        $this->dispatchLayerEvent('contentHeader', [], ['layer' => 'View', 'class' => $this->getView()->getName()]);
 
         echo $this->getView()->fetch('content');
 
         /*** contentFooter ***/
-        $this->dispatchLayerEvent('contentFooter', null, ['layer' => 'View', 'class' => '', 'plugin' => '']);
+        $this->dispatchLayerEvent('contentFooter', [], ['layer' => 'View', 'class' => '', 'plugin' => '']);
 
         /*** Controller.contentFooter ***/
-        $this->dispatchLayerEvent('contentFooter', null, ['layer' => 'View', 'class' => $this->getView()->getName()]);
+        $this->dispatchLayerEvent('contentFooter', [], ['layer' => 'View', 'class' => $this->getView()->getName()]);
     }
 
     /**


### PR DESCRIPTION
contentHeader/contentFooter イベントが動作していなかったので修正しました。
型の問題でエラーが出ていました。
ご確認お願いします。

確認に使ったイベントクラスはこちらです。

```
<?php
namespace Test\Event;

use BaserCore\Event\BcViewEventListener;
use Cake\Event\EventInterface;

class TestViewEventListener extends BcViewEventListener
{

    public $events = [
        'contentHeader',
        'BcBlog.BlogPosts.contentHeader',
        'contentFooter',
        'BcBlog.BlogPosts.contentFooter',
    ];

    public function contentHeader(EventInterface $event)
    {
        echo 'contentHeader';
    }

    public function bcBlogBlogPostsContentHeader(EventInterface $event)
    {
        echo 'bcBlogBlogPostsContentHeader';
    }

    public function contentFooter(EventInterface $event)
    {
        echo 'contentFooter';
    }

    public function bcBlogBlogPostsContentFooter(EventInterface $event)
    {
        echo 'bcBlogBlogPostsContentFooter';
    }
}
```