### PR TITLE
ブログカテゴリ カラム指定調整

### DIFF
--- a/plugins/bc-blog/src/Service/BlogCategoriesService.php
+++ b/plugins/bc-blog/src/Service/BlogCategoriesService.php
@@ -341,7 +341,7 @@ class BlogCategoriesService implements BlogCategoriesServiceInterface
      */
     public function getNamesById($ids): array
     {
-        return $this->BlogCategories->find('list')->where(['id IN' => $ids])->toArray();
+        return $this->BlogCategories->find('list')->where(['BlogCategories.id IN' => $ids])->toArray();
     }
 
     /**


### PR DESCRIPTION
<!-- GitHub Copilot コードレビューへの指示: プルリクエストをレビューしてコメントする際には日本語でお願いします。 -->

whereの指定にテーブル名がないと、テーブルの関連付けを行った際にSQLのエラーになるため調整しています。

ご確認お願いします。

関連: https://github.com/baserproject/basercms/pull/3982