### PR TITLE
fix#4359 【プラグイン】カスタムコンテンツ:エントリーテキストとテキストエリアでspanタグなどが使えない問題を解決

### DIFF
--- a/plugins/bc-custom-content/plugins/BcCcText/src/View/Helper/BcCcTextHelper.php
+++ b/plugins/bc-custom-content/plugins/BcCcText/src/View/Helper/BcCcTextHelper.php
@@ -101,8 +101,9 @@ class BcCcTextHelper extends Helper
      */
     public function get($fieldValue, CustomLink $link, array $options = [])
     {
+        if ($fieldValue === null) return '';
         if (isset($options['escape']) && !$options['escape']) {
-            return nl2br($fieldValue);
+            return nl2br((string) $fieldValue);
         }
         return h($fieldValue);
     }

--- a/plugins/bc-custom-content/plugins/BcCcText/src/View/Helper/BcCcTextHelper.php
+++ b/plugins/bc-custom-content/plugins/BcCcText/src/View/Helper/BcCcTextHelper.php
@@ -101,6 +101,9 @@ class BcCcTextHelper extends Helper
      */
     public function get($fieldValue, CustomLink $link, array $options = [])
     {
+        if (isset($options['escape']) && !$options['escape']) {
+            return nl2br($fieldValue);
+        }
         return h($fieldValue);
     }
 

--- a/plugins/bc-custom-content/plugins/BcCcText/src/View/Helper/BcCcTextHelper.php
+++ b/plugins/bc-custom-content/plugins/BcCcText/src/View/Helper/BcCcTextHelper.php
@@ -103,7 +103,7 @@ class BcCcTextHelper extends Helper
     {
         if ($fieldValue === null) return '';
         if (isset($options['escape']) && !$options['escape']) {
-            return nl2br((string) $fieldValue);
+            return  $fieldValue;
         }
         return h($fieldValue);
     }

--- a/plugins/bc-custom-content/plugins/BcCcTextarea/src/View/Helper/BcCcTextareaHelper.php
+++ b/plugins/bc-custom-content/plugins/BcCcTextarea/src/View/Helper/BcCcTextareaHelper.php
@@ -105,7 +105,7 @@ class BcCcTextareaHelper extends Helper
     {
         if ($fieldValue === null) return '';
         if (isset($options['escape']) && !$options['escape']) {
-            return nl2br((string) $fieldValue);
+            return nl2br($fieldValue);
         }
         return nl2br(h($fieldValue));
     }

--- a/plugins/bc-custom-content/plugins/BcCcTextarea/src/View/Helper/BcCcTextareaHelper.php
+++ b/plugins/bc-custom-content/plugins/BcCcTextarea/src/View/Helper/BcCcTextareaHelper.php
@@ -105,7 +105,7 @@ class BcCcTextareaHelper extends Helper
     {
         if ($fieldValue === null) return '';
         if (isset($options['escape']) && !$options['escape']) {
-            return nl2br($fieldValue);
+            return  $fieldValue;
         }
         return nl2br(h($fieldValue));
     }

--- a/plugins/bc-custom-content/plugins/BcCcTextarea/src/View/Helper/BcCcTextareaHelper.php
+++ b/plugins/bc-custom-content/plugins/BcCcTextarea/src/View/Helper/BcCcTextareaHelper.php
@@ -103,6 +103,9 @@ class BcCcTextareaHelper extends Helper
      */
     public function get($fieldValue, CustomLink $link, array $options = [])
     {
+        if (isset($options['escape']) && !$options['escape']) {
+            return nl2br($fieldValue);
+        }
         return nl2br(h($fieldValue));
     }
 

--- a/plugins/bc-custom-content/plugins/BcCcTextarea/src/View/Helper/BcCcTextareaHelper.php
+++ b/plugins/bc-custom-content/plugins/BcCcTextarea/src/View/Helper/BcCcTextareaHelper.php
@@ -103,8 +103,9 @@ class BcCcTextareaHelper extends Helper
      */
     public function get($fieldValue, CustomLink $link, array $options = [])
     {
+        if ($fieldValue === null) return '';
         if (isset($options['escape']) && !$options['escape']) {
-            return nl2br($fieldValue);
+            return nl2br((string) $fieldValue);
         }
         return nl2br(h($fieldValue));
     }

--- a/plugins/bc-custom-content/src/View/Helper/CustomContentHelper.php
+++ b/plugins/bc-custom-content/src/View/Helper/CustomContentHelper.php
@@ -226,6 +226,7 @@ class CustomContentHelper extends CustomContentAppHelper
     {
         if (is_array($entry)) $entry = new CustomEntry($entry);
         $options = array_merge([
+            'escape' => true,
             'beforeHead' => true,
             'afterHead' => true,
             'beforeLinefeed' => true,

--- a/plugins/bc-custom-content/tests/TestCase/View/Helper/CustomContentHelperTest.php
+++ b/plugins/bc-custom-content/tests/TestCase/View/Helper/CustomContentHelperTest.php
@@ -301,6 +301,12 @@ class CustomContentHelperTest extends BcTestCase
             [true, 'BcCcRelated', '/baser/admin', 'recruit_category', 1, ['beforeLinefeed' => false], '1&nbsp;プログラマー&nbsp;1<br>'], //isAdminSystem = true && beforeLinefeed = false
             [true, 'BcCcRelated', '/baser/admin', 'recruit_category', 1, ['afterHead' => false], '<br>1&nbsp;プログラマー<br>'], //isAdminSystem = true && afterHead = false
             [true, 'BcCcRelated', '/baser/admin', 'recruit_category', 1, ['afterLinefeed' => false], '<br>1&nbsp;プログラマー&nbsp;1'], //isAdminSystem = true && afterLinefeed = false
+            [true, 'BcCcText', '/', 'recruit_category', '<strong>タグ</strong>', [], '&lt;strong&gt;タグ&lt;/strong&gt;'], // デフォルトではエスケープされる
+            [true, 'BcCcTextarea', '/', 'recruit_category', '<strong>タグ</strong>', [], '&lt;strong&gt;タグ&lt;/strong&gt;'], // デフォルトではエスケープされる
+            [true, 'BcCcText', '/', 'recruit_category', '<strong>タグ</strong>', ['escape' => false], '<strong>タグ</strong>'], // escape=false でタグを保持
+            [true, 'BcCcTextarea', '/', 'recruit_category', '<strong>タグ</strong>', ['escape' => false], '<strong>タグ</strong>'], // escape=false でタグを保持
+            [true, 'BcCcText', '/', 'recruit_category', null, ['escape' => false], ''], // 空値でも例外にならない
+            [true, 'BcCcTextarea', '/', 'recruit_category', null, ['escape' => false], ''], // 空値でも例外にならない
         ];
     }
 


### PR DESCRIPTION
<!-- GitHub Copilot コードレビューへの指示: プルリクエストをレビューしてコメントする際には日本語でお願いします。 -->
