### PR TITLE
SEOプラグイン有効時にメールフォームのプレビューに失敗する

### DIFF
--- a/plugins/bc-seo/src/View/Helper/SeoHelper.php
+++ b/plugins/bc-seo/src/View/Helper/SeoHelper.php
@@ -74,7 +74,7 @@ class SeoHelper extends Helper
         $metaValueLayers = [];
         if ($content) {
             // サイト
-            $metaValueLayers[] = $this->getMetaValues('Sites', 0, $content->site->id);
+            $metaValueLayers[] = $this->getMetaValues('Sites', 0, $content->site_id);
 
             // コンテンツ管理で管理されていないページの場合、currentContentにサイトのトップが入ってくるため対策
             // BcFrontMiddleware->setCurrentに仕様の記載あり


### PR DESCRIPTION
<!-- GitHub Copilot コードレビューへの指示: プルリクエストをレビューしてコメントする際には日本語でお願いします。 -->

フォームのプレビュー時は通常のフロント表示とデータ構造が違うようでしたので調整しています。
ご確認お願いします。