### PR TITLE
fix #4303 【メール】マルチチェックボックスの各選択肢が自動でspanタグで囲まれる問題を解決

### DIFF
--- a/plugins/bc-admin-third/templates/plugin/BcMail/Admin/element/MailFields/form.php
+++ b/plugins/bc-admin-third/templates/plugin/BcMail/Admin/element/MailFields/form.php
@@ -247,6 +247,18 @@
         <td class="col-input bca-form-table__input">
           <?php echo $this->BcAdminForm->control('options', ['type' => 'text', 'size' => 40, 'maxlength' => 255]) ?>
           <?php echo $this->BcAdminForm->error('options') ?>
+          <i class="bca-icon--question-circle bca-help"></i>
+          <div class="bca-helptext">
+            <p>inputタグに対してオプションを設定します。</p>
+            <dl>
+              <dt>placeholder</dt>
+              <dd>プレースホルダー：利用するには、次の形式のように | 区切りで入力します。「placeholder|プレースホルダーの内容」</dd>
+              <dt>empty</dt>
+              <dd>セレクトボックスの何も選択していないときの表示は、次の形式のように | 区切りで入力します。「empty|何も選択していないときのメッセージ」</dd>
+              <dt>templateVars.tag</dt>
+              <dd>マルチチェックボックスでそれぞれのインプットタグをラッピングする要素を指定します。例）templateVars.tag|div class="checkbox"（div class="checkbox"で囲む）<br>※デフォルトはspanタグでラッピングされます。</dd>
+            </dl>
+          </div>
         </td>
       </tr>
       <tr id="RowAutoComplete">

--- a/plugins/bc-admin-third/templates/plugin/BcMail/Admin/element/MailFields/form.php
+++ b/plugins/bc-admin-third/templates/plugin/BcMail/Admin/element/MailFields/form.php
@@ -255,8 +255,8 @@
               <dd>プレースホルダー：利用するには、次の形式のように | 区切りで入力します。「placeholder|プレースホルダーの内容」</dd>
               <dt>empty</dt>
               <dd>セレクトボックスの何も選択していないときの表示は、次の形式のように | 区切りで入力します。「empty|何も選択していないときのメッセージ」</dd>
-              <dt>templateVars.tag</dt>
-              <dd>マルチチェックボックスでそれぞれのインプットタグをラッピングする要素を指定します。例）templateVars.tag|div class="checkbox"（div class="checkbox"で囲む）<br>※デフォルトはspanタグでラッピングされます。</dd>
+              <dt>checkboxWrapTag</dt>
+              <dd>マルチチェックボックスでそれぞれのインプットタグをラッピングする要素を指定します。例）checkboxWrapTag|div class="checkbox"（div class="checkbox"で囲む）<br>※デフォルトはspanタグでラッピングされます。</dd>
             </dl>
           </div>
         </td>

--- a/plugins/bc-mail/src/View/Helper/MailformHelper.php
+++ b/plugins/bc-mail/src/View/Helper/MailformHelper.php
@@ -179,11 +179,26 @@ class MailformHelper extends BcFreezeHelper
                 if (!empty($attributes['templateVars.tag'])) {
                     // 取得した値が有効なタグか確認
                     $validTags = ['div', 'span', 'p', 'li', 'dt', 'dd', 'label'];
+                    $rawTemplateTag = $attributes['templateVars.tag'];
                     foreach ($validTags as $validTag) {
                         // templateVars.tagが有効なタグ名から始まっている場合、$attributes['templateVars']['tag'] にセット
-                        if (str_starts_with($attributes['templateVars.tag'], $validTag)) {
-                            $attributes['templateVars']['tag'] = $attributes['templateVars.tag'];
-                            break;
+                        if (str_starts_with($rawTemplateTag, $validTag)) {
+                            // 検証済みのタグ名のみをtemplateVars['tag']にセット
+                            $attributes['templateVars']['tag'] = $validTag;
+                            // 先頭のタグ名以降の文字列を取得（例: ' class="checkbox"'）
+                            $rest = trim(substr($rawTemplateTag, strlen($validTag)));
+                            if ($rest !== '') {
+                                $rests = explode(' ', $rest);
+                                foreach ($rests as $key => $restPart) {
+                                    // タグ名を除外した属性値の中で、onclickやonchangeなどのイベント属性が含まれている場合、unsetする
+                                    if (str_starts_with($restPart, 'on')) {
+                                        unset($rests[$key]);
+                                    }
+                                }
+                                if (!empty($rests) && isset($attributes['templateVars']['tag'])) {
+                                    $attributes['templateVars']['tag'] .= ' ' . implode(' ', $rests);
+                                }
+                            }
                         }
                     }
                     // inputタグに出力されないようにunset

--- a/plugins/bc-mail/src/View/Helper/MailformHelper.php
+++ b/plugins/bc-mail/src/View/Helper/MailformHelper.php
@@ -175,6 +175,20 @@ class MailformHelper extends BcFreezeHelper
                 $attributes['value'] = null;
                 $attributes['empty'] = false;
                 $attributes['templateVars']['tag'] = 'span';
+                // オプションでtemplateVars.tagが指定されていた場合の対応
+                if (!empty($attributes['templateVars.tag'])) {
+                    // 取得した値が有効なタグか確認
+                    $validTags = ['div', 'span', 'p', 'li', 'dt', 'dd', 'label'];
+                    foreach ($validTags as $validTag) {
+                        // templateVars.tagが有効なタグ名から始まっている場合、$attributes['templateVars']['tag'] にセット
+                        if (str_starts_with($attributes['templateVars.tag'], $validTag)) {
+                            $attributes['templateVars']['tag'] = $attributes['templateVars.tag'];
+                            break;
+                        }
+                    }
+                    // inputタグに出力されないようにunset
+                    unset($attributes['templateVars.tag']);
+                }
                 $out = $this->select($fieldName, $options, $attributes);
                 break;
             case 'file':

--- a/plugins/bc-mail/src/View/Helper/MailformHelper.php
+++ b/plugins/bc-mail/src/View/Helper/MailformHelper.php
@@ -175,13 +175,13 @@ class MailformHelper extends BcFreezeHelper
                 $attributes['value'] = null;
                 $attributes['empty'] = false;
                 $attributes['templateVars']['tag'] = 'span';
-                // オプションでtemplateVars.tagが指定されていた場合の対応
-                if (!empty($attributes['templateVars.tag'])) {
+                // オプションでcheckboxWrapTagが指定されていた場合の対応
+                if (!empty($attributes['checkboxWrapTag'])) {
                     // 取得した値が有効なタグか確認
                     $validTags = ['div', 'span', 'p', 'li', 'dt', 'dd', 'label'];
-                    $rawTemplateTag = $attributes['templateVars.tag'];
+                    $rawTemplateTag = $attributes['checkboxWrapTag'];
                     foreach ($validTags as $validTag) {
-                        // templateVars.tagが有効なタグ名から始まっている場合、$attributes['templateVars']['tag'] にセット
+                        // checkboxWrapTagが有効なタグ名から始まっている場合、$attributes['templateVars']['tag'] にセット
                         if (str_starts_with($rawTemplateTag, $validTag)) {
                             // 検証済みのタグ名のみをtemplateVars['tag']にセット
                             $attributes['templateVars']['tag'] = $validTag;
@@ -202,7 +202,7 @@ class MailformHelper extends BcFreezeHelper
                         }
                     }
                     // inputタグに出力されないようにunset
-                    unset($attributes['templateVars.tag']);
+                    unset($attributes['checkboxWrapTag']);
                 }
                 $out = $this->select($fieldName, $options, $attributes);
                 break;

--- a/plugins/bc-mail/tests/TestCase/View/Helper/MailformHelperTest.php
+++ b/plugins/bc-mail/tests/TestCase/View/Helper/MailformHelperTest.php
@@ -58,6 +58,14 @@ class MailformHelperTest extends BcTestCase
         $this->markTestIncomplete('このテストは、まだ実装されていません。');
     }
 
+    /*
+     * マルチチェックボックスのオプションでtemplateVars.tagが指定されていた場合、ホワイトリスト内のタグを出力する
+     */
+    public function testControlWithTemplateVarsTag()
+    {
+        $this->markTestIncomplete('このテストは、まだ実装されていません。');
+    }
+
     /**
      * create
      * ファイル添付の対応のためにデフォルト値を変更


### PR DESCRIPTION
・入力画面にヘルプも追加しています。
<img width="926" height="461" alt="image" src="https://github.com/user-attachments/assets/9c659d6b-69e5-4631-b1f0-7fea39a0a1cb" />

<!-- GitHub Copilot コードレビューへの指示: プルリクエストをレビューしてコメントする際には日本語でお願いします。 -->
