### PR TITLE
fix エントリーリスト取得条件のデフォルト値追加と、currentContentが取得できていない問題を解消

### DIFF
--- a/plugins/bc-custom-content/src/View/Helper/CustomContentHelper.php
+++ b/plugins/bc-custom-content/src/View/Helper/CustomContentHelper.php
@@ -506,6 +506,9 @@ class CustomContentHelper extends CustomContentAppHelper
     {
         $options = array_merge([
             'limit' => $limit,
+            'status' => 'publish',
+            'order' => 'created',
+            'direction' => 'DESC',
         ], $options);
         $contentService = $this->getService(ContentsServiceInterface::class);
         $url = $this->parseContentsName($contentsName);
@@ -513,6 +516,8 @@ class CustomContentHelper extends CustomContentAppHelper
         if($content->type !== 'CustomContent') {
             throw new NotFoundException(__d('baser_core', '指定されたコンテンツは存在しません。'));
         }
+        $request = $this->getView()->getRequest()->withAttribute('currentContent', $content);
+        $this->getView()->setRequest($request);
         $service = $this->getService(CustomContentFrontServiceInterface::class);
         $customContent = $service->ContentsService->get($content->entity_id);
         $service->EntriesService->setup($customContent->custom_table_id);


### PR DESCRIPTION
@ryuring 
以下のように修正しました！
レビューお願いします！

・デフォルトで公開状態のエントリーのみを取得する
・デフォルトで最新のエントリーから表示する
・エントリーリスト取得時にcrrentContentをセットする