### PR TITLE
fix #4190 hasメソッドに変更

### DIFF
--- a/plugins/baser-core/src/Event/BcShortCodeEventListener.php
+++ b/plugins/baser-core/src/Event/BcShortCodeEventListener.php
@@ -97,7 +97,7 @@ class BcShortCodeEventListener implements EventListenerInterface
                             }
                         }
 
-                        if ($view->helpers()->{$func[0]}) {
+                        if ($view->helpers()->has($func[0])) {
                             $Helper = $view->{$func[0]};
                         } else {
                             $className = $plugin . "\\" . "View\\Helper\\" . $func[0] . 'Helper';


### PR DESCRIPTION
遅くなりましたが、以下の課題を対応しました。
https://github.com/baserproject/basercms/issues/4190

## 対応内容
- ショートコードを読み込む際にエラーが発生しないようにhasメソッドで分岐

## 確認方法
- ショートコードを読み込んだ際にhasメソッドによる分岐が機能していることを確認

ご確認よろしくお願いします。