### PR TITLE
【メール】管理者宛メール本文にユーザーのIPアドレスを表示する

### DIFF
--- a/plugins/bc-front/templates/plugin/BcMail/email/text/mail_default.php
+++ b/plugins/bc-front/templates/plugin/BcMail/email/text/mail_default.php
@@ -30,8 +30,8 @@
   <?php echo __d('baser_core', 'この度は、ご連絡ありがとうございます。') ?>　
   <?php echo __d('baser_core', '送信内容は下記のようになっております。') ?>　
 <?php elseif ($other['mode'] === 'admin'): ?>
-　<?php echo $site->display_name ?> <?php echo __d('baser_core', 'へ連絡を受け付けました。') ?>　
-　<?php echo __d('baser_core', '受信内容は下記のとおりです。') ?>　
+　<?php echo $site->display_name ?> <?php echo __d('baser_core', 'へ連絡を受け付けました。') ?>
+　<?php echo __d('baser_core', '受信内容は下記のとおりです。') ?>
 <?php endif; ?>
 　
 ━━━━◇◆━━━━━━━━━━━━━━━━━━━━━
@@ -48,14 +48,19 @@
   　<?php echo __d('baser_core', 'メールを確認させて頂き次第、早急にご連絡させていただきます。') ?>　
   　<?php echo __d('baser_core', '恐れ入りますがしばらくお待ちください。') ?>　
 <?php elseif ($other['mode'] === 'admin'): ?>
-  <?php echo __d('baser_core', 'なお、このメールは自動転送システムです。') ?>　
-  　<?php echo __d('baser_core', '受け付けた旨のメールもユーザーへ送られています。') ?>　
+  <?php echo __d('baser_core', 'なお、このメールは自動転送システムです。') ?>
+  　<?php echo __d('baser_core', '受け付けた旨のメールもユーザーへ送られています。') ?>
 <?php endif; ?>
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-　<?php echo $mailConfig->site_name; ?>　
-　<?php echo $mailConfig->site_url ?>　<?php echo $mailConfig->site_email; ?>　
-　<?php if ($mailConfig->site_tel): ?>TEL　<?php echo $mailConfig->site_tel; ?><?php endif; ?><?php if ($mailConfig->site_fax): ?>　FAX　<?php echo $mailConfig->site_fax; ?><?php endif; ?>　
+　<?php echo $mailConfig->site_name; ?>
+　<?php echo $mailConfig->site_url ?>　<?php echo $mailConfig->site_email; ?>
+　<?php if ($mailConfig->site_tel): ?>TEL　<?php echo $mailConfig->site_tel; ?><?php endif; ?><?php if ($mailConfig->site_fax): ?>　FAX　<?php echo $mailConfig->site_fax; ?><?php endif; ?>
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+<?php if ($other['mode'] === 'admin'): ?>
+
+　<?php echo __d('baser_core', '送信者IPアドレス') ?>：<?php echo h($other['ip']) ?>
+
+<?php endif; ?>

--- a/plugins/bc-mail/src/Controller/MailController.php
+++ b/plugins/bc-mail/src/Controller/MailController.php
@@ -302,6 +302,7 @@ class MailController extends MailFrontAppController
 
         // メール送信
         try {
+            $sendEmailOptions['clientIp'] = $this->getRequest()->clientIp();
             $service->sendMail($mailContent, $entity, $sendEmailOptions);
             $this->getRequest()->getSession()->delete('BcMail.valid');
         } catch (\Throwable $e) {

--- a/plugins/bc-mail/src/Service/Front/MailFrontService.php
+++ b/plugins/bc-mail/src/Service/Front/MailFrontService.php
@@ -367,7 +367,8 @@ class MailFrontService implements MailFrontServiceInterface
             'mailContent' => $mailContent,
             'mailConfig' => $mailConfig,
             'other' => [
-                'date' => date('Y/m/d H:i')
+                'date' => date('Y/m/d H:i'),
+                'ip' => $options['clientIp'] ?? ''
             ]
         ], $options);
     }

--- a/plugins/bc-mail/tests/TestCase/Service/Front/MailFrontServiceTest.php
+++ b/plugins/bc-mail/tests/TestCase/Service/Front/MailFrontServiceTest.php
@@ -153,6 +153,12 @@ class MailFrontServiceTest extends BcTestCase
         $this->assertEquals('name_test', $result['content']->name);
         $this->assertEquals('description test', $result['mailContent']->description);
         $this->assertEquals('test_name', $result['mailConfig']->name);
+        // clientIp が渡された場合、other['ip'] に設定される
+        $result = $this->MailFrontService->createMailData($mailConfig, $mailContent, $mailFields, $mailMessages, ['clientIp' => '192.168.1.1']);
+        $this->assertEquals('192.168.1.1', $result['other']['ip']);
+        // clientIp が渡されない場合、other['ip'] は空文字
+        $result = $this->MailFrontService->createMailData($mailConfig, $mailContent, $mailFields, $mailMessages, []);
+        $this->assertEquals('', $result['other']['ip']);
     }
     /**
      * test getAdminMail
@@ -528,9 +534,11 @@ class MailFrontServiceTest extends BcTestCase
         ])->persist();
         // normal case
         $mailContent = $MailContentsService->get(99);
-        $this->MailFrontService->sendMail($mailContent, $mailMessage, []);
+        $this->MailFrontService->sendMail($mailContent, $mailMessage, ['clientIp' => '192.168.1.1']);
         $this->assertMailSentTo('t@gm.com');
         $this->assertMailSubjectContains('お問い合わせを頂きました99');
+        // 管理者宛メールにIPアドレスが含まれていること
+        $this->assertMailContainsText('192.168.1.1');
     }
 
     /**


### PR DESCRIPTION
## 概要

fixes #4321

メールフォームが脅迫等に悪用された際に通報しやすくするため、管理者宛メールの末尾にフォーム送信者のIPアドレスを表示する。

## 変更内容

- `MailController::submit()` — リクエストのIPアドレスを `$sendEmailOptions['clientIp']` に格納
- `MailFrontService::createMailData()` — `other['ip']` としてメールデータに組み込む
- `mail_default.php` — 管理者宛メールのみ、フッター罫線の下にIPアドレスを表示

## メール本文イメージ（管理者宛）

```
━━━━━━━━━━━━━━━━━━━━━━━━━━━

　サイト名
　https://example.com　info@example.com

━━━━━━━━━━━━━━━━━━━━━━━━━━━

　送信者IPアドレス：203.0.113.42

```

## テスト

- `MailFrontServiceTest::test_createMailData()` — `clientIp` オプションの有無で `other['ip']` が正しくセットされることを確認
- `MailFrontServiceTest::test_sendMail()` — 送信メール本文にIPアドレスが含まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)