### PR TITLE
fix #4005 ファイル項目を含まないテーブルのエントリーがプレビュー

### DIFF
--- a/plugins/bc-custom-content/src/Service/Front/CustomContentFrontService.php
+++ b/plugins/bc-custom-content/src/Service/Front/CustomContentFrontService.php
@@ -364,7 +364,12 @@ class CustomContentFrontService extends BcFrontContentsService implements Custom
         }
 
         $events = BcUtil::offEvent($customEntriesTable->getEventManager(), 'Model.beforeMarshal');
-        $entity = $customEntriesTable->saveTmpFiles($postEntity, mt_rand(0, 99999999));
+
+        // setupUploaderが呼ばれてファイルフィールドがあれば、saveTmpFilesメソッドが使えるようになる.
+        $entity = $customEntriesTable->behaviors()->hasMethod('saveTmpFiles')
+        ? $customEntriesTable->saveTmpFiles($postEntity, mt_rand(0, 99999999))
+        : $customEntriesTable->newEntity($postEntity);
+
         $entity = $customEntriesTable->patchEntity(
             $customEntry ?? $customEntriesTable->newEmptyEntity(),
             ($postEntity)? $entity->toArray(): []


### PR DESCRIPTION
https://github.com/baserproject/basercms/issues/4005

## 対応内容
- ファイルフィールドがないカスタムコンテンツの時はnewEntityを呼び出すように修正

## 確認方法
- ファイルフィールドがないカスタムコンテンツでプレビューができること
- ファイルフィールドがあるカスタムコンテンツでプレビューができること
