### PR TITLE
fix #4276 キャッシュクリアのキャンセル時にツールバーの背景が白くなる問題を修正

### DIFF
--- a/plugins/bc-admin-third/webroot/js/vendor/jquery.fixedMenu.js
+++ b/plugins/bc-admin-third/webroot/js/vendor/jquery.fixedMenu.js
@@ -8,7 +8,8 @@
     $.fn.fixedMenu=function(){
         return this.each(function(){
             var menu= $(this);
-            menu.find('ul li > a').bind('click',function(){
+            menu.find('ul li > a').bind('click',function(e){
+				if (e.isDefaultPrevented()) return;
 				if ($(this).parent().hasClass('active')){
 					$(this).parent().removeClass('active');
 				}


### PR DESCRIPTION
https://github.com/baserproject/basercms/issues/4276 の対応です。

変更ファイルはライブラリだが作成者はメンテしておらず配布サイト自体閉鎖されており、見当たらない
ログを見る限りはbaserCMSで若干修正して使っている、このため変更を加えました。

## 修正内容

`fixedMenu.js` のクリックハンドラーに `e.isDefaultPrevented()` チェックを追加。

- キャンセル時: inline onclick の `return false` により `defaultPrevented = true` → `active` 付与をスキップ（白背景が出なくなる）
- OK時: `defaultPrevented = false` → `active` を付与してからページ遷移


## 事前準備
- `/baser/admin/baser-core/sites/index`にアクセスし新規追加からサイトを登録しておく   
(ToolMenuの動作にも影響するため)


## MRで確認してほしいこと
### `#ToolMenu` の動作
- [x] ヘッダーメニューのToolMenuをクリックしボタンの背景色が白くなることを確認する
- [x] メニューが開いた状態でどこかをクリックし、背景色の白が戻りメニューが折り畳まれることを確認する 
- [x] 既存の動作から変わっていないことを確認する

<img width="781" height="497" alt="マルチサイト" src="https://github.com/user-attachments/assets/d5315378-c64f-491f-b737-7cb9123087c3" />


### `#UserMenu` の動作
 ヘッダーメニューのキャッシュクリアボタンを押しダイアログの以下の挙動を確認してください

#### OKの場合
- [x] キャッシュクリアが機能し背景が白の状態でリロードされることを確認する

#### キャンセルの場合
- [x] 背景色がキャンセル前と変わらないことを確認する

**※ キャンセル時のフォーカスの背景色に関しては解除することもできますが、現状が自然な挙動と感じたため、本タスクでは修正していません。**

## 備考

isDefaultPreventedメソッドのドキュメント

https://api.jquery.com/event.isDefaultPrevented/