### PR TITLE
カスタムコンテンツ フロントで関連テーブルのデータを表示すると、その後取得するカスタムコンテンツの取得先が正しくなくなる #4266

### DIFF
--- a/plugins/bc-custom-content/src/View/Helper/CustomContentHelper.php
+++ b/plugins/bc-custom-content/src/View/Helper/CustomContentHelper.php
@@ -568,6 +568,7 @@ class CustomContentHelper extends CustomContentAppHelper
     public function getPrevEntry(CustomEntry|EntityInterface $entry)
     {
         $service = $this->getService(CustomEntriesServiceInterface::class);
+        $service->setup($entry->custom_table_id);
         return $service->getPrevEntry($entry);
     }
 
@@ -583,6 +584,7 @@ class CustomContentHelper extends CustomContentAppHelper
     {
         /** @var CustomEntriesService $service */
         $service = $this->getService(CustomEntriesServiceInterface::class);
+        $service->setup($entry->custom_table_id);
         return $service->getNextEntry($entry);
     }
 

--- a/plugins/bc-seo/src/View/Helper/SeoHelper.php
+++ b/plugins/bc-seo/src/View/Helper/SeoHelper.php
@@ -23,7 +23,6 @@ class SeoHelper extends Helper
 {
     private $fields;
     private $seoMetasTable;
-    private $customEntriesTable;
 
     public array $helpers = [
         'BaserCore.BcBaser',
@@ -40,9 +39,6 @@ class SeoHelper extends Helper
 
         $this->fields = Configure::read('BcSeo.fields');
         $this->seoMetasTable = TableRegistry::getTableLocator()->get('BcSeo.SeoMetas');
-        if (TableRegistry::getTableLocator()->exists('BcCustomContent.CustomEntries')) {
-            $this->customEntriesTable = TableRegistry::getTableLocator()->get('BcCustomContent.CustomEntries');
-        }
         $this->getView()->set('canonicalUrl', false);
     }
 
@@ -118,7 +114,7 @@ class SeoHelper extends Helper
             $customEntry = $this->getView()->get('customEntry');
             if ($customEntry->id) {
                 $metaValueLayers[] = $this->getMetaValues('CustomEntries',
-                    $this->customEntriesTable->tableId, $customEntry->id);
+                    $customEntry->custom_table_id, $customEntry->id);
             }
         }
 


### PR DESCRIPTION
<!-- GitHub Copilot コードレビューへの指示: プルリクエストをレビューしてコメントする際には日本語でお願いします。 -->

以下のissueに対応しています。
https://github.com/baserproject/basercms/issues/4266

## 対応内容

### plugins/bc-custom-content/src/View/Helper/CustomContentHelper.php

データ取得前にテーブルIDを明示するようにしています。
処理先のサービスクラスで実行するか迷ったのですが、他の箇所ではHelperから実行しているようですので合わせています。

### plugins/bc-seo/src/View/Helper/SeoHelper.php

customEntriesTable の tableId は状況によって変わるため、データ元を変更しています。

ご確認お願いします。
