### PR TITLE
ブログコンテンツ削除時にブログ記事とカテゴリの関連データが削除されない

### DIFF
--- a/plugins/bc-blog/src/Model/Table/BlogContentsTable.php
+++ b/plugins/bc-blog/src/Model/Table/BlogContentsTable.php
@@ -122,7 +122,7 @@ class BlogContentsTable extends BlogAppTable
             'order' => 'posted DESC',
             'foreignKey' => 'blog_content_id',
             'dependent' => true,
-            'exclusive' => false,
+            'cascadeCallbacks' => true,
         ]);
         $this->hasMany('BlogCategories', [
             'className' => 'BcBlog.BlogCategories',
@@ -130,7 +130,7 @@ class BlogContentsTable extends BlogAppTable
             'limit' => 10,
             'foreignKey' => 'blog_content_id',
             'dependent' => true,
-            'exclusive' => false,
+            'cascadeCallbacks' => true,
         ]);
     }
 


### PR DESCRIPTION
<!-- GitHub Copilot コードレビューへの指示: プルリクエストをレビューしてコメントする際には日本語でお願いします。 -->

ブログコンテンツ削除時にブログ記事とカテゴリの関連データが削除されないため、関連付けの設定を調整しています。

https://book.cakephp.org/5/ja/orm/associations.html#hasmany
> cascadeCallbacks: これと dependent が true の時には、カスケード削除は コールバックが正しく呼ばれるように、エンティティーを読み出して削除します。 false の時には、関連付けられたデータを削除するために deleteAll() が使われ コールバックは呼ばれません。

「exclusive」という設定の削除も行いましたが、こちらの設定はcake2系のもののようでした。

https://book.cakephp.org/2/ja/models/associations-linking-models-together.html#hasmany
> exclusive: true をセットすれば、deleteAll() を呼び出した時に データを再帰的に削除するようになります。この処理は以前に比べて劇的な パフォーマンスの改善が施されていますが、あまり多用しないでください。