### PR TITLE
fix#4221【カスタムコンテンツ】フィールド編集で関連データとして指定したテーブルのエントリーがセレクトボックスしか設定できない問題を解消

### DIFF
--- a/plugins/bc-custom-content/plugins/BcCcRelated/src/View/Helper/BcCcRelatedHelper.php
+++ b/plugins/bc-custom-content/plugins/BcCcRelated/src/View/Helper/BcCcRelatedHelper.php
@@ -85,8 +85,9 @@ class BcCcRelatedHelper extends Helper
             $list = [];
         }
 
+        $optionsType = $field->meta["BcCcRelated"]["display_type"];
         $options = array_merge([
-            'type' => 'select',
+            'type' => $optionsType,
             'options' => $list,
             'empty' => __d('baser_core', '選択してください'),
         ], $options);
@@ -143,7 +144,15 @@ class BcCcRelatedHelper extends Helper
         /** @var CustomEntriesServiceInterface $entriesService */
         $entriesService = $this->getService(CustomEntriesServiceInterface::class);
         $entriesService->setup($link->custom_field->meta['BcCcRelated']['custom_table_id']);
-        $entry = $entriesService->get($fieldValue, ['contain' => 'CustomTables']);
+        if(is_array($fieldValue)){
+            foreach($fieldValue as $value) {
+                $entry = $entriesService->get($value, ['contain' => 'CustomTables']);
+                $entries[] = $entry->title;
+            }
+            return implode(' ', $entries);
+        }else{
+            $entry = $entriesService->get($fieldValue, ['contain' => 'CustomTables']);
+        }
 
         if ($options['getRelatedBody'])
             return $entry;

--- a/plugins/bc-custom-content/plugins/BcCcRelated/src/View/Helper/BcCcRelatedHelper.php
+++ b/plugins/bc-custom-content/plugins/BcCcRelated/src/View/Helper/BcCcRelatedHelper.php
@@ -136,7 +136,8 @@ class BcCcRelatedHelper extends Helper
     public function get($fieldValue, CustomLink $link, array $options = [])
     {
         $options = array_merge([
-            'getRelatedBody' => false
+            'getRelatedBody' => false,
+            'separator' => ' / ',
         ], $options);
 
         if (!$fieldValue) return '';
@@ -147,9 +148,12 @@ class BcCcRelatedHelper extends Helper
         if(is_array($fieldValue)){
             foreach($fieldValue as $value) {
                 $entry = $entriesService->get($value, ['contain' => 'CustomTables']);
-                $entries[] = $entry->title;
+                $entries[] = $entry->{$entry->custom_table->display_field};
             }
-            return implode(' ', $entries);
+            if ($options['getRelatedBody']) {
+                return $entries;
+            }
+            return implode($options['separator'], $entries);
         }else{
             $entry = $entriesService->get($fieldValue, ['contain' => 'CustomTables']);
         }

--- a/plugins/bc-custom-content/plugins/BcCcRelated/templates/Admin/element/custom_field_meta.php
+++ b/plugins/bc-custom-content/plugins/BcCcRelated/templates/Admin/element/custom_field_meta.php
@@ -37,6 +37,10 @@
         &nbsp;&nbsp;
         <?php echo $this->BcAdminForm->label('meta.BcCcRelated.filter_value', __d('baser_core', '絞り込み値')) ?>&nbsp;&nbsp;
         <?php echo $this->BcAdminForm->control('meta.BcCcRelated.filter_value', ['type' => 'text', 'size' => 20]) ?>
+        <br>
+        <?php $options = [ 'select' => 'セレクトボックス', 'radio' => 'ラジオボタン', 'multiCheckbox' => 'マルチチェックボックス']; ?>
+        <?php echo $this->BcAdminForm->label('meta.BcCcRelated.display_type', __d('baser_core', 'タイプ')) ?>&nbsp;&nbsp;
+        <?php echo $this->BcAdminForm->control('meta.BcCcRelated.display_type', ['type' => 'select', 'options' => $options]) ?>　　
         <i class="bca-icon--question-circle bca-help"></i>　　
         <div class="bca-helptext">
           <?php echo __d('baser_core', 'データの絞り込みを行う場合、絞り込みのフィールド名と値を設定します。') ?>


### PR DESCRIPTION
@uchin0 (@ryuring )
https://github.com/baserproject/basercms/issues/4221
上記の問題を解消しました。
レビューお願いします！