### PR TITLE
コンテンツ管理 権限チェック調整

### DIFF
--- a/plugins/baser-core/src/View/Helper/BcContentsHelper.php
+++ b/plugins/baser-core/src/View/Helper/BcContentsHelper.php
@@ -141,11 +141,13 @@ class BcContentsHelper extends Helper
                 if (!empty($item['routes'][$method])) {
                     $route = $item['routes'][$method];
                     $item['url'][$method] = Router::url($route);
+                    $item['permissionCheckUrl'][$method] = Router::url([...$route, '_base' => false]);
                 }
             }
             // disabled
             if (!empty($item['url']['add'])) {
-                $item['addDisabled'] = !($this->PermissionsService->check($item['url']['add'], Hash::extract($user->user_groups, '{n}.id')));
+                $item['addDisabled'] = !($this->PermissionsService->check($item['permissionCheckUrl']['add'],
+                    Hash::extract($user->user_groups, '{n}.id')));
             } else {
                 $item['addDisabled'] = true;
             }
@@ -167,10 +169,10 @@ class BcContentsHelper extends Helper
     public function isActionAvailable($type, $action, $entityId): bool
     {
         $user = BcUtil::loginUser();
-        if (!isset($this->getConfig('items')[$type]['url'][$action])) {
+        if (!isset($this->getConfig('items')[$type]['permissionCheckUrl'][$action])) {
             return false;
         }
-        $url = $this->getConfig('items')[$type]['url'][$action] . '/' . $entityId;
+        $url = $this->getConfig('items')[$type]['permissionCheckUrl'][$action] . '/' . $entityId;
         if (isset($user->user_groups)) {
             $userGroups = $user->user_groups;
             $userGroupIds = [];

--- a/plugins/baser-core/tests/TestCase/View/Helper/BcContentsHelperTest.php
+++ b/plugins/baser-core/tests/TestCase/View/Helper/BcContentsHelperTest.php
@@ -231,7 +231,7 @@ class BcContentsHelperTest extends BcTestCase
     {
         // TODO: configが設定されてない場合だとすべてtrueで通ってしまうため再確認要
         $this->loginAdmin($this->getRequest(), $userGroup);
-        $this->BcContents->setConfig('items.' . $type . '.url.' . $action, 'sample');
+        $this->BcContents->setConfig('items.' . $type . '.permissionCheckUrl.' . $action, 'sample');
         $result = $this->BcContents->isActionAvailable($type, $action, $entityId);
         $this->assertEquals($expect, $result);
     }


### PR DESCRIPTION
issue: https://github.com/baserproject/basercms/issues/3739
こちらのissueの5系の対応を行いました。

4系の際の対応はこちらです。
https://github.com/baserproject/basercms/pull/3743/files
4系の際は権限チェックの直前でpreg_replaceでURLのフォルダの部分の削除を行っていました。
5系では権限チェック用のURLを別に生成することで対応しています。

ご確認お願いします。