### PR TITLE
fix #4002 運用者：タグ追加ボタンが表示されていない

### DIFF
--- a/plugins/bc-blog/src/Model/Table/BlogTagsTable.php
+++ b/plugins/bc-blog/src/Model/Table/BlogTagsTable.php
@@ -91,7 +91,7 @@ class BlogTagsTable extends BlogAppTable
 
     /**
      * アクセス制限としてブログタグの新規追加ができるか確認する
-     *
+     * 管理画面における権限を前提とする
      * @param array $userGroupId ユーザーグループID
      * @param int $blogContentId ブログコンテンツID
      * @checked
@@ -104,10 +104,9 @@ class BlogTagsTable extends BlogAppTable
         $permissionsService = $this->getService(PermissionsServiceInterface::class);
         $addUrl = preg_replace('|^/index.php|', '', Router::url([
             'plugin' => 'BcBlog',
-            'prefix' => 'Api/Admin',
+            'prefix' => 'Admin',
             'controller' => 'BlogTags',
-            'action' => 'add',
-            '_ext' => 'json'
+            'action' => 'add'
         ]));
         return $permissionsService->check($addUrl, $userGroupId);
     }

--- a/plugins/bc-blog/src/Model/Table/BlogTagsTable.php
+++ b/plugins/bc-blog/src/Model/Table/BlogTagsTable.php
@@ -107,7 +107,7 @@ class BlogTagsTable extends BlogAppTable
             'prefix' => 'Api/Admin',
             'controller' => 'BlogTags',
             'action' => 'add',
-            $blogContentId
+            '_ext' => 'json'
         ]));
         return $permissionsService->check($addUrl, $userGroupId);
     }


### PR DESCRIPTION
https://github.com/baserproject/basercms/issues/4002

## 対応内容
- WEBAPIのルートの末尾にjsonを追加して、権限チェックが正しく機能するように

## 確認方法
- サイト運営権限でログインして記事追加ページのタグ追加ボタンが表示されて追加できること
- `ブログタグAPI`権限でwebapiのルートを無効化に変更して非表示になることを確認(タイプ：Api/Admin)

## 注意
この部分は管理システムの権限チェックではなく
ajaxから送信するようになっているため、webapiのルートでチェックするようになっている

ご確認よろしくお願いします。