### PR TITLE
fix #4201 【カスタムコンテンツ】特定のカスタムコンテンツでプレビューを押すとエラーになる問題を解決

### DIFF
--- a/plugins/bc-custom-content/src/Service/Front/CustomContentFrontService.php
+++ b/plugins/bc-custom-content/src/Service/Front/CustomContentFrontService.php
@@ -364,20 +364,11 @@ class CustomContentFrontService extends BcFrontContentsService implements Custom
         }
 
         $events = BcUtil::offEvent($customEntriesTable->getEventManager(), 'Model.beforeMarshal');
-        // カスタムエントリーのエンティティをパッチ
-        if ($customEntriesTable->hasBehavior('BcUpload')) {
-            // BcUpload ビヘイビアがある場合は、アップロードファイルを保存
-            $entity = $customEntriesTable->patchEntity(
-                $customEntry ?? $customEntriesTable->newEmptyEntity(),
-                $customEntriesTable->saveTmpFiles($postEntity, mt_rand(0, 99999999))->toArray()
-            );
-        } else {
-            // BcUpload ビヘイビアがない場合は、通常のパッチ
-            $entity = $customEntriesTable->patchEntity(
-                $customEntry ?? $customEntriesTable->newEmptyEntity(),
-                $postEntity
-            );
-        }
+        $entity = $customEntriesTable->saveTmpFiles($postEntity, mt_rand(0, 99999999));
+        $entity = $customEntriesTable->patchEntity(
+            $customEntry ?? $customEntriesTable->newEmptyEntity(),
+                ($postEntity)? $entity->toArray(): []
+        );
         BcUtil::onEvent($customEntriesTable->getEventManager(), 'Model.beforeMarshal', $events);
 
         $entity = $customEntriesTable->decodeRow($entity);

--- a/plugins/bc-custom-content/src/Service/Front/CustomContentFrontService.php
+++ b/plugins/bc-custom-content/src/Service/Front/CustomContentFrontService.php
@@ -364,21 +364,17 @@ class CustomContentFrontService extends BcFrontContentsService implements Custom
         }
 
         $events = BcUtil::offEvent($customEntriesTable->getEventManager(), 'Model.beforeMarshal');
-        // カスタムエントリーのエンティティをパッチ
-        if ($customEntriesTable->hasBehavior('BcUpload')) {
+
+        if ($postEntity && $customEntriesTable->hasBehavior('BcUpload')) {
             // BcUpload ビヘイビアがある場合は、アップロードファイルを保存
             $entity = $customEntriesTable->saveTmpFiles($postEntity, mt_rand(0, 99999999));
-            $entity = $customEntriesTable->patchEntity(
-                $customEntry ?? $customEntriesTable->newEmptyEntity(),
-                ($postEntity)? $entity->toArray(): []
-            );
-        } else {
-            // BcUpload ビヘイビアがない場合は、通常のパッチ
-            $entity = $customEntriesTable->patchEntity(
-                $customEntry ?? $customEntriesTable->newEmptyEntity(),
-                $postEntity
-            );
+            $postEntity = $entity->toArray();
         }
+        $entity = $customEntriesTable->patchEntity(
+            $customEntry ?? $customEntriesTable->newEmptyEntity(),
+            $postEntity
+        );
+
         BcUtil::onEvent($customEntriesTable->getEventManager(), 'Model.beforeMarshal', $events);
 
         $entity = $customEntriesTable->decodeRow($entity);

--- a/plugins/bc-custom-content/src/Service/Front/CustomContentFrontService.php
+++ b/plugins/bc-custom-content/src/Service/Front/CustomContentFrontService.php
@@ -364,14 +364,20 @@ class CustomContentFrontService extends BcFrontContentsService implements Custom
         }
 
         $events = BcUtil::offEvent($customEntriesTable->getEventManager(), 'Model.beforeMarshal');
+        // カスタムエントリーのエンティティをパッチ
         if ($customEntriesTable->hasBehavior('BcUpload')) {
             // BcUpload ビヘイビアがある場合は、アップロードファイルを保存
-            $postEntity = $customEntriesTable->saveTmpFiles($postEntity, mt_rand(0, 99999999))->toArray();
+            $entity = $customEntriesTable->patchEntity(
+                $customEntry ?? $customEntriesTable->newEmptyEntity(),
+                $customEntriesTable->saveTmpFiles($postEntity, mt_rand(0, 99999999))->toArray()
+            );
+        } else {
+            // BcUpload ビヘイビアがない場合は、通常のパッチ
+            $entity = $customEntriesTable->patchEntity(
+                $customEntry ?? $customEntriesTable->newEmptyEntity(),
+                $postEntity
+            );
         }
-        $entity = $customEntriesTable->patchEntity(
-            $customEntry ?? $customEntriesTable->newEmptyEntity(),
-            ($postEntity) ? $postEntity : []
-        );
         BcUtil::onEvent($customEntriesTable->getEventManager(), 'Model.beforeMarshal', $events);
 
         $entity = $customEntriesTable->decodeRow($entity);

--- a/plugins/bc-custom-content/src/Service/Front/CustomContentFrontService.php
+++ b/plugins/bc-custom-content/src/Service/Front/CustomContentFrontService.php
@@ -364,11 +364,21 @@ class CustomContentFrontService extends BcFrontContentsService implements Custom
         }
 
         $events = BcUtil::offEvent($customEntriesTable->getEventManager(), 'Model.beforeMarshal');
-        $entity = $customEntriesTable->saveTmpFiles($postEntity, mt_rand(0, 99999999));
-        $entity = $customEntriesTable->patchEntity(
-            $customEntry ?? $customEntriesTable->newEmptyEntity(),
+        // カスタムエントリーのエンティティをパッチ
+        if ($customEntriesTable->hasBehavior('BcUpload')) {
+            // BcUpload ビヘイビアがある場合は、アップロードファイルを保存
+            $entity = $customEntriesTable->saveTmpFiles($postEntity, mt_rand(0, 99999999));
+            $entity = $customEntriesTable->patchEntity(
+                $customEntry ?? $customEntriesTable->newEmptyEntity(),
                 ($postEntity)? $entity->toArray(): []
-        );
+            );
+        } else {
+            // BcUpload ビヘイビアがない場合は、通常のパッチ
+            $entity = $customEntriesTable->patchEntity(
+                $customEntry ?? $customEntriesTable->newEmptyEntity(),
+                $postEntity
+            );
+        }
         BcUtil::onEvent($customEntriesTable->getEventManager(), 'Model.beforeMarshal', $events);
 
         $entity = $customEntriesTable->decodeRow($entity);

--- a/plugins/bc-custom-content/src/Service/Front/CustomContentFrontService.php
+++ b/plugins/bc-custom-content/src/Service/Front/CustomContentFrontService.php
@@ -364,10 +364,13 @@ class CustomContentFrontService extends BcFrontContentsService implements Custom
         }
 
         $events = BcUtil::offEvent($customEntriesTable->getEventManager(), 'Model.beforeMarshal');
-        $entity = $customEntriesTable->saveTmpFiles($postEntity, mt_rand(0, 99999999));
+        if ($customEntriesTable->hasBehavior('BcUpload')) {
+            // BcUpload ビヘイビアがある場合は、アップロードファイルを保存
+            $postEntity = $customEntriesTable->saveTmpFiles($postEntity, mt_rand(0, 99999999))->toArray();
+        }
         $entity = $customEntriesTable->patchEntity(
             $customEntry ?? $customEntriesTable->newEmptyEntity(),
-            ($postEntity)? $entity->toArray(): []
+            ($postEntity) ? $postEntity : []
         );
         BcUtil::onEvent($customEntriesTable->getEventManager(), 'Model.beforeMarshal', $events);
 


### PR DESCRIPTION
こちら本当はわかりやすいように以下のコードで修正をしたかったのですが、
現在のコードに合わせて調整しています。

```
        // カスタムエントリーのエンティティをパッチ
        if ($customEntriesTable->hasBehavior('BcUpload')) {
            // BcUpload ビヘイビアがある場合は、アップロードファイルを保存
            $entity = $customEntriesTable->patchEntity(
                $customEntry ?? $customEntriesTable->newEmptyEntity(),
                $customEntriesTable->saveTmpFiles($postEntity, mt_rand(0, 99999999))->toArray()
            );
        } else {
            // BcUpload ビヘイビアがない場合は、通常のパッチ
            $entity = $customEntriesTable->patchEntity(
                $customEntry ?? $customEntriesTable->newEmptyEntity(),
                $postEntity
            );
        }
```
