### PR TITLE
fix #4003 カテゴリー一覧 運用者：アクションアイコンが表示されない

### DIFF
--- a/plugins/bc-admin-third/templates/plugin/BcBlog/Admin/element/BlogCategories/index_row.php
+++ b/plugins/bc-admin-third/templates/plugin/BcBlog/Admin/element/BlogCategories/index_row.php
@@ -56,26 +56,24 @@
         'data-bca-btn-type' => 'preview',
         'data-bca-btn-size' => 'lg']
     ) ?>
-    <?php if (\BaserCore\Utility\BcUtil::isAdminUser()): ?>
-      <?php $this->BcBaser->link('',
-        ['action' => 'edit', $blogContent->id, $blogCategory->id],
-        [
-          'title' => __d('baser_core', '編集'),
-          'class' => 'bca-btn-icon',
-          'data-bca-btn-type' => 'edit',
-          'data-bca-btn-size' => 'lg'
-        ]
-      ) ?>
-      <?= $this->BcAdminForm->postLink('',
-        ['action' => 'delete', $blogContent->id, $blogCategory->id],
-        [
-          'confirm' => __d('baser_core', "このデータを本当に削除してもいいですか？\n\nこのカテゴリに関連する記事は、どのカテゴリにも関連しない状態として残ります。"),
-          'title' => __d('baser_core', '削除'),
-          'class' => 'btn-delete bca-btn-icon',
-          'data-bca-btn-type' => 'delete',
-          'data-bca-btn-size' => 'lg',
-        ]
-      ) ?>
-    <?php endif ?>
+    <?php $this->BcBaser->link('',
+      ['action' => 'edit', $blogContent->id, $blogCategory->id],
+      [
+        'title' => __d('baser_core', '編集'),
+        'class' => 'bca-btn-icon',
+        'data-bca-btn-type' => 'edit',
+        'data-bca-btn-size' => 'lg'
+      ]
+    ) ?>
+    <?= $this->BcAdminForm->postLink('',
+      ['action' => 'delete', $blogContent->id, $blogCategory->id],
+      [
+        'confirm' => __d('baser_core', "このデータを本当に削除してもいいですか？\n\nこのカテゴリに関連する記事は、どのカテゴリにも関連しない状態として残ります。"),
+        'title' => __d('baser_core', '削除'),
+        'class' => 'btn-delete bca-btn-icon',
+        'data-bca-btn-type' => 'delete',
+        'data-bca-btn-size' => 'lg',
+      ]
+    ) ?>
   </td>
 </tr>


### PR DESCRIPTION
https://github.com/baserproject/basercms/issues/4003

## 対応内容
- 管理者権限かどうかで表示をチェックしていたので、分岐を削除(ヘルパー内で権限チェックが行われる認識のため)

## 確認方法
- サイト運用者などの役割で「ブログカテゴリ管理」権限の編集と削除の機能を**ON**と**OFF**に切り替えて機能していることを確認

ご確認よろしくお願いします。