### PR TITLE
fix: メールフィールド名にMySQL予約語を登録した場合のバリデーション追加 (#4332)

### DIFF
--- a/plugins/bc-mail/src/Model/Table/MailFieldsTable.php
+++ b/plugins/bc-mail/src/Model/Table/MailFieldsTable.php
@@ -58,6 +58,7 @@ class MailFieldsTable extends MailAppTable
      */
     public function validationDefault(Validator $validator): Validator
     {
+        $validator->setProvider('bc', 'BaserCore\Model\Validation\BcValidation');
         $validator
             ->integer('id')
             ->allowEmptyString('id', null, 'create');
@@ -80,6 +81,12 @@ class MailFieldsTable extends MailAppTable
                     'rule' => 'duplicateMailField',
                     'provider' => 'table',
                     'message' => __d('baser_core', '既に登録のあるフィールド名です。')
+                ]])
+            ->add('field_name', [
+                'reserved' => [
+                    'rule' => ['reserved'],
+                    'provider' => 'bc',
+                    'message' => __d('baser_core', 'システム予約名称のため利用できません。')
                 ]]);
         $validator
             ->scalar('type')

--- a/plugins/bc-mail/tests/TestCase/Model/Table/MailFieldsTableTest.php
+++ b/plugins/bc-mail/tests/TestCase/Model/Table/MailFieldsTableTest.php
@@ -159,6 +159,35 @@ class MailFieldsTableTest extends BcTestCase
     }
 
     /**
+     * test validationDefault reserved word check
+     * @dataProvider validationDefaultReservedDataProvider
+     */
+    public function test_validationDefaultReserved($fieldName, $expected)
+    {
+        $validator = $this->MailFieldsTable->getValidator('default');
+        $errors = $validator->validate([
+            'mail_content_id' => 999,
+            'field_name' => $fieldName,
+        ]);
+        if ($expected) {
+            $this->assertArrayNotHasKey('reserved', $errors['field_name'] ?? []);
+        } else {
+            $this->assertArrayHasKey('reserved', $errors['field_name']);
+            $this->assertEquals('システム予約名称のため利用できません。', $errors['field_name']['reserved']);
+        }
+    }
+
+    public static function validationDefaultReservedDataProvider()
+    {
+        return [
+            ['test_field', true],
+            ['select', false],
+            ['insert', false],
+            ['update', false],
+        ];
+    }
+
+    /**
      * コントロールソースを取得する
      */
     public function testGetControlSource()


### PR DESCRIPTION
MailFieldsTable::validationDefault() に BcValidation::reserved() による 予約語チェックを追加。CustomFieldsTable と同様のバリデーションパターンを適用。

- field_name に reserved バリデーションルールを追加
- BcValidation プロバイダー (bc) を登録
- ユニットテストを追加（select, insert, update などの予約語をテスト）

<!-- GitHub Copilot コードレビューへの指示: プルリクエストをレビューしてコメントする際には日本語でお願いします。 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an additional validation rule on `MailFieldsTable` that can block previously-accepted `field_name` values (e.g., `select`, `insert`, `update`), but the change is localized to input validation and covered by new unit tests.
> 
> **Overview**
> Prevents registering mail field `field_name` values that are database/system reserved words by wiring `BaserCore\Model\Validation\BcValidation::reserved()` into `MailFieldsTable::validationDefault()` (including registering the `bc` validator provider).
> 
> Adds unit coverage to ensure reserved words like `select`/`insert`/`update` are rejected with the new error message, while normal names still pass.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e049aff4b3cad95111856eec091b31e5e9ff4f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->