### PR TITLE
ウィジェットエリア編集画面　jQueryアップデートによる不具合の修正

### DIFF
--- a/app/webroot/theme/admin-third/js/admin/widget_areas/form.js
+++ b/app/webroot/theme/admin-third/js/admin/widget_areas/form.js
@@ -43,7 +43,7 @@ $(function () {
         },
         update: function (event, ui) {
             // jQueryUI 1.8.14 より、 ui.item.attr("id")で id が取得できない
-            if ($(ui.item[0]).attr("id").match(/^Setting/i)) {
+            if ($(ui.item.context).attr("id").match(/^Setting/i)) {
                 widgetAreaUpdateSortedIds();
                 return;
             }
@@ -57,7 +57,7 @@ $(function () {
             });
 
             baseId++;
-            var id = $(ui.item[0]).attr("id").replace('Widget', '');
+            var id = $(ui.item.context).attr("id").replace('Widget', '');
             var sourceId = id.replace('Widget', '');
             var settingId = 'Setting' + (baseId);
             var tmpId = 'Tmp' + (baseId);
@@ -101,32 +101,16 @@ $(function () {
             accept: 'div.draggable',
             tolderance: 'intersect'
         });
-    $("div.draggable").draggable({
-        scroll: true,
-        helper: function() {
-            // cloneした要素に元のidをコピー
-            var clone = $(this).clone();
-            var originalId = $(this).attr("id");
-            if (!originalId) {
-                // 元の要素にidが無い場合は付与
-                originalId = "Widget-" + Date.now();
-                $(this).attr("id", originalId);
-            }
-            clone.attr("id", originalId);
-            return clone;
-        },
-        opacity: 0.80,
-        revert: 'invalid',
-        cursor: 'move',
-        connectToSortable: '#Target',
-        containment: 'body',
-        start: function(event, ui) {
-            if (!$(this).attr("id")) {
-                var tempId = "Widget-" + Date.now();
-                $(this).attr("id", tempId);
-            }
-        }
-    });
+    $("div.draggable").draggable(
+        {
+            scroll: true,
+            helper: 'clone',
+            opacity: 0.80,
+            revert: 'invalid',
+            cursor: 'move',
+            connectToSortable: '#Target',
+            containment: 'body'
+        });
 
     $("#Target .sortable").each(function (k, v) {
         registWidgetEvent($(this).attr('id').replace('Setting', ''));

--- a/app/webroot/theme/admin-third/js/admin/widget_areas/form.js
+++ b/app/webroot/theme/admin-third/js/admin/widget_areas/form.js
@@ -43,7 +43,7 @@ $(function () {
         },
         update: function (event, ui) {
             // jQueryUI 1.8.14 より、 ui.item.attr("id")で id が取得できない
-            if ($(ui.item.context).attr("id").match(/^Setting/i)) {
+            if ($(ui.item[0]).attr("id").match(/^Setting/i)) {
                 widgetAreaUpdateSortedIds();
                 return;
             }
@@ -57,7 +57,7 @@ $(function () {
             });
 
             baseId++;
-            var id = $(ui.item.context).attr("id").replace('Widget', '');
+            var id = $(ui.item[0]).attr("id").replace('Widget', '');
             var sourceId = id.replace('Widget', '');
             var settingId = 'Setting' + (baseId);
             var tmpId = 'Tmp' + (baseId);
@@ -101,16 +101,32 @@ $(function () {
             accept: 'div.draggable',
             tolderance: 'intersect'
         });
-    $("div.draggable").draggable(
-        {
-            scroll: true,
-            helper: 'clone',
-            opacity: 0.80,
-            revert: 'invalid',
-            cursor: 'move',
-            connectToSortable: '#Target',
-            containment: 'body'
-        });
+    $("div.draggable").draggable({
+        scroll: true,
+        helper: function() {
+            // cloneした要素に元のidをコピー
+            var clone = $(this).clone();
+            var originalId = $(this).attr("id");
+            if (!originalId) {
+                // 元の要素にidが無い場合は付与
+                originalId = "Widget-" + Date.now();
+                $(this).attr("id", originalId);
+            }
+            clone.attr("id", originalId);
+            return clone;
+        },
+        opacity: 0.80,
+        revert: 'invalid',
+        cursor: 'move',
+        connectToSortable: '#Target',
+        containment: 'body',
+        start: function(event, ui) {
+            if (!$(this).attr("id")) {
+                var tempId = "Widget-" + Date.now();
+                $(this).attr("id", tempId);
+            }
+        }
+    });
 
     $("#Target .sortable").each(function (k, v) {
         registWidgetEvent($(this).attr('id').replace('Setting', ''));

--- a/lib/Baser/Config/theme/bccolumn/Mail/default/index.php
+++ b/lib/Baser/Config/theme/bccolumn/Mail/default/index.php
@@ -2,8 +2,8 @@
 /**
  * メールフォーム
  */
-$this->BcBaser->css('admin/jquery-ui/jquery-ui-1.14.1.min', array('inline' => true));
-$this->BcBaser->js(array('admin/vendors/jquery-ui-1.14.1.min', 'admin/vendors/i18n/ui.datepicker-ja'), false);
+$this->BcBaser->css('admin/jquery-ui/jquery-ui.min', array('inline' => true));
+$this->BcBaser->js(array('admin/vendors/jquery-ui-1.11.4.min', 'admin/vendors/i18n/ui.datepicker-ja'), false);
 ?>
 
 

--- a/lib/Baser/Config/theme/bccolumn/Mail/default/index.php
+++ b/lib/Baser/Config/theme/bccolumn/Mail/default/index.php
@@ -2,8 +2,8 @@
 /**
  * メールフォーム
  */
-$this->BcBaser->css('admin/jquery-ui/jquery-ui.min', array('inline' => true));
-$this->BcBaser->js(array('admin/vendors/jquery-ui-1.11.4.min', 'admin/vendors/i18n/ui.datepicker-ja'), false);
+$this->BcBaser->css('admin/jquery-ui/jquery-ui-1.14.1.min', array('inline' => true));
+$this->BcBaser->js(array('admin/vendors/jquery-ui-1.14.1.min', 'admin/vendors/i18n/ui.datepicker-ja'), false);
 ?>
 
 

--- a/lib/Baser/webroot/js/admin/widget_areas/form.js
+++ b/lib/Baser/webroot/js/admin/widget_areas/form.js
@@ -38,7 +38,7 @@ $(function () {
         },
         update: function (event, ui) {
             // jQueryUI 1.8.14 より、 ui.item.attr("id")で id が取得できない
-            if ($(ui.item.context).attr("id").match(/^Setting/i)) {
+            if ($(ui.item[0]).attr("id").match(/^Setting/i)) {
                 widgetAreaUpdateSortedIds();
                 return;
             }
@@ -52,7 +52,7 @@ $(function () {
             });
 
             baseId++;
-            var id = $(ui.item.context).attr("id").replace('Widget', '');
+            var id = $(ui.item[0]).attr("id").replace('Widget', '');
             var sourceId = id.replace('Widget', '');
             var settingId = 'Setting' + (baseId);
             var tmpId = 'Tmp' + (baseId);
@@ -96,16 +96,32 @@ $(function () {
             accept: 'div.draggable',
             tolderance: 'intersect'
         });
-    $("div.draggable").draggable(
-        {
-            scroll: true,
-            helper: 'clone',
-            opacity: 0.80,
-            revert: 'invalid',
-            cursor: 'move',
-            connectToSortable: '#Target',
-            containment: 'body'
-        });
+    $("div.draggable").draggable({
+        scroll: true,
+        helper: function() {
+            // cloneした要素に元のidをコピー
+            var clone = $(this).clone();
+            var originalId = $(this).attr("id");
+            if (!originalId) {
+                // 元の要素にidが無い場合は付与
+                originalId = "Widget-" + Date.now();
+                $(this).attr("id", originalId);
+            }
+            clone.attr("id", originalId);
+            return clone;
+        },
+        opacity: 0.80,
+        revert: 'invalid',
+        cursor: 'move',
+        connectToSortable: '#Target',
+        containment: 'body',
+        start: function(event, ui) {
+            if (!$(this).attr("id")) {
+                var tempId = "Widget-" + Date.now();
+                $(this).attr("id", tempId);
+            }
+        }
+    });
 
     $("#Target .sortable").each(function (k, v) {
         registWidgetEvent($(this).attr('id').replace('Setting', ''));

--- a/lib/Baser/webroot/js/admin/widget_areas/form.js
+++ b/lib/Baser/webroot/js/admin/widget_areas/form.js
@@ -38,7 +38,7 @@ $(function () {
         },
         update: function (event, ui) {
             // jQueryUI 1.8.14 より、 ui.item.attr("id")で id が取得できない
-            if ($(ui.item[0]).attr("id").match(/^Setting/i)) {
+            if ($(ui.item.context).attr("id").match(/^Setting/i)) {
                 widgetAreaUpdateSortedIds();
                 return;
             }
@@ -52,7 +52,7 @@ $(function () {
             });
 
             baseId++;
-            var id = $(ui.item[0]).attr("id").replace('Widget', '');
+            var id = $(ui.item.context).attr("id").replace('Widget', '');
             var sourceId = id.replace('Widget', '');
             var settingId = 'Setting' + (baseId);
             var tmpId = 'Tmp' + (baseId);
@@ -96,32 +96,16 @@ $(function () {
             accept: 'div.draggable',
             tolderance: 'intersect'
         });
-    $("div.draggable").draggable({
-        scroll: true,
-        helper: function() {
-            // cloneした要素に元のidをコピー
-            var clone = $(this).clone();
-            var originalId = $(this).attr("id");
-            if (!originalId) {
-                // 元の要素にidが無い場合は付与
-                originalId = "Widget-" + Date.now();
-                $(this).attr("id", originalId);
-            }
-            clone.attr("id", originalId);
-            return clone;
-        },
-        opacity: 0.80,
-        revert: 'invalid',
-        cursor: 'move',
-        connectToSortable: '#Target',
-        containment: 'body',
-        start: function(event, ui) {
-            if (!$(this).attr("id")) {
-                var tempId = "Widget-" + Date.now();
-                $(this).attr("id", tempId);
-            }
-        }
-    });
+    $("div.draggable").draggable(
+        {
+            scroll: true,
+            helper: 'clone',
+            opacity: 0.80,
+            revert: 'invalid',
+            cursor: 'move',
+            connectToSortable: '#Target',
+            containment: 'body'
+        });
 
     $("#Target .sortable").each(function (k, v) {
         registWidgetEvent($(this).attr('id').replace('Setting', ''));


### PR DESCRIPTION
ウィジェット編集画面　利用できるウィジェットから利用中のウィジェットに移した時に、そのウィジェットの編集ページが開かなかったため修正。

原因、jQuery2系から3系のアップデートで廃止、仕様が変更された記述が残っていたため