### PR TITLE
fix #4174 【ブログ】ブログ設定編集画面にて、ヘルプのRSSフィードのリンクがおかしくなる問題を解決

### DIFF
--- a/plugins/bc-admin-third/templates/plugin/BcBlog/Admin/element/BlogContents/form.php
+++ b/plugins/bc-admin-third/templates/plugin/BcBlog/Admin/element/BlogContents/form.php
@@ -113,7 +113,7 @@ use Cake\Routing\Router;
               <li><?php echo __d('baser_core', '半角数字で入力してください。') ?></li>
               <?php if ($this->getRequest()->getParam('action') === 'edit'): ?>
                 <li><?php echo __d('baser_core', 'RSSフィードのURL') ?>&nbsp;
-                  <?php $this->BcBaser->link(Router::url('/' . $this->BcAdminForm->getSourceValue('Content.name') . '/index.rss', true), '/' . $this->BcAdminForm->getSourceValue('Content.name') . '/index.rss', ['target' => '_blank']) ?>
+                  <?php $this->BcBaser->link(Router::url('/' . $this->BcAdminForm->getSourceValue('content.name') . '/index.rss', true), '/' . $this->BcAdminForm->getSourceValue('content.name') . '/index.rss', ['target' => '_blank']) ?>
                 </li>
               <?php endif ?>
             </ul>


### PR DESCRIPTION
@ryuring 

bc-admin-third/templates/Admin/element/content_fields.phpに合わせて
`"content.name"`
にて調整しています。

ご確認の上、マージをお願いします。