### PR TITLE
カスタムコンテンツ カラム指定調整

### DIFF
--- a/plugins/bc-custom-content/src/Service/CustomEntriesService.php
+++ b/plugins/bc-custom-content/src/Service/CustomEntriesService.php
@@ -890,7 +890,7 @@ class CustomEntriesService implements CustomEntriesServiceInterface
             ->where([
                 'CustomEntries.custom_table_id' => $entry->custom_table_id,
                 'CustomEntries.status' => true,
-                $orderField . ' ' . $operator => $entry->{$orderField}
+                'CustomEntries.' . $orderField . ' ' . $operator => $entry->{$orderField}
             ])
             ->orderBy($orderBy)
             ->limit(1);
@@ -901,7 +901,7 @@ class CustomEntriesService implements CustomEntriesServiceInterface
                 ->where([
                     'CustomEntries.custom_table_id' => $entry->custom_table_id,
                     'CustomEntries.status' => true,
-                    $orderField => $entry->{$orderField},
+                    'CustomEntries.' . $orderField => $entry->{$orderField},
                     'CustomEntries.id ' . $operator => $entry->id
                 ])
                 ->orderBy($orderBy)
@@ -937,7 +937,7 @@ class CustomEntriesService implements CustomEntriesServiceInterface
             ->where([
                 'CustomEntries.custom_table_id' => $entry->custom_table_id,
                 'CustomEntries.status' => true,
-                $orderField . ' ' . $operator => $entry->{$orderField}
+                'CustomEntries.' . $orderField . ' ' . $operator => $entry->{$orderField}
             ])
             ->orderBy($orderBy)
             ->limit(1);
@@ -948,7 +948,7 @@ class CustomEntriesService implements CustomEntriesServiceInterface
                 ->where([
                     'CustomEntries.custom_table_id' => $entry->custom_table_id,
                     'CustomEntries.status' => true,
-                    $orderField => $entry->{$orderField},
+                    'CustomEntries.' . $orderField => $entry->{$orderField},
                     'CustomEntries.id ' . $operator => $entry->id
                 ])
                 ->orderBy($orderBy)

--- a/plugins/bc-custom-content/src/Service/CustomEntriesService.php
+++ b/plugins/bc-custom-content/src/Service/CustomEntriesService.php
@@ -208,7 +208,7 @@ class CustomEntriesService implements CustomEntriesServiceInterface
         $entities = [];
         foreach($srcEntities->toArray() as $key => $value) {
             /* @var CustomEntry $entity */
-            $entity = $this->CustomEntries->find()->where(['id' => $key])->first();
+            $entity = $this->CustomEntries->find()->where(['CustomEntries.id' => $key])->first();
             if (!preg_match("/^([_]+)/i", $value, $matches)) {
                 $entity->depth = 0;
                 $entities[] = $entity;
@@ -888,8 +888,8 @@ class CustomEntriesService implements CustomEntriesServiceInterface
         }
         $query = $this->CustomEntries->find()
             ->where([
-                'custom_table_id' => $entry->custom_table_id,
-                'status' => true,
+                'CustomEntries.custom_table_id' => $entry->custom_table_id,
+                'CustomEntries.status' => true,
                 $orderField . ' ' . $operator => $entry->{$orderField}
             ])
             ->orderBy($orderBy)
@@ -899,10 +899,10 @@ class CustomEntriesService implements CustomEntriesServiceInterface
         if (!$prev) {
             $query = $this->CustomEntries->find()
                 ->where([
-                    'custom_table_id' => $entry->custom_table_id,
-                    'status' => true,
+                    'CustomEntries.custom_table_id' => $entry->custom_table_id,
+                    'CustomEntries.status' => true,
                     $orderField => $entry->{$orderField},
-                    'id ' . $operator => $entry->id
+                    'CustomEntries.id ' . $operator => $entry->id
                 ])
                 ->orderBy($orderBy)
                 ->limit(1);
@@ -935,8 +935,8 @@ class CustomEntriesService implements CustomEntriesServiceInterface
 
         $query = $this->CustomEntries->find()
             ->where([
-                'custom_table_id' => $entry->custom_table_id,
-                'status' => true,
+                'CustomEntries.custom_table_id' => $entry->custom_table_id,
+                'CustomEntries.status' => true,
                 $orderField . ' ' . $operator => $entry->{$orderField}
             ])
             ->orderBy($orderBy)
@@ -946,10 +946,10 @@ class CustomEntriesService implements CustomEntriesServiceInterface
         if (!$next) {
             $query = $this->CustomEntries->find()
                 ->where([
-                    'custom_table_id' => $entry->custom_table_id,
-                    'status' => true,
+                    'CustomEntries.custom_table_id' => $entry->custom_table_id,
+                    'CustomEntries.status' => true,
                     $orderField => $entry->{$orderField},
-                    'id ' . $operator => $entry->id
+                    'CustomEntries.id ' . $operator => $entry->id
                 ])
                 ->orderBy($orderBy)
                 ->limit(1);


### PR DESCRIPTION
<!-- GitHub Copilot コードレビューへの指示: プルリクエストをレビューしてコメントする際には日本語でお願いします。 -->

カスタムコンテンツのwhereの指定にテーブル名がないと、テーブルの関連づけを行った際にSQLのエラーになるため調整しています。

ご確認お願いします。

関連: https://github.com/baserproject/basercms/pull/3982