### PR TITLE
fix #4319 【メール】Cache-Controlヘッダ （no-cache no-store must-revalidate）が出力されない件を修正

### DIFF
--- a/docker/docker-compose.yml.default
+++ b/docker/docker-compose.yml.default
@@ -13,13 +13,14 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: "root"
       MYSQL_DATABASE: "basercms"
-    command: mysqld --character-set-server=utf8 --collation-server=utf8_general_ci --innodb-use-native-aio=0 --default_authentication_plugin=mysql_native_password
+    command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci --innodb-use-native-aio=0 --default_authentication_plugin=mysql_native_password
 
   bc-php:
     container_name: bc-php
     image: baserproject/basercms:php8.1
     volumes:
       - ../:/var/www/html:delegated
+      - ./php/php.ini:/usr/local/etc/php/conf.d/99-custom.ini
     environment:
       PHP_IDE_CONFIG: "serverName=localhost"
       XDEBUG_MODE: "debug"

--- a/docker/php/php.ini
+++ b/docker/php/php.ini
@@ -1,0 +1,1 @@
+session.cache_limiter = none

--- a/plugins/bc-mail/src/Controller/MailController.php
+++ b/plugins/bc-mail/src/Controller/MailController.php
@@ -121,7 +121,7 @@ class MailController extends MailFrontAppController
             $this->response = $this->response
                 ->withHeader('Cache-Control', 'no-cache, no-store, must-revalidate')
                 ->withHeader('Pragma', 'no-cache')
-                ->withHeader('Expires', date(DATE_RFC1123, strtotime('-1 day')));
+                ->withHeader('Expires', gmdate(DATE_RFC1123, strtotime('-1 day')));
         }
     }
 

--- a/plugins/bc-mail/src/Controller/MailController.php
+++ b/plugins/bc-mail/src/Controller/MailController.php
@@ -12,6 +12,7 @@
 namespace BcMail\Controller;
 
 use BaserCore\Error\BcException;
+use BaserCore\Utility\BcUtil;
 use BaserCore\Service\BcCaptchaServiceInterface;
 use BaserCore\Utility\BcSiteConfig;
 use BcMail\Model\Entity\MailMessage;
@@ -115,14 +116,13 @@ class MailController extends MailFrontAppController
     public function beforeRender(EventInterface $event): void
     {
         parent::beforeRender($event);
-        // TODO ucmitz 未実装
-        /*
-        // キャッシュ対策
-        if (!isConsole() && !$this->request->getParam('requested')) {
-            header("Cache-Control: no-cache, no-store, must-revalidate");
-            header("Pragma: no-cache");
-            header("Expires: " . date(DATE_RFC1123, strtotime("-1 day")));
-        }*/
+        // キャッシュ対策: メールフォーム画面でCache-Controlヘッダーを出力
+        if (!BcUtil::isConsole() && !$this->request->getParam('requested')) {
+            $this->response = $this->response
+                ->withHeader('Cache-Control', 'no-cache, no-store, must-revalidate')
+                ->withHeader('Pragma', 'no-cache')
+                ->withHeader('Expires', date(DATE_RFC1123, strtotime('-1 day')));
+        }
     }
 
     /**


### PR DESCRIPTION
よろしくお願いします。

docker環境だとphp.iniでnocacheが強制されていたので設定の調整も入れています。

<!-- GitHub Copilot コードレビューへの指示: プルリクエストをレビューしてコメントする際には日本語でお願いします。 -->
