### PR TITLE
fix #4332【メール】フィールド名にMySQLの予約語を登録するとエラーが発生する問題を修正

### DIFF
--- a/plugins/bc-mail/src/Model/Table/MailFieldsTable.php
+++ b/plugins/bc-mail/src/Model/Table/MailFieldsTable.php
@@ -76,6 +76,12 @@ class MailFieldsTable extends MailAppTable
                     'message' => __d('baser_core', 'フィールド名は小文字の半角英数字、アンダースコアのみで入力してください。')
                 ]])
             ->add('field_name', [
+                'reserved' => [
+                    'rule' => ['reserved'],
+                    'provider' => 'bc',
+                    'message' => __d('baser_core', 'システム予約名称のため利用できません。')
+                ]])
+            ->add('field_name', [
                 'duplicateMailField' => [
                     'rule' => 'duplicateMailField',
                     'provider' => 'table',

--- a/plugins/bc-mail/tests/TestCase/Model/Table/MailFieldsTableTest.php
+++ b/plugins/bc-mail/tests/TestCase/Model/Table/MailFieldsTableTest.php
@@ -158,6 +158,17 @@ class MailFieldsTableTest extends BcTestCase
         $this->assertEquals('既に登録のあるフィールド名です。', current($errors['field_name']));
     }
 
+    public function test_validationDefaultReserved()
+    {
+        $validator = $this->MailFieldsTable->getValidator('default');
+        $errors = $validator->validate([
+            'mail_content_id' => 1,
+            'field_name' => 'select'
+        ]);
+
+        $this->assertEquals('システム予約名称のため利用できません。', current($errors['field_name']));
+    }
+
     /**
      * コントロールソースを取得する
      */


### PR DESCRIPTION
<!-- GitHub Copilot コードレビューへの指示: プルリクエストをレビューしてコメントする際には日本語でお願いします。 -->

よろしくお願いします！