### PR TITLE
fix #4004 運用者：「初期データ読み込み」ボタンが表示されない

### DIFF
--- a/plugins/bc-admin-third/templates/Admin/element/Themes/index_list.php
+++ b/plugins/bc-admin-third/templates/Admin/element/Themes/index_list.php
@@ -73,7 +73,7 @@ use Cake\Core\Configure;
             <?php endif ?>
           </p>
         </div>
-        <?php if ($defaultDataPatterns && $this->BcBaser->isAdminUser()): ?>
+        <?php if ($defaultDataPatterns && $this->BCBaser->isLinkEnabled($this->Url->build(['action' => 'load_default_data_pattern']))): ?>
           <?php echo $this->BcAdminForm->create(null, ['url' => ['action' => 'load_default_data_pattern'], 'id' => 'ThemeLoadDefaultDataPatternForm']) ?>
           <?php echo $this->BcAdminForm->control('default_data_pattern', ['type' => 'select', 'options' => $defaultDataPatterns]) ?>
           <?php echo $this->BcAdminForm->submit(__d('baser_core', '初期データ読込'), ['class' => 'bca-btn', 'div' => false, 'id' => 'BtnLoadDefaultDataPattern']) ?>


### PR DESCRIPTION
https://github.com/baserproject/basercms/issues/4004

## 対応内容
- 管理者権限かどうかで表示をチェックしていたので、権限チェックに変更

## 確認方法
- サイト運用者などの役割で「テーマ管理」権限の初期データ読み込みの権限をONにして、表示されることを確認

ご確認よろしくお願いします。

## その他
デフォルトではこの権限はoffのため問題ないと思いますが
ロール等や権限なども初期化されるため、ログイン画面から締め出しを食うことになる気がするため、管理者権限でチェックしていたのかなと思いました。