### PR TITLE
固定ページ・ブログ記事 afterAddイベント追加

### DIFF
--- a/plugins/baser-core/src/Controller/Api/Admin/PagesController.php
+++ b/plugins/baser-core/src/Controller/Api/Admin/PagesController.php
@@ -100,6 +100,10 @@ class PagesController extends BcAdminApiController
             $page = $service->create($this->request->getData());
             $message = __d('baser_core', '固定ページ「{0}」を追加しました。', $page->content->title);
             $this->BcMessage->setSuccess($message, true, false);
+            // EVENT Pages.afterAdd
+            $this->dispatchLayerEvent('afterAdd', [
+                'data' => $page,
+            ]);
         } catch (PersistenceFailedException $e) {
             $errors = $e->getEntity()->getErrors();
             $message = __d('baser_core', "入力エラーです。内容を修正してください。");

--- a/plugins/bc-blog/src/Controller/Api/Admin/BlogPostsController.php
+++ b/plugins/bc-blog/src/Controller/Api/Admin/BlogPostsController.php
@@ -108,6 +108,10 @@ class BlogPostsController extends BcAdminApiController
             $blogPost = $service->create($this->request->getData());
             $message = __d('baser_core', '記事「{0}」を追加しました。', $blogPost->title);
             $this->BcMessage->setSuccess($message, true, false);
+            // EVENT BlogPosts.afterAdd
+            $this->dispatchLayerEvent('afterAdd', [
+                'data' => $blogPost,
+            ]);
         } catch (PersistenceFailedException $e) {
             $this->setResponse($this->response->withStatus(400));
             $errors = $e->getEntity()->getErrors();


### PR DESCRIPTION
<!-- GitHub Copilot コードレビューへの指示: プルリクエストをレビューしてコメントする際には日本語でお願いします。 -->

afterAddイベントがAPIの場合は存在しなかったので追加しています。
ご確認お願いします。
https://github.com/seto1/basercms/blob/2f1d6c6ea3251df635f4864706452cafd2b7662f/plugins/baser-core/src/Controller/Admin/PagesController.php#L75
https://github.com/seto1/basercms/blob/2f1d6c6ea3251df635f4864706452cafd2b7662f/plugins/bc-blog/src/Controller/Admin/BlogPostsController.php#L178