### PR TITLE
fix #4308 【アップローダー】「.docx」「.xlsx」だと公開期間の指定が効いていない

### DIFF
--- a/lib/Baser/Plugin/Uploader/Controller/UploaderFilesController.php
+++ b/lib/Baser/Plugin/Uploader/Controller/UploaderFilesController.php
@@ -514,6 +514,11 @@ class UploaderFilesController extends AppController
 				"sig" => "application/pgp-signature",
 				"spl" => "application/futuresplash",
 				"doc" => "application/msword",
+				"docx" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+				"xls" => "application/vnd.ms-excel",
+				"xlsx" => "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+				"ppt" => "application/vnd.ms-powerpoint",
+				"pptx" => "application/vnd.openxmlformats-officedocument.presentationml.presentation",
 				"ai" => "application/postscript",
 				"torrent" => "application/x-bittorrent",
 				"dvi" => "application/x-dvi",
@@ -541,7 +546,14 @@ class UploaderFilesController extends AppController
 				"asf" => "video/x-ms-asf",
 				"wmv" => "video/x-ms-wmv"
 			];
-			header("Content-type: " . $contentsMaping[$ext]);
+
+			if (isset($contentsMaping[$ext])) {
+				$contentType = $contentsMaping[$ext];
+			} else {
+				$contentType = 'application/octet-stream';
+			}
+
+			header("Content-Type: " . $contentType);
 			readfile(WWW_ROOT . 'files' . DS . 'uploads' . DS . 'limited' . DS . $filename);
 			exit();
 		} else {


### PR DESCRIPTION
- 公開期間を指定した拡張子 docx, xls, xlsx, ppt, pptx のファイルにアクセスするとエラーになる動作を調整
- 未定義の拡張子に対してデフォルトのMIMEタイプとして（octet-stream）を設定し、ダウンロード動作となるよう調整
- 動作上区別はないが、RFC等の表記の慣習として Content-Type（Tを大文字）が推奨されるため調整

