### PR TITLE
fix #4214 webpackのビルドが通らない

### DIFF
--- a/plugins/bc-admin-third/webpack.config.js
+++ b/plugins/bc-admin-third/webpack.config.js
@@ -36,9 +36,9 @@ module.exports = {
         path: path.join(__dirname, 'webroot/js')
     },
     resolve: {
-        alias: {
-            process: "process/browser"
-        }
+        fallback: {
+            'process/browser': require.resolve('process/browser'),
+        },
     },
     optimization: {
         splitChunks: {


### PR DESCRIPTION
https://github.com/baserproject/basercms/issues/4214

## 対応内容
- React DnDのissueに上がっていた内容を取り込み

## 確認方法
- [basercms公式のビルド方法](https://baserproject.github.io/5/core_theme/javascript)を実行してビルドエラーが出ずにビルドされること

こちらのビルド環境の問題な気もしますが、ご確認よろしくお願いします。