### PR TITLE
fix ブログタグテストの並び順を安定化

### DIFF
--- a/plugins/bc-blog/tests/TestCase/Controller/BlogControllerTest.php
+++ b/plugins/bc-blog/tests/TestCase/Controller/BlogControllerTest.php
@@ -291,7 +291,13 @@ class BlogControllerTest extends BcTestCase
             'publish_begin' => '2020-01-27 12:00:00',
             'publish_end' => '9000-01-27 12:00:00'
         ])->persist();
-        BlogPostFactory::make(['id' => 1, 'blog_content_id' => 1, 'no' => 1, 'status' => true])->persist();
+        BlogPostFactory::make([
+            'id' => 1,
+            'blog_content_id' => 1,
+            'no' => 1,
+            'status' => true,
+            'posted' => '2024-01-03 00:00:00'
+        ])->persist();
         BlogContentFactory::make(['id' => 1])->persist();
         ContentFactory::make([
             'id' => 2,
@@ -306,7 +312,13 @@ class BlogControllerTest extends BcTestCase
             'publish_begin' => '2020-01-27 12:00:00',
             'publish_end' => '9000-01-27 12:00:00'
         ])->persist();
-        BlogPostFactory::make(['id' => 2, 'blog_content_id' => 2, 'no' => 2, 'status' => true])->persist();
+        BlogPostFactory::make([
+            'id' => 2,
+            'blog_content_id' => 2,
+            'no' => 2,
+            'status' => true,
+            'posted' => '2024-01-02 00:00:00'
+        ])->persist();
         BlogContentFactory::make(['id' => 2])->persist();
         ContentFactory::make([
             'id' => 3,
@@ -321,7 +333,13 @@ class BlogControllerTest extends BcTestCase
             'publish_begin' => '2020-01-27 12:00:00',
             'publish_end' => '9000-01-27 12:00:00'
         ])->persist();
-        BlogPostFactory::make(['id' => 3, 'blog_content_id' => 3, 'no' => 3, 'status' => true])->persist();
+        BlogPostFactory::make([
+            'id' => 3,
+            'blog_content_id' => 3,
+            'no' => 3,
+            'status' => true,
+            'posted' => '2024-01-01 00:00:00'
+        ])->persist();
         BlogContentFactory::make(['id' => 3])->persist();
         BlogPostBlogTagFactory::make(['id' => 1, 'blog_post_id' => 1, 'blog_tag_id' => 1])->persist();
         BlogPostBlogTagFactory::make(['id' => 2, 'blog_post_id' => 2, 'blog_tag_id' => 1])->persist();


### PR DESCRIPTION
<!-- GitHub Copilot コードレビューへの指示: プルリクエストをレビューしてコメントする際には日本語でお願いします。 -->

## 概要
BlogControllerTest::test_tags が BlogPostFactory のランダムな posted 値に依存しており、
全体(or BcBlog)テスト実行時にタグ一覧の先頭記事が不安定になる場合があったので修正しました。

## 対応内容
- test_tags で作成する 3 件の BlogPost に固定の posted を設定
- タグ一覧のソート条件 `posted DESC, id DESC` に対して期待結果が安定するように調整

## 確認
- `docker exec bc-php vendor/bin/phpunit plugins/bc-blog/tests/TestCase/Controller/BlogControllerTest.php --filter test_tags`
- `docker exec bc-php vendor/bin/phpunit plugins/bc-blog/tests/TestCase/Controller/BlogControllerTest.php`
- `docker exec bc-php vendor/bin/phpunit plugins/bc-blog/tests`

## 補足
- プロダクトコードは変更していません
- テストデータの不安定さのみを解消しています