### PR TITLE
fix #4308 【アップローダー】「.docx」「.xlsx」だと公開期間の指定が効いていない

### DIFF
--- a/plugins/bc-uploader/src/Controller/UploaderFilesController.php
+++ b/plugins/bc-uploader/src/Controller/UploaderFilesController.php
@@ -108,7 +108,7 @@ class UploaderFilesController extends BcFrontAppController
 
             $this->setResponse(
                 $this->getResponse()
-                    ->withHeader('Content-type', $contentType)
+                    ->withHeader('Content-Type', $contentType)
                     ->withBody(new Stream(WWW_ROOT . 'files' . DS . 'uploads' . DS . 'limited' . DS . $filename))
             );
             $this->disableAutoRender();

--- a/plugins/bc-uploader/src/Controller/UploaderFilesController.php
+++ b/plugins/bc-uploader/src/Controller/UploaderFilesController.php
@@ -67,6 +67,11 @@ class UploaderFilesController extends BcFrontAppController
                 "sig" => "application/pgp-signature",
                 "spl" => "application/futuresplash",
                 "doc" => "application/msword",
+                "docx" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                "xls" => "application/vnd.ms-excel",
+                "xlsx" => "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                "ppt" => "application/vnd.ms-powerpoint",
+                "pptx" => "application/vnd.openxmlformats-officedocument.presentationml.presentation",
                 "ai" => "application/postscript",
                 "torrent" => "application/x-bittorrent",
                 "dvi" => "application/x-dvi",
@@ -94,9 +99,16 @@ class UploaderFilesController extends BcFrontAppController
                 "asf" => "video/x-ms-asf",
                 "wmv" => "video/x-ms-wmv"
             ];
+
+            if (isset($contentsMaping[$ext])) {
+                $contentType = $contentsMaping[$ext];
+            } else {
+                $contentType = 'application/octet-stream';
+            }
+
             $this->setResponse(
                 $this->getResponse()
-                    ->withHeader('Content-type', $contentsMaping[$ext])
+                    ->withHeader('Content-type', $contentType)
                     ->withBody(new Stream(WWW_ROOT . 'files' . DS . 'uploads' . DS . 'limited' . DS . $filename))
             );
             $this->disableAutoRender();


### PR DESCRIPTION
- 公開期間を指定した拡張子 docx, xls, xlsx, ppt, pptx のファイルにアクセスするとエラーになる動作を調整
- 未定義の拡張子に対してデフォルトのMIMEタイプとして（octet-stream）を設定し、ダウンロード動作となるよう調整
