### PR TITLE
fix #4341 固定ページのタイトル未入力時にプレビューで500エラーが発生する問題を修正

### DIFF
--- a/plugins/baser-core/src/Service/Front/PagesFrontService.php
+++ b/plugins/baser-core/src/Service/Front/PagesFrontService.php
@@ -15,7 +15,6 @@ use BaserCore\Model\Entity\Page;
 use BaserCore\Service\PagesService;
 use Cake\Controller\Controller;
 use Cake\Datasource\EntityInterface;
-use Cake\Http\Exception\NotFoundException;
 use Cake\Http\ServerRequest;
 use BaserCore\Annotation\UnitTest;
 use BaserCore\Annotation\NoTodo;
@@ -63,15 +62,6 @@ class PagesFrontService extends PagesService implements PagesFrontServiceInterfa
                 $pageArray['contents'] = $pageArray['draft'];
             }
             $page = $this->Pages->patchEntity($page, $pageArray);
-
-            $validationErrors = $page->getErrors();
-            if ($validationErrors) {
-                foreach($validationErrors as $columnsErros) {
-                    foreach($columnsErros as $error) {
-                        throw new NotFoundException($error);
-                    }
-                }
-            }
             $page->content = $this->Contents->saveTmpFiles($request->getData('content'), mt_rand(0, 99999999));
         }
         unset($vars['editLink']);

--- a/plugins/baser-core/tests/TestCase/Controller/Admin/PreviewControllerTest.php
+++ b/plugins/baser-core/tests/TestCase/Controller/Admin/PreviewControllerTest.php
@@ -92,6 +92,11 @@ class PreviewControllerTest extends BcTestCase
         $this->post('/baser/admin/baser-core/preview/view?url=https://localhost/&preview=draft', $page->toArray());
         $this->assertResponseOk();
         $this->assertEquals($page->draft, $this->viewVariable('page')['contents']);
+
+        $page->content['title'] = '';
+        $this->post('/baser/admin/baser-core/preview/view?url=https://localhost/&preview=default', $page->toArray());
+        $this->assertResponseOk();
+        $this->assertSame('', $this->viewVariable('page')->content->title);
     }
 
     /**


### PR DESCRIPTION
<!-- GitHub Copilot コードレビューへの指示: プルリクエストをレビューしてコメントする際には日本語でお願いします。 -->

よろしくお願いします！