### PR TITLE
fix #4275 【システム】管理画面：サイト切り替え時に文字が見切れる場合がある 

### DIFF
--- a/plugins/bc-admin-third/webroot/css/admin/style.css
+++ b/plugins/bc-admin-third/webroot/css/admin/style.css
@@ -338,7 +338,7 @@ template {
   -moz-box-sizing: content-box;
   -webkit-box-sizing: content-box;
 }
-/* 
+/*
     User Style:
     Change the following styles to modify the appearance of Colorbox.  They are
     ordered & tabbed in a way that represents the nesting of the generated HTML.
@@ -10451,7 +10451,6 @@ body {
   margin: -1px 0 0 !important;
   padding: 0;
   position: absolute !important;
-  right: 0 !important;
   border: 1px solid #ccc !important;
   box-shadow: 0 1px 3px #ccc !important;
   background-color: #fff !important;


### PR DESCRIPTION
@ryuring 

<img width="609" height="137" alt="スクリーンショット 2025-11-05 17 38 51" src="https://github.com/user-attachments/assets/38e2ce8b-105d-4fff-986a-efc02b15d508" />


管理画面上で、短いタイトル→長いタイトルに切り替える時に途切れないように調整しました