### PR TITLE
fix #4188 【カスタムコンテンツ】検索テーブルに別のカスタムコンテンツの情報で上書きされてしまう問題を解決

### DIFF
--- a/plugins/bc-search-index/src/Model/Behavior/BcSearchIndexManagerBehavior.php
+++ b/plugins/bc-search-index/src/Model/Behavior/BcSearchIndexManagerBehavior.php
@@ -215,7 +215,8 @@ class BcSearchIndexManagerBehavior extends Behavior
             $before = $this->SearchIndexes->find()
                 ->where([
                     'model' => $searchIndex['model'],
-                    'model_id' => $searchIndex['model_id']
+                    'model_id' => $searchIndex['model_id'],
+                    'content_id' => $searchIndex['content_id'],
                 ])->first();
         }
         if ($before) {


### PR DESCRIPTION
@ryuring 
@seto1 
@kaburk 

結構クリティカルな問題なので、取り急ぎ応急処置として、保存時のデータ検索に
content_idを追加しています。

お手数ですが、ご確認お願いできますでしょうか？