### PR TITLE
コンテンツ削除権限チェック調整

### DIFF
--- a/plugins/baser-core/src/Service/Admin/ContentsAdminService.php
+++ b/plugins/baser-core/src/Service/Admin/ContentsAdminService.php
@@ -79,7 +79,7 @@ class ContentsAdminService extends ContentsService implements ContentsAdminServi
     protected function _isAvailableDelete($content)
     {
         if(!BcUtil::loginUser()->user_groups) return false;
-        $path = BcUtil::getPrefix() . 'baser-core/contents/delete';
+        $path = BcUtil::getPrefix() . '/baser-core/contents/delete';
         $userGroupIds = Hash::extract(BcUtil::loginUser()->user_groups, '{n}.id');
         $service = $this->getService(PermissionsServiceInterface::class);
         return ($content->id && $service->check($path, $userGroupIds) && !$content->site_root);


### PR DESCRIPTION
削除権限が無いのに固定ページ編集画面に削除ボタンが表示されていたので修正しています。
パス生成の部分で/が抜けていたので、以下のパスで権限のチェックを行っていたのが原因のようです。
/baser/adminbaser-core/contents/delete
ご確認お願いします。