### PR TITLE
CustomEntriesに関連づけたテーブルのデータが保存されない

### DIFF
--- a/plugins/bc-custom-content/src/Model/Table/CustomEntriesTable.php
+++ b/plugins/bc-custom-content/src/Model/Table/CustomEntriesTable.php
@@ -610,7 +610,7 @@ class CustomEntriesTable extends AppTable
                 if ($link->name === $key) {
                     $fieldLink = $link;
                     break;
-                };
+                }
             }
             if (empty($fieldLink)) continue;
             $controlType = CustomContentUtil::getPluginSetting($fieldLink->custom_field->type, 'controlType');

--- a/plugins/bc-custom-content/src/Model/Table/CustomEntriesTable.php
+++ b/plugins/bc-custom-content/src/Model/Table/CustomEntriesTable.php
@@ -605,12 +605,15 @@ class CustomEntriesTable extends AppTable
     public function autoConvert(ArrayObject $content)
     {
         foreach($content as $key => $value) {
-            $link = null;
+            $fieldLink = null;
             foreach($this->links as $link) {
-                if ($link->name === $key) break;
+                if ($link->name === $key) {
+                    $fieldLink = $link;
+                    break;
+                };
             }
-            if (empty($link)) continue;
-            $controlType = CustomContentUtil::getPluginSetting($link->custom_field->type, 'controlType');
+            if (empty($fieldLink)) continue;
+            $controlType = CustomContentUtil::getPluginSetting($fieldLink->custom_field->type, 'controlType');
             if ($controlType === 'file') continue;
             if (is_array($value)) {
                 unset($value['__loop-src__']);

--- a/plugins/bc-custom-content/tests/TestCase/Model/Table/CustomEntriesTableTest.php
+++ b/plugins/bc-custom-content/tests/TestCase/Model/Table/CustomEntriesTableTest.php
@@ -829,6 +829,7 @@ class CustomEntriesTableTest extends BcTestCase
         ])->persist();
         CustomLinkFactory::make([
             'id' => 1,
+            'name' => 'meta',
             'custom_table_id' => 1,
             'custom_field_id' => 1
         ])->persist();
@@ -856,6 +857,7 @@ class CustomEntriesTableTest extends BcTestCase
         ])->persist();
         CustomLinkFactory::make([
             'id' => 1,
+            'name' => 'meta',
             'custom_table_id' => 1,
             'custom_field_id' => 1
         ])->persist();
@@ -865,8 +867,15 @@ class CustomEntriesTableTest extends BcTestCase
         ])->persist();
         CustomLinkFactory::make([
             'id' => 2,
+            'name' => 'meta',
             'custom_table_id' => 2,
             'custom_field_id' => 2
+        ])->persist();
+        CustomLinkFactory::make([
+            'id' => 3,
+            'name' => 'noname',
+            'custom_table_id' => 1,
+            'custom_field_id' => 1
         ])->persist();
 
         //ArrayObject
@@ -880,7 +889,7 @@ class CustomEntriesTableTest extends BcTestCase
 
         //$controlType === 'file'
         $this->CustomEntriesTable->setLinks(2);
-        $rs = $this->CustomEntriesTable->autoConvert($arrayObject);
+        $rs = $this->CustomEntriesTable->autoConvert(clone $arrayObject);
         //戻り値を確認
         $this->assertEquals('プログラマー', $rs['name']);
         //配列場合、
@@ -893,13 +902,21 @@ class CustomEntriesTableTest extends BcTestCase
 
         //$controlType !== 'file'
         $this->CustomEntriesTable->setLinks(1);
-        $rs = $this->CustomEntriesTable->autoConvert($arrayObject);
+        $rs = $this->CustomEntriesTable->autoConvert(clone $arrayObject);
         //戻り値を確認
         $this->assertEquals('プログラマー', $rs['name']);
         //配列場合、
         //__loop-src__がunsetされたか確認すること
         //json_encodeができるか確認すること
         $this->assertEquals('{"BcCcCheckbox":{"label":""}}', $rs['meta']);
+
+        // 対象外の項目の配列はJSONに交換されない
+        $this->CustomEntriesTable->setLinks(3);
+        $rs = $this->CustomEntriesTable->autoConvert(clone $arrayObject);
+        $this->assertEquals([
+            '__loop-src__' => 'aaa',
+            'BcCcCheckbox' => ['label' => '']
+        ], $rs['meta']);
     }
 
     /**


### PR DESCRIPTION
issue: https://github.com/baserproject/basercms/issues/4233

CustomEntriesに関連する項目以外に対してもjson_encodeが実行されてしまうため調整しています。

こちらの記述だと、if文でマッチしない場合は$this->linksの最後の項目が使われてしまうようでした。

```
foreach($this->links as $link) {
     if ($link->name === $key) break;
}
```