### PR TITLE
SMTPサーバ指定によるメール送信でSMTP認証なしの設定ができない問題を解消 fix #4292

### DIFF
--- a/plugins/baser-core/src/Mailer/BcMailer.php
+++ b/plugins/baser-core/src/Mailer/BcMailer.php
@@ -80,15 +80,15 @@ class BcMailer extends Mailer
         /** @var SiteConfigsService $siteConfigsService */
         $siteConfigsService = $this->getService(SiteConfigsServiceInterface::class);
         $siteConfig = $siteConfigsService->get();
-        if ($siteConfig->smtp_host && $siteConfig->smtp_user && $siteConfig->smtp_password) {
+        if ($siteConfig->smtp_host) {
             $type = 'smtp';
             $config = [
                 'className' => 'Smtp',
                 'host' => $siteConfig->smtp_host,
-                'username' => $siteConfig->smtp_user,
-                'password' => $siteConfig->smtp_password
+                'username' => $siteConfig->smtp_user ? $siteConfig->smtp_user : null,
+                'password' => $siteConfig->smtp_password ? $siteConfig->smtp_password : null,
             ];
-            if ($siteConfig->smtp_port) $config['port'] = $siteConfig->smtp_port;
+            $config['port'] = $siteConfig->smtp_port ? $siteConfig->smtp_port : 25;
             if ($siteConfig->smtp_tls) $config['tls'] = $siteConfig->smtp_tls;
             if (!TransportFactory::getConfig($type)) {
                 TransportFactory::setConfig($type, $config);


### PR DESCRIPTION
@ryuring 
https://github.com/baserproject/basercms/issues/4292

上記のIssueを解消しました！
[4系](https://github.com/baserproject/basercms/blob/4.8.2/lib/Baser/Controller/BcAppController.php#L886-L900)の仕様に揃えて以下の調整をしています
ご確認よろしくお願いします！

- メール設定でSMTP設定を利用する際、hostの指定のみ必須にするよう調整
- hostの入力があり、ユーザー、パスワードの指定がない場合nullを指定
- hostの入力があり、ポートの指定がない場合25を指定