### PR TITLE
fix: #4344 【ページ】草稿欄のバリデーションエラーメッセージが本稿欄表示になっている

### DIFF
--- a/plugins/baser-core/resources/locales/baser_core.pot
+++ b/plugins/baser-core/resources/locales/baser_core.pot
@@ -9830,6 +9830,10 @@ msgstr ""
 msgid "草稿欄に保存できるデータ量を超えています。"
 msgstr ""
 
+#: ./plugins/baser-core/src/Model/Table/PagesTable.php:147
+msgid "草稿欄でPHPの構文エラーが発生しました。"
+msgstr ""
+
 #: ./plugins/bc-blog/src/Model/Table/BlogPostsTable.php:166
 msgid "草稿欄でスクリプトの入力は許可されていません。"
 msgstr ""

--- a/plugins/baser-core/resources/locales/en/baser_core.po
+++ b/plugins/baser-core/resources/locales/en/baser_core.po
@@ -11544,6 +11544,10 @@ msgstr "Scripts are not allowed in the summary field."
 msgid "草稿欄に保存できるデータ量を超えています。"
 msgstr "Exceeding savable data amount for draft."
 
+#: plugins/baser-core/src/Model/Table/PagesTable.php:147
+msgid "草稿欄でPHPの構文エラーが発生しました。"
+msgstr "A PHP syntax error occurred in the draft field."
+
 #: plugins/bc-blog/src/Model/Table/BlogPostsTable.php:166
 msgid "草稿欄でスクリプトの入力は許可されていません。"
 msgstr "You are not allowed to enter scripts in the draft field."

--- a/plugins/baser-core/src/Model/Table/PagesTable.php
+++ b/plugins/baser-core/src/Model/Table/PagesTable.php
@@ -140,17 +140,17 @@ class PagesTable extends AppTable
         $validator
         ->scalar('draft')
         ->allowEmptyString('draft', null)
-        ->maxLengthBytes('draft', 16777215, __d('baser_core', '本稿欄に保存できるデータ量を超えています。'))
+        ->maxLengthBytes('draft', 16777215, __d('baser_core', '草稿欄に保存できるデータ量を超えています。'))
         ->add('draft', 'custom', [
             'rule' => ['phpValidSyntax'],
             'provider' => 'page',
-            'message' => __d('baser_core', '本稿欄でPHPの構文エラーが発生しました。')
+            'message' => __d('baser_core', '草稿欄でPHPの構文エラーが発生しました。')
         ])
         ->add('draft', [
             'containsScript' => [
                 'rule' => ['containsScript'],
                 'provider' => 'bc',
-                'message' => __d('baser_core', '本稿欄でスクリプトの入力は許可されていません。')
+                'message' => __d('baser_core', '草稿欄でスクリプトの入力は許可されていません。')
             ]
         ]);
 

--- a/plugins/baser-core/tests/TestCase/Model/Table/PagesTableTest.php
+++ b/plugins/baser-core/tests/TestCase/Model/Table/PagesTableTest.php
@@ -85,6 +85,11 @@ class PagesTableTest extends BcTestCase
             $fields[] = $key;
         }
         $this->assertEquals(['id','contents', 'draft'], $fields);
+
+        $errors = $validator->validate([
+            'draft' => '<?php echo $test; ?>'
+        ]);
+        $this->assertEquals('草稿欄でスクリプトの入力は許可されていません。', current($errors['draft']));
     }
 
     public function test既存ページチェック正常()


### PR DESCRIPTION
## 概要

 の草稿欄バリデーションにおいて、エラーメッセージが「本稿欄」と表示されていた問題を修正しました。

## 修正内容

-  のメッセージ: "本稿欄に保存できるデータ量を超えています。" → "草稿欄に保存できるデータ量を超えています。"
-  のメッセージ: "本稿欄でPHPの構文エラーが発生しました。" → "草稿欄でPHPの構文エラーが発生しました。"
- `containsScript` のメッセージ: "本稿欄でスクリプトの入力は許可されていません。" → "草稿欄でスクリプトの入力は許可されていません。"
- ロケールファイル（`baser_core.pot`・`en/baser_core.po`）に草稿欄のPHP構文エラーメッセージを追加

## テスト

```bash
docker exec bc-php bin/cake setup test
docker exec bc-php vendor/bin/phpunit --no-coverage plugins/baser-core/tests/TestCase/Model/Table/PagesTableTest.php
```

## 関連

- fixes #4344