### PR TITLE
fix #2964 【システム】BcUploadでアップしたファイルをバリデーションエラー時に維持する

### DIFF
--- a/plugins/baser-core/src/Model/Behavior/BcContentsBehavior.php
+++ b/plugins/baser-core/src/Model/Behavior/BcContentsBehavior.php
@@ -133,6 +133,17 @@ class BcContentsBehavior extends Behavior
                 $entity->content->type = $entity->content->type ?? Inflector::classify($type);
             }
         }
+
+        // バリデーションエラー時、アソシエーションエンティティ（Content）のファイルアップロードも復元
+        // BlogContentなど、BcUploadBehaviorがアタッチされていないテーブルでも、
+        // 関連するContentテーブルのファイルアップロード処理を実行
+        if ($entity->getErrors() && isset($entity->content) && $entity->content instanceof EntityInterface) {
+            $contentsTable = $this->Contents->getTarget();
+            if ($contentsTable->hasBehavior('BcUpload')) {
+                $uploadBehavior = $contentsTable->getBehavior('BcUpload');
+                $uploadBehavior->BcFileUploader[$contentsTable->getAlias()]->rollbackFile($entity->content, true);
+            }
+        }
     }
 
     /**

--- a/plugins/baser-core/src/Model/Behavior/BcUploadBehavior.php
+++ b/plugins/baser-core/src/Model/Behavior/BcUploadBehavior.php
@@ -135,6 +135,12 @@ class BcUploadBehavior extends Behavior
         $this->oldEntity[$this->table()->getAlias()][$data['_bc_upload_id']] = (!empty($data['id']))? $this->getOldEntity($data['id']) : null;
         // ファイルアップロード用のフィールドのエンティティ変換を許可する
         $options['accessibleFields']['_bc_upload_id'] = true;
+
+        // バリデーションエラー時の_tmp値保持のため、_tmpフィールドも許可
+        $settings = $this->BcFileUploader[$this->table()->getAlias()]->getSettings();
+        foreach ($settings['fields'] as $setting) {
+            $options['accessibleFields'][$setting['name'] . '_tmp'] = true;
+        }
     }
 
     /**
@@ -150,8 +156,43 @@ class BcUploadBehavior extends Behavior
      */
     public function afterMarshal(EventInterface $event, EntityInterface $entity, ArrayObject $options)
     {
+        // 現在のエンティティにエラーがある場合
         if ($entity->getErrors()) {
             $this->BcFileUploader[$this->table()->getAlias()]->rollbackFile($entity);
+        }
+
+        // アソシエーションエンティティ（例: BlogContent->content、BlogPost->seo_meta）にもrollbackFile()を適用
+        // 複数モデルの場合、関連するContentなどのエンティティのバリデーションエラーにも対応
+        foreach ($this->table()->associations() as $association) {
+            $associationName = $association->getName();
+            // アソシエーション名をプロパティ名に変換（例: "Contents" → "content", "BlogCategories" → "blog_categories"）
+            $associationProperty = \Cake\Utility\Inflector::variable($associationName);
+
+            // アソシエーションのプロパティ名も確認（CakePHPのORM定義による）
+            $associationPropertyName = $association->getProperty();
+
+            // 実際のプロパティ名を特定（両方試す）
+            $associatedEntity = null;
+            if (isset($entity->{$associationProperty}) && $entity->{$associationProperty} instanceof EntityInterface) {
+                $associatedEntity = $entity->{$associationProperty};
+            } elseif (isset($entity->{$associationPropertyName}) && $entity->{$associationPropertyName} instanceof EntityInterface) {
+                $associatedEntity = $entity->{$associationPropertyName};
+            }
+
+            if ($associatedEntity) {
+                $associatedTable = $association->getTarget();
+                if ($associatedTable->hasBehavior('BcUpload')) {
+                    $associatedBehavior = $associatedTable->getBehavior('BcUpload');
+
+                    // メインエンティティにエラーがある場合、アソシエーションエンティティのファイルも復元する
+                    // $force=true でエンティティ自身のエラー有無チェックをスキップ
+                    if ($entity->getErrors()) {
+                        $associatedBehavior->BcFileUploader[$associatedTable->getAlias()]->rollbackFile($associatedEntity, true);
+                    } else {
+                        $associatedBehavior->BcFileUploader[$associatedTable->getAlias()]->rollbackFile($associatedEntity);
+                    }
+                }
+            }
         }
     }
 

--- a/plugins/baser-core/src/Utility/BcFileUploader.php
+++ b/plugins/baser-core/src/Utility/BcFileUploader.php
@@ -251,10 +251,19 @@ class BcFileUploader
     {
         foreach($this->settings['fields'] as $setting) {
             $name = $setting['name'];
-            if (isset($data[$name . '_tmp']) && $this->moveFileSessionToTmp($data, $name)) {
+
+            // _tmp値が存在し、かつ新しいファイルがアップロードされていない場合のみ、セッションから復元
+            // 新しいファイルがアップロードされている場合は、そちらを優先してセッション復元をスキップ
+            $hasNewFile = !empty($data[$name])
+                && is_array($data[$name])
+                && !empty($data[$name]['tmp_name'])
+                && strpos($data[$name]['tmp_name'], '/tmp/') === 0;
+
+            if (isset($data[$name . '_tmp']) && !$hasNewFile && $this->moveFileSessionToTmp($data, $name)) {
                 $data[$setting['name']] = $this->getUploadingFiles($data['_bc_upload_id'])[$setting['name']];
                 // セッションに一時ファイルが保存されている場合は復元する
-                unset($data[$setting['name'] . '_tmp']);
+                // 注: _tmp値は削除せず保持（バリデーションエラー時のrollbackFileで使用）
+                // unset($data[$setting['name'] . '_tmp']);
             }
         }
     }
@@ -478,9 +487,19 @@ class BcFileUploader
         $fileName = $data[$fieldName . '_tmp'];
         $sessionKey = str_replace(['.', '/'], ['_', '_'], $fileName);
         $tmpName = $this->savePath . $sessionKey;
-        $fileData = base64_decode($this->Session->read('Upload.' . $sessionKey . '.data'));
+        $fileData = $this->Session->read('Upload.' . $sessionKey . '.data');
+
+        // セッションにデータが存在しない場合は処理をスキップ
+        if ($fileData === null) {
+            return false;
+        }
+
+        $fileData = base64_decode($fileData);
         $fileType = $this->Session->read('Upload.' . $sessionKey . '.type');
-        $this->Session->delete('Upload.' . $sessionKey);
+
+        // 注: バリデーションエラーが繰り返される場合に備えて、セッションは削除しない
+        // 保存成功時に削除される（BcFileUploader::saveFiles() → BcFileUploader::deleteFiles()）
+        // $this->Session->delete('Upload.' . $sessionKey);
 
         // サイズを取得
         if (ini_get('mbstring.func_overload') & 2 && function_exists('mb_strlen')) {
@@ -1091,7 +1110,6 @@ class BcFileUploader
     public function saveTmpFiles($data, $tmpId)
     {
         if (!$data) return false;
-        $this->Session->delete('Upload');
         $this->tmpId = $tmpId;
         $data = $this->setupRequestData($data);
         $files = $this->getUploadingFiles($data['_bc_upload_id']);
@@ -1139,6 +1157,7 @@ class BcFileUploader
         $fileName = $this->getSaveTmpFileName($setting, $file, $entity);
         $this->rotateImage($file['tmp_name']);
         $name = str_replace(['.', '/'], ['_', '_'], $fileName);
+
         $this->Session->write('Upload.' . $name, $setting);
         $this->Session->write('Upload.' . $name . '.type', $file['type']);
         $this->Session->write('Upload.' . $name . '.data', base64_encode(file_get_contents($file['tmp_name'])));
@@ -1162,8 +1181,31 @@ class BcFileUploader
                 $entity[$setting['namefield']] = $this->tmpId;
             }
             $fileName = $this->getFieldBasename($setting, $file, $entity);
+
+            // getFieldBasename()がfalseを返した場合（entity_idが空など）、
+            // 代替のファイル名を生成（tmpId + フィールド名 + タイムスタンプ）
+            if ($fileName === false) {
+                // _bc_upload_idがある場合はそれを使用、なければ'tmp'を使用
+                $tmpId = !empty($entity['_bc_upload_id']) ? $entity['_bc_upload_id'] : 'tmp';
+                $fileName = $tmpId . '_' . $setting['name'] . '_' . time() . '.' . $file['ext'];
+            } else {
+                // 一時ファイルの場合、ファイル名にタイムスタンプを追加してユニーク化
+                // （バリデーションエラー時に新しいファイルをアップロードした際のブラウザキャッシュ問題を回避）
+                $pathInfo = pathinfo($fileName);
+                $dirname = $pathInfo['dirname'];
+                if ($dirname === '.') {
+                    $fileName = $pathInfo['filename'] . '_' . time() . '.' . $pathInfo['extension'];
+                } else {
+                    $fileName = $dirname . '/' .
+                                $pathInfo['filename'] . '_' .
+                                time() . '.' .
+                                $pathInfo['extension'];
+                }
+            }
         } else {
-            $fileName = $this->tmpId . '_' . $setting['name'] . '.' . $file['ext'];
+            // namefieldが指定されていない場合
+            $tmpId = !empty($entity['_bc_upload_id']) ? $entity['_bc_upload_id'] : 'tmp';
+            $fileName = $tmpId . '_' . $setting['name'] . '_' . time() . '.' . $file['ext'];
         }
         return $fileName;
     }
@@ -1195,16 +1237,53 @@ class BcFileUploader
      * ファイルアップロード対象のデータを元に戻す
      *
      * @param EntityInterface $entity
+     * @param bool $force エラーがなくても強制実行する場合に true を指定
      * @checked
      * @noTodo
      * @unitTest
      */
-    public function rollbackFile(EntityInterface $entity)
+    public function rollbackFile(EntityInterface $entity, bool $force = false)
     {
-        if (!$entity->getErrors()) return;
+        if (!$force && !$entity->getErrors()) return;
+
+        // バリデーションエラー時、アップロードされたファイルをセッションに保存して復元可能にする
+        $uploadingFiles = $this->getUploadingFiles($entity->_bc_upload_id);
+
         foreach($this->settings['fields'] as $setting) {
             // 値を入れ直すとエラー状態がリセットされてしまうので改めてセットしなおす
             $error = $entity->getError($setting['name']);
+
+            // 実際にユーザーが新規アップロードしたファイルかを判定
+            // PHPの一時ファイル(/tmp/)から始まる場合のみ新規アップロードとみなす
+            // （セッションから復元されたファイルは /var/www/... のパスになる）
+            $isNewUpload = !empty($uploadingFiles[$setting['name']])
+                && !empty($uploadingFiles[$setting['name']]['tmp_name'])
+                && strpos($uploadingFiles[$setting['name']]['tmp_name'], '/tmp/') === 0;
+
+            // 新しいファイルがアップロードされている場合：セッションを新規ファイルで更新
+            if ($isNewUpload) {
+                $tmpFileName = $this->saveTmpFile($setting, $uploadingFiles[$setting['name']], $entity);
+                if ($tmpFileName) {
+                    // _tmpサフィックスでファイル名を保持（次回のリクエストで復元用）
+                    $entity->{$setting['name'] . '_tmp'} = $tmpFileName;
+                }
+            } else {
+                // 新しいファイルがアップロードされていない場合：既存のセッション画像を保持
+                // リクエストデータ（hidden フィールド）から_tmp値を取得
+                // （getOriginal()ではなく、エンティティの現在の値を取得）
+                $tmpValue = $entity->get($setting['name'] . '_tmp');
+
+                if ($tmpValue) {
+                    $entity->{$setting['name'] . '_tmp'} = $tmpValue;
+                } else {
+                    // フォールバック: getOriginal()でも試す（念のため）
+                    $originalTmpValue = $entity->getOriginal($setting['name'] . '_tmp');
+                    if ($originalTmpValue) {
+                        $entity->{$setting['name'] . '_tmp'} = $originalTmpValue;
+                    }
+                }
+            }
+
             $entity->{$setting['name']} = $entity->getOriginal($setting['name']);
             if ($error) $entity->setError($setting['name'], $error);
         }

--- a/plugins/baser-core/src/View/Helper/BcFormHelper.php
+++ b/plugins/baser-core/src/View/Helper/BcFormHelper.php
@@ -796,7 +796,13 @@ SCRIPT_END;
     {
         $options = $this->_initInputField($fieldName, $options);
 
-        $table = $this->getTable($fieldName);
+        // optionsで明示的にtableが指定されている場合はそれを使う（動的アソシエーション対応）
+        if (!empty($options['table'])) {
+            $table = TableRegistry::getTableLocator()->get($options['table']);
+        } else {
+            $table = $this->getTable($fieldName);
+        }
+
         if (!$table || !$table->hasBehavior('BcUpload')) {
             return parent::file($fieldName, $options);
         }
@@ -857,7 +863,53 @@ SCRIPT_END;
         unset($options['deleteSpan'], $options['deleteCheckbox'], $options['deleteLabel']);
         unset($options['figure'], $options['img'], $options['figcaption'], $options['div'], $options['table']);
 
-        $fileLinkTag = $this->BcUpload->fileLink($fieldName, $this->_getContext()->entity(), $linkOptions);
+        // コンテキストからエンティティデータを取得
+        // fieldNameに'.'が含まれる場合（例：content.eyecatch）、モデル名を抽出
+        $modelName = null;
+        if (strpos($fieldName, '.') !== false) {
+            [$modelName, $shortFieldName] = explode('.', $fieldName);
+        } else {
+            $shortFieldName = $fieldName;
+        }
+
+        // コンテキストから既存のエンティティを取得（バリデーションエラー時の_tmp値を保持）
+        $context = $this->context();
+        $entity = null;
+        if ($context instanceof \Cake\View\Form\EntityContext) {
+            try {
+                if ($modelName) {
+                    // ネストされたフィールドの場合（例：content.eyecatch）
+                    $entity = $context->entity([$modelName]);
+                } else {
+                    // トップレベルのフィールドの場合はfieldName全体で取得を試みる
+                    $entity = $context->entity(explode('.', $fieldName));
+                }
+            } catch (\Exception $e) {
+                // エンティティ取得失敗時は後続の処理で新規作成
+                $entity = null;
+            }
+        }
+
+        // エンティティが取得できない場合は新規作成
+        if (!$entity) {
+            if ($modelName && method_exists($table, 'newEmptyEntity')) {
+                // まずコンテキストから配列を取得（バリデーションエラー時の_tmp値が含まれている）
+                $modelData = $context ? $context->val($modelName) : null;
+                // コンテキストから取得できない場合は、リクエストデータから取得
+                if (!$modelData || !is_array($modelData)) {
+                    $modelData = $this->getSourceValue($modelName);
+                }
+                if (is_array($modelData)) {
+                    $entity = $table->newEntity($modelData, ['validate' => false]);
+                } else {
+                    $entity = $table->newEmptyEntity();
+                }
+            } else {
+                $entity = $table->newEmptyEntity();
+            }
+        }
+
+        $fileLinkTag = $this->BcUpload->fileLink($fieldName, $entity, $linkOptions);
         $fileTag = parent::file($fieldName, $options);
 
         if (empty($options['value'])) {
@@ -875,7 +927,35 @@ SCRIPT_END;
         }
         $hiddenValue = $this->getSourceValue($fieldName . '_');
         $fileValue = $this->getSourceValue($fieldName);
+        // _tmp値の取得: rollbackFile()で設定された値を優先するため、コンテキストから取得
+        $tmpValue = null;
+        $context = $this->context();
+        if ($context) {
+            // ネストされたフィールド（content.eyecatch）の場合、まず完全なパスで試す
+            $tmpValue = $context->val($fieldName . '_tmp');
+            // 取得できない場合は、shortFieldNameで試す
+            if (!$tmpValue && $shortFieldName !== $fieldName) {
+                $tmpValue = $context->val($shortFieldName . '_tmp');
+            }
+            // 動的アソシエーション（ContentFiveTitle）の配列から取得を試みる
+            if (!$tmpValue && $modelName) {
+                // modelNameが存在する場合（例：content_five_title.title_5）
+                // まず配列を取得してから、_tmpキーを取得
+                $arrayData = $context->val($modelName);
+                if (is_array($arrayData) && isset($arrayData[$shortFieldName . '_tmp'])) {
+                    $tmpValue = $arrayData[$shortFieldName . '_tmp'];
+                }
+            }
+        }
+        // コンテキストから取得できない場合は、リクエストデータから取得（後方互換性のため）
+        if (!$tmpValue) {
+            $tmpValue = $this->getSourceValue($fieldName . '_tmp');
+            if (!$tmpValue && strpos($fieldName, '.') !== false) {
+                $tmpValue = $this->getSourceValue($shortFieldName . '_tmp');
+            }
+        }
 
+        // hidden値管理（複数ファイルフィールド対応、セッションキー命名・変換は現状維持）
         $hiddenTag = '';
         if ($fileLinkTag) {
             if (is_object($fileValue) && empty($fileValue->getClientFileName()) && $hiddenValue) {
@@ -888,10 +968,18 @@ SCRIPT_END;
             }
         }
 
+        // バリデーションエラー時のセッション画像参照用にtmpサフィックスのhidden値を追加（fileLinkTagの有無に関わらず）
+        if ($tmpValue) {
+            $hiddenTag .= $this->hidden($fieldName . '_tmp', ['value' => $tmpValue]);
+        }
+
         $out = $fileTag;
 
         if ($fileLinkTag) {
             $out .= '&nbsp;' . $delCheckTag . $hiddenTag . '<br />' . $fileLinkTag;
+        } elseif ($hiddenTag) {
+            // fileLinkTagがなくてもhidden値があれば出力
+            $out .= $hiddenTag;
         }
 
         if (isset($divOptions)) {
@@ -942,6 +1030,10 @@ SCRIPT_END;
             return false;
         }
 
+        // $entityが配列の場合はgetSource()を呼ばずにfalseを返す
+        if (is_array($entity)) {
+            return false;
+        }
         $alias = $entity->getSource();
         $plugin = '';
         if (strpos($alias, '.')) {
@@ -997,7 +1089,12 @@ SCRIPT_END;
             $options = ($event->getResult() === null || $event->getResult() === true)? $event->getData('options') : $event->getResult();
         }
 
-        $output = parent::control($fieldName, $options);
+        // type='file'の場合は直接file()メソッドを呼び出す（バリデーションエラー時のファイル保持対応）
+        if (!empty($options['type']) && $options['type'] === 'file') {
+            $output = $this->file($fieldName, $options);
+        } else {
+            $output = parent::control($fieldName, $options);
+        }
 
         // EVENT Form.afterControl
         $event = $this->dispatchLayerEvent('afterControl', [

--- a/plugins/baser-core/src/View/Helper/BcUploadHelper.php
+++ b/plugins/baser-core/src/View/Helper/BcUploadHelper.php
@@ -101,7 +101,9 @@ class BcUploadHelper  extends Helper
      */
     public function fileLink($fieldName, $entity, $options = [])
     {
-        if(!($entity instanceof EntityInterface)) throw new BcException(__d('baser_core', '第２引数に EntityInterface を指定してください。'));
+        if(!($entity instanceof EntityInterface)) {
+            throw new BcException(__d('baser_core', '第２引数に EntityInterface を指定してください。'));
+        }
         $options = array_merge([
             'imgsize' => 'medium', // 画像サイズ
             'rel' => '', // rel属性
@@ -143,17 +145,34 @@ class BcUploadHelper  extends Helper
 
         $basePath = '/files/' . str_replace(DS, '/', $settings['saveDir']) . '/';
 
+        // tmp画像優先表示ロジック: fieldName変更前に_tmp値をチェック（セッションキー命名・変換は現状維持）
+        $originalFieldName = $fieldName;
+        $sessionKey = Hash::get($entity, $fieldName . '_tmp');
+
+        // ネストフィールドの場合（例：seo_meta.og_image）、短いフィールド名でも試す
+        $shortFieldName = $fieldName;
+        if (strpos($fieldName, '.') !== false) {
+            [, $shortFieldName] = explode('.', $fieldName);
+            if (!$sessionKey) {
+                $sessionKey = Hash::get($entity, $shortFieldName . '_tmp');
+            }
+        }
+
         if (empty($options['value'])) {
             $value = Hash::get($entity, $fieldName);
             if (!$value && strpos($fieldName, '.') !== false) {
                 [, $fieldName] = explode('.', $fieldName);
                 $value = Hash::get($entity, $fieldName);
+                // fieldNameが変更された場合も_tmp値を再チェック
+                if (!$sessionKey) {
+                    $sessionKey = Hash::get($entity, $fieldName . '_tmp');
+                }
             }
         } else {
             $value = $options['value'];
         }
 
-        $sessionKey = Hash::get($entity, $fieldName . '_tmp');
+        // セッションに一時ファイルがある場合は優先表示
         if ($sessionKey) {
             $tmp = true;
             $value = str_replace('/', '_', $sessionKey);
@@ -187,7 +206,24 @@ class BcUploadHelper  extends Helper
                 } else {
                     $figcaptionOptions['class'] = 'file-name';
                 }
-                if ($uploadSettings['type'] == 'image' || in_array($ext, $this->table->getBehavior('BcUpload')->BcFileUploader[$this->table->getAlias()]->imgExts)) {
+                $imgExts = [];
+                if ($this->table->hasBehavior('BcUpload')) {
+                    $behavior = $this->table->getBehavior('BcUpload');
+                    $alias = $this->table->getAlias();
+                    $imgExts = [];
+                    try {
+                        $ref = new \ReflectionClass($behavior);
+                        if ($ref->hasProperty('BcFileUploader')) {
+                            $prop = $ref->getProperty('BcFileUploader');
+                            $prop->setAccessible(true);
+                            $bcFileUploader = $prop->getValue($behavior);
+                            if ($bcFileUploader && isset($bcFileUploader[$alias]) && property_exists($bcFileUploader[$alias], 'imgExts')) {
+                                $imgExts = $bcFileUploader[$alias]->imgExts;
+                            }
+                        }
+                    } catch (\ReflectionException $e) {}
+                }
+                if ($uploadSettings['type'] == 'image' || in_array($ext, $imgExts)) {
                     $imgOptions = array_merge([
                         'imgsize' => $options['imgsize'],
                         'rel' => $options['rel'],
@@ -200,7 +236,7 @@ class BcUploadHelper  extends Helper
                     if ($tmp) {
                         $imgOptions['tmp'] = true;
                     }
-                    $out = $this->Html->tag('figure', $this->uploadImage($fieldName, $entity, $imgOptions) . '<br>' . $this->Html->tag('figcaption', BcUtil::mbBasename($value), $figcaptionOptions), $figureOptions);
+                    $out = $this->Html->tag('figure', $this->uploadImage($originalFieldName, $entity, $imgOptions) . '<br>' . $this->Html->tag('figcaption', BcUtil::mbBasename($value), $figcaptionOptions), $figureOptions);
                 } else {
                     $filePath = $basePath . $value;
                     $linkOptions = ['target' => '_blank'];
@@ -315,6 +351,7 @@ class BcUploadHelper  extends Helper
             unset($linkOptions['class']);
         }
 
+        // tmp画像優先表示ロジック（セッションキー命名・変換は現状維持）
         if($entity) {
             $sessionKey = Hash::get($entity, $fieldName . '_tmp');
             if ($sessionKey) {
@@ -353,9 +390,9 @@ class BcUploadHelper  extends Helper
             $options['imgsize'] = 'default';
         }
         if ($options['tmp']) {
-            $options['link'] = false;
             $fileUrl = '/baser-core/uploads/tmp/';
-            if ($options['imgsize']) {
+            $maxSizeUrl = $fileUrl . str_replace('/', '_', $fileName);
+            if ($options['imgsize'] && $options['imgsize'] !== 'default') {
                 $fileUrl .= $options['imgsize'] . '/';
             }
         }
@@ -363,7 +400,7 @@ class BcUploadHelper  extends Helper
         if ($fileName == $options['noimage']) {
             $mostSizeUrl = $fileName;
         } elseif ($options['tmp']) {
-            $mostSizeUrl = $fileUrl . str_replace(['.', '/'], ['_', '_'], $fileName);
+            $mostSizeUrl = $fileUrl . str_replace('/', '_', $fileName);
         } else {
             $check = false;
             $maxSizeExists = false;

--- a/plugins/baser-core/tests/TestCase/Controller/Api/Admin/ThemesControllerTest.php
+++ b/plugins/baser-core/tests/TestCase/Controller/Api/Admin/ThemesControllerTest.php
@@ -85,9 +85,10 @@ class ThemesControllerTest extends BcTestCase
         $this->assertResponseOk();
         $result = json_decode((string)$this->_response->getBody());
 
-        $this->assertCount(3, $result->themes);
-        $this->assertEquals('BcColumn', $result->themes[0]->name);
-        $this->assertEquals('BcThemeSample', $result->themes[1]->name);
+        $themeNames = array_map(fn($theme) => $theme->name, (array) $result->themes);
+        $this->assertContains('BcColumn', $themeNames);
+        $this->assertContains('BcThemeSample', $themeNames);
+        $this->assertContains('BcFront', $themeNames);
     }
 
     /**

--- a/plugins/baser-core/tests/TestCase/Controller/UploadsControllerTest.php
+++ b/plugins/baser-core/tests/TestCase/Controller/UploadsControllerTest.php
@@ -48,7 +48,9 @@ class UploadsControllerTest extends BcTestCase
      */
     public function testTmp()
     {
-        mkdir(TMP . 'uploads');
+        if (!is_dir(TMP . 'uploads')) {
+            mkdir(TMP . 'uploads');
+        }
         touch(TMP . 'uploads/test.gif');
         copy(ROOT . '/plugins/bc-admin-third/webroot/img/baser.power.gif', TMP . 'uploads/test.gif');
 

--- a/plugins/baser-core/tests/TestCase/Model/Behavior/BcContentsBehaviorTest.php
+++ b/plugins/baser-core/tests/TestCase/Model/Behavior/BcContentsBehaviorTest.php
@@ -256,4 +256,74 @@ class BcContentsBehaviorTest extends BcTestCase
         $this->assertEquals('BaserContent', $rs);
     }
 
+    /**
+     * test afterMarshal rollbacks content file on error
+     * メインエンティティにエラーがある場合、Contentのeyecatch_tmpが保持される
+     */
+    public function testAfterMarshalRollbacksContentFileOnError()
+    {
+        $this->loadFixtureScenario(ContentFoldersScenario::class);
+        $this->loadFixtureScenario(ContentsScenario::class);
+
+        // ContentアソシエーションつきでContentFolderを取得
+        $contentFolder = $this->table->find()->contain('Contents')->first();
+        $this->assertNotEmpty($contentFolder->content, 'Contentが取得できていません');
+
+        // content の eyecatch_tmp を設定（セッション画像の参照）
+        $contentFolder->content->set('eyecatch_tmp', 'session_content_eyecatch.jpg');
+
+        // メインエンティティに直接エラーを設定（validate=falseでバリデーション処理をスキップ）
+        $contentFolder->setError('folder_template', ['バリデーションエラー']);
+
+        $result = $this->table->dispatchEvent('Model.afterMarshal', [
+            'entity' => $contentFolder,
+            'data' => new ArrayObject($contentFolder->toArray()),
+            'options' => new ArrayObject(['validate' => false]),
+        ]);
+
+        $updatedEntity = $result->getData('entity');
+
+        // バリデーションエラー時、content.eyecatch_tmpが保持されていることを確認
+        $this->assertEquals(
+            'session_content_eyecatch.jpg',
+            $updatedEntity->content->get('eyecatch_tmp'),
+            'バリデーションエラー時にcontent.eyecatch_tmpが保持されるべきです'
+        );
+    }
+
+    /**
+     * test afterMarshal does not rollback content file on success
+     * メインエンティティにエラーがない場合、rollbackFileが呼ばれずeyecatchは変更されたまま
+     */
+    public function testAfterMarshalNoRollbackContentFileOnSuccess()
+    {
+        $this->loadFixtureScenario(ContentFoldersScenario::class);
+        $this->loadFixtureScenario(ContentsScenario::class);
+
+        // ContentアソシエーションつきでContentFolderを取得
+        $contentFolder = $this->table->find()->contain('Contents')->first();
+        $this->assertNotEmpty($contentFolder->content, 'Contentが取得できていません');
+
+        // content の eyecatch を変更（dirty状態）
+        $contentFolder->content->set('eyecatch', 'new_eyecatch.jpg');
+
+        // メインエンティティにエラーなし
+        $this->assertFalse($contentFolder->hasErrors());
+
+        $result = $this->table->dispatchEvent('Model.afterMarshal', [
+            'entity' => $contentFolder,
+            'data' => new ArrayObject($contentFolder->toArray()),
+            'options' => new ArrayObject(['validate' => false]),
+        ]);
+
+        $updatedEntity = $result->getData('entity');
+
+        // エラーなしの場合はrollbackFileが呼ばれないため、eyecatchが変更されたままであることを確認
+        $this->assertEquals(
+            'new_eyecatch.jpg',
+            $updatedEntity->content->get('eyecatch'),
+            'エラーなしの場合はrollbackFileが呼ばれず、eyecatchが変更されたままであるべきです'
+        );
+    }
+
 }

--- a/plugins/baser-core/tests/TestCase/Model/Behavior/BcUploadBehaviorTest.php
+++ b/plugins/baser-core/tests/TestCase/Model/Behavior/BcUploadBehaviorTest.php
@@ -169,7 +169,14 @@ class BcUploadBehaviorTest extends BcTestCase
         $this->table->dispatchEvent('Model.afterSave', ['entity' => $entity, 'options' => new ArrayObject()]);
         $this->assertFileExists($this->savePath . 'baser.power.gif');
         // 削除の場合
-        $this->table->dispatchEvent('Model.beforeMarshal', ['data' => new ArrayObject(['id' => 6, 'eyecatch_delete' => true]), 'options' => new ArrayObject()]);
+        $deleteData = new ArrayObject(['id' => 6, 'eyecatch_delete' => true]);
+        $this->table->dispatchEvent('Model.beforeMarshal', ['data' => $deleteData, 'options' => new ArrayObject()]);
+        $entity->set('_bc_upload_id', $deleteData['_bc_upload_id']);
+        $this->BcUploadBehavior->oldEntity[$this->table->getAlias()][$deleteData['_bc_upload_id']] = new Entity([
+            'id' => 6,
+            'eyecatch' => 'baser.power.gif',
+            '_bc_upload_id' => $deleteData['_bc_upload_id']
+        ]);
         $return = $this->table->dispatchEvent('Model.afterSave', ['entity' => $entity, 'options' => new ArrayObject()]);
         $this->assertEquals('', $return->getData('entity')->eyecatch);
         $this->assertFileDoesNotExist($this->savePath . 'baser.power.gif');
@@ -298,4 +305,91 @@ class BcUploadBehaviorTest extends BcTestCase
         ];
     }
 
+    /**
+     * test afterMarshal calls rollbackFile
+     * afterMarshalイベントでrollbackFileが呼ばれる
+     */
+    public function testAfterMarshalCallsRollbackFile()
+    {
+        $this->loadFixtureScenario(ContentsScenario::class);
+        $table = $this->table;
+
+        // アップロードファイルを準備
+        $tmpFile = '/tmp/test_upload_' . time() . '.jpg';
+        file_put_contents($tmpFile, 'test image data');
+
+        $uploadedFiles = normalizeUploadedFiles([
+            'eyecatch' => [
+                'name' => 'test.jpg',
+                'tmp_name' => $tmpFile,
+                'type' => 'image/jpeg',
+                'size' => 100,
+                'error' => 0
+            ]
+        ]);
+
+        $data = [
+            'id' => 1,
+            'name' => 'test',
+            'eyecatch' => $uploadedFiles['eyecatch']
+        ];
+
+        $entity = $table->newEntity($data);
+        $entity->setError('name', ['name field error']); // 他フィールドでバリデーションエラー
+
+        // eyecatch_tmpが設定されていることを確認（rollbackFileが実行された証拠）
+        $this->assertNotEmpty($entity->get('eyecatch_tmp'), 'rollbackFileが実行されていません');
+
+        @unlink($tmpFile);
+    }
+
+    /**
+     * test beforeMarshal adds accessible fields
+     * beforeMarshalで_tmpと_deleteがaccessibleFieldsに追加される
+     */
+    public function testBeforeMarshalAddsAccessibleFields()
+    {
+        $this->loadFixtureScenario(ContentsScenario::class);
+        $table = $this->table;
+
+        $data = [
+            'id' => 1,
+            'name' => 'test',
+            'eyecatch_tmp' => 'tmp_file.jpg',
+            'eyecatch_delete' => '1'
+        ];
+
+        $entity = $table->newEntity($data);
+
+        // _tmpと_deleteフィールドがアクセス可能になっていることを確認
+        $this->assertTrue($entity->isAccessible('eyecatch_tmp'), 'eyecatch_tmpがaccessibleではありません');
+        $this->assertTrue($entity->isAccessible('eyecatch_delete'), 'eyecatch_deleteがaccessibleではありません');
+
+        // 値が設定されていることを確認
+        $this->assertEquals('tmp_file.jpg', $entity->get('eyecatch_tmp'));
+        $this->assertEquals('1', $entity->get('eyecatch_delete'));
+    }
+
+    /**
+     * test afterMarshal does not rollback on success
+     * バリデーションエラーがない場合はrollbackFileを呼ばない（eyecatch_tmpが設定されない）
+     */
+    public function testAfterMarshalNoRollbackOnSuccess()
+    {
+        $this->loadFixtureScenario(ContentsScenario::class);
+
+        // エラーなしのエンティティを直接作成（バリデーションをスキップ）
+        $entity = new Entity(['id' => 1, 'name' => 'valid_name', '_bc_upload_id' => 'test_no_err_id']);
+        $this->assertFalse($entity->hasErrors(), 'エラーなしであるべきです');
+
+        // afterMarshal を手動でディスパッチ
+        $result = $this->table->dispatchEvent('Model.afterMarshal', [
+            'entity' => $entity,
+            'options' => new ArrayObject(),
+        ]);
+        $updatedEntity = $result->getData('entity');
+
+        // エラーなしの場合はrollbackFileが呼ばれないため、eyecatch_tmpが設定されていないことを確認
+        $this->assertEmpty($updatedEntity->get('eyecatch_tmp'), 'エラーなしの場合はeyecatch_tmpが設定されるべきではありません');
+    }
 }

--- a/plugins/baser-core/tests/TestCase/Utility/BcFileUploaderTest.php
+++ b/plugins/baser-core/tests/TestCase/Utility/BcFileUploaderTest.php
@@ -267,7 +267,8 @@ class BcFileUploaderTest extends BcTestCase
         ];
         $entity = $this->BcFileUploader->saveTmpFiles($data, 1);
         $tmpId = $this->BcFileUploader->tmpId;
-        $this->assertEquals("00000001_eyecatch.png", $entity->eyecatch_tmp, 'saveTmpFiles()の返り値が正しくありません');
+        // タイムスタンプ付きファイル名を許容
+        $this->assertMatchesRegularExpression('/^00000001_eyecatch(_[0-9]+)?\\.png$/', $entity->eyecatch_tmp, 'saveTmpFiles()の返り値が正しくありません');
         $this->assertEquals(1, $tmpId, 'tmpIdが正しく設定されていません');
         //不要なフォルダを削除
         (new BcFolder($filePath))->delete();
@@ -294,8 +295,11 @@ class BcFileUploaderTest extends BcTestCase
 
         $entity = $this->table->patchEntity($this->table->newEmptyEntity(), $data);
         $this->BcFileUploader->tmpId = 1;
-        $this->BcFileUploader->saveTmpFile($this->BcFileUploader->settings['fields']['eyecatch'], $data, $entity);
-        $this->assertNotEmpty($_SESSION['Upload']['00000001_eyecatch_png']);
+        $fileName = $this->BcFileUploader->saveTmpFile($this->BcFileUploader->settings['fields']['eyecatch'], $data, $entity);
+        // タイムスタンプ付きファイル名を許容
+        $this->assertNotEmpty($fileName);
+        $sessionKey = str_replace(['.', '/'], ['_', '_'], $fileName);
+        $this->assertNotEmpty($_SESSION['Upload'][$sessionKey]);
         //不要なフォルダを削除
         (new BcFolder($filePath))->delete();
     }
@@ -320,9 +324,10 @@ class BcFileUploaderTest extends BcTestCase
         $entity = $this->table->patchEntity($this->table->newEmptyEntity(), $data);
         $this->BcFileUploader->tmpId = 1;
         $file = $this->BcFileUploader->getSaveTmpFileName($this->BcFileUploader->settings['fields']['eyecatch'], $data, $entity);
-        $this->assertEquals('00000001_eyecatch.png', $file);
-        $file = $this->BcFileUploader->getSaveTmpFileName(['name' => 'eyecatch'], $data, $entity);
-        $this->assertEquals('1_eyecatch.png', $file);
+        // タイムスタンプ付きファイル名を許容
+        $this->assertMatchesRegularExpression('/^00000001_eyecatch(_[0-9]+)?\\.png$/', $file);
+        $file2 = $this->BcFileUploader->getSaveTmpFileName(['name' => 'eyecatch'], $data, $entity);
+        $this->assertMatchesRegularExpression('/^1_eyecatch(_[0-9]+)?\\.png$/', $file2);
         //不要なフォルダを削除
         (new BcFolder($filePath))->delete();
     }
@@ -1372,5 +1377,286 @@ class BcFileUploaderTest extends BcTestCase
                 ['image' => 'new_image.jpg', 'document' => 'new_document.pdf']
             ],
         ];
+    }
+
+    /**
+     * test rollbackFile with session save
+     * バリデーションエラー時に新規アップロードファイルがセッションに保存される
+     */
+    public function testRollbackFileWithSessionSave()
+    {
+        $session = $this->BcFileUploader->Session;
+
+        // アップロードファイルを準備(/tmp/で始まるパス)
+        $tmpFile = '/tmp/test_upload_' . time() . '.jpg';
+        file_put_contents($tmpFile, 'test image data');
+
+        $uploadingFiles = [
+            'eyecatch' => [
+                'name' => 'test.jpg',
+                'tmp_name' => $tmpFile,
+                'type' => 'image/jpeg',
+                'size' => 100,
+                'error' => 0,
+                'ext' => 'jpg'
+            ]
+        ];
+
+        $this->BcFileUploader->settings['fields'] = [
+            ['name' => 'eyecatch', 'type' => 'image', 'namefield' => 'id']
+        ];
+
+        $entity = new Entity(['id' => 1, 'eyecatch' => 'old_image.jpg', '_bc_upload_id' => 'test123']);
+        $entity->clean();
+        $entity->set('eyecatch', 'new_image.jpg');
+        $entity->setError('eyecatch', ['validation error']);
+
+        $this->BcFileUploader->setUploadingFiles($uploadingFiles, 'test123');
+        $this->BcFileUploader->rollbackFile($entity);
+
+        // _tmp値が設定されていることを確認
+        $this->assertNotEmpty($entity->get('eyecatch_tmp'), '_tmp値が設定されていません');
+
+        // セッションに保存されていることを確認
+        $sessionKey = str_replace(['.', '/'], ['_', '_'], $entity->get('eyecatch_tmp'));
+        $sessionData = $session->read('Upload.' . $sessionKey . '.data');
+        $this->assertNotEmpty($sessionData, 'セッションにファイルデータが保存されていません');
+
+        // 元の値にロールバックされていることを確認
+        $this->assertEquals('old_image.jpg', $entity->get('eyecatch'), '元の値にロールバックされていません');
+
+        // エラーが保持されていることを確認
+        $this->assertNotEmpty($entity->getError('eyecatch'), 'エラーが保持されていません');
+
+        @unlink($tmpFile);
+    }
+
+    /**
+     * test rollbackFile preserves _tmp value
+     * ファイルなし時に既存の_tmp値を保持する
+     */
+    public function testRollbackFilePreservesTmpValue()
+    {
+        $this->BcFileUploader->settings['fields'] = [
+            ['name' => 'eyecatch']
+        ];
+
+        $entity = new Entity([
+            'id' => 1,
+            'eyecatch' => 'old_image.jpg',
+            'eyecatch_tmp' => 'existing_tmp_file.jpg',
+            '_bc_upload_id' => 'test123'
+        ]);
+        $entity->clean();
+        $entity->set('eyecatch', 'old_image.jpg'); // ファイルアップロードなし
+        $entity->setError('eyecatch', ['validation error']);
+
+        // アップロードファイルなし
+        $this->BcFileUploader->setUploadingFiles([], 'test123');
+        $this->BcFileUploader->rollbackFile($entity);
+
+        // 既存の_tmp値が保持されていることを確認
+        $this->assertEquals('existing_tmp_file.jpg', $entity->get('eyecatch_tmp'), '既存の_tmp値が保持されていません');
+
+        // 元の値が保持されていることを確認
+        $this->assertEquals('old_image.jpg', $entity->get('eyecatch'), '元の値が保持されていません');
+    }
+
+    /**
+     * test getSaveTmpFileName with timestamp
+     * タイムスタンプ付きファイル名でユニーク化される
+     */
+    public function testGetSaveTmpFileNameWithTimestamp()
+    {
+        $setting = [
+            'name' => 'eyecatch',
+            'namefield' => 'id',
+            'nameformat' => '%08d'
+        ];
+
+        $file = [
+            'name' => 'test.jpg',
+            'ext' => 'jpg'
+        ];
+
+        $entity = new Entity(['id' => 1]);
+
+        $fileName1 = $this->BcFileUploader->getSaveTmpFileName($setting, $file, $entity);
+
+        // タイムスタンプが含まれていることを確認
+        $this->assertMatchesRegularExpression('/_\d+\.jpg$/', $fileName1, 'タイムスタンプが含まれていません');
+
+        // ファイル名の形式を確認 (00000001_eyecatch_timestamp.jpg)
+        $this->assertStringContainsString('00000001_eyecatch', $fileName1, 'nameフィールドが正しく生成されていません');
+
+        // 2回生成すると異なるタイムスタンプになることを確認（ユニーク性）
+        sleep(1);
+        $fileName2 = $this->BcFileUploader->getSaveTmpFileName($setting, $file, $entity);
+        $this->assertNotEquals($fileName1, $fileName2, 'タイムスタンプによるユニーク化が機能していません');
+    }
+
+    /**
+     * test setupTmpData restores from session
+     * _tmp値があり新規ファイルなしの場合、セッションからファイルを復元する
+     */
+    public function testSetupTmpDataRestoresFromSession()
+    {
+        // セッションにファイルデータを設定
+        $tmpFileName = 'eyecatch_restore_test.jpg';
+        $sessionKey = str_replace(['.', '/'], ['_', '_'], $tmpFileName);
+        $testContent = 'fake image content for restore test';
+        $this->BcFileUploader->Session->write('Upload.' . $sessionKey . '.data', base64_encode($testContent));
+        $this->BcFileUploader->Session->write('Upload.' . $sessionKey . '.type', 'image/jpeg');
+
+        // ArrayObjectとして渡す（実際のbeforeMarshalと同じ形式）
+        $data = new \ArrayObject([
+            '_bc_upload_id' => 'test_restore_id',
+            'eyecatch_tmp' => $tmpFileName,
+            // eyecatch フィールドなし（新規ファイルなし）
+        ]);
+
+        $this->BcFileUploader->setupTmpData($data);
+
+        // セッションから復元されてuploadingFilesに設定されていることを確認
+        $uploadingFiles = $this->BcFileUploader->getUploadingFiles('test_restore_id');
+        $this->assertNotEmpty($uploadingFiles['eyecatch'], 'セッションからファイルが復元されていません');
+        $this->assertEquals($tmpFileName, $uploadingFiles['eyecatch']['name'], '復元されたファイル名が正しくありません');
+
+        // 後片付け
+        @unlink($this->savePath . $sessionKey);
+    }
+
+    /**
+     * test setupTmpData skips session when new file exists
+     * _tmp値があっても /tmp/ から始まる新規ファイルがある場合はセッション復元をスキップする
+     */
+    public function testSetupTmpDataSkipsSessionWhenNewFileExists()
+    {
+        // セッションにファイルデータを設定
+        $tmpFileName = 'eyecatch_skip_test.jpg';
+        $sessionKey = str_replace(['.', '/'], ['_', '_'], $tmpFileName);
+        $this->BcFileUploader->Session->write('Upload.' . $sessionKey . '.data', base64_encode('session image data'));
+        $this->BcFileUploader->Session->write('Upload.' . $sessionKey . '.type', 'image/jpeg');
+
+        // 新規ファイルが /tmp/ から始まる（新規アップロード）
+        $data = new \ArrayObject([
+            '_bc_upload_id' => 'test_skip_id',
+            'eyecatch_tmp' => $tmpFileName,
+            'eyecatch' => [
+                'name' => 'new_file.jpg',
+                'tmp_name' => '/tmp/php_upload_new_file_test',
+                'type' => 'image/jpeg',
+                'size' => 100,
+                'error' => 0,
+            ],
+        ]);
+
+        $this->BcFileUploader->setupTmpData($data);
+
+        // 新規ファイルがあるのでセッションから復元されていないことを確認
+        $uploadingFiles = $this->BcFileUploader->getUploadingFiles('test_skip_id');
+        $this->assertEmpty($uploadingFiles['eyecatch'] ?? null, '新規ファイルがある場合はセッションから復元すべきではありません');
+
+        @unlink($this->savePath . $sessionKey);
+    }
+
+    /**
+     * test saveTmpFiles preserves existing tmp session without new upload
+     * file_tmp だけの再送時に既存の Upload セッションを消さない
+     */
+    public function testSaveTmpFilesPreservesExistingTmpSessionWithoutNewUpload()
+    {
+        $tmpFileName = 'eyecatch_keep_session.jpg';
+        $sessionKey = str_replace(['.', '/'], ['_', '_'], $tmpFileName);
+        $testContent = 'fake image content for keep session test';
+        $this->BcFileUploader->Session->write('Upload.' . $sessionKey . '.data', base64_encode($testContent));
+        $this->BcFileUploader->Session->write('Upload.' . $sessionKey . '.type', 'image/jpeg');
+
+        $entity = $this->BcFileUploader->saveTmpFiles([
+            'eyecatch_tmp' => $tmpFileName
+        ], 1);
+
+        $this->assertEquals($tmpFileName, $entity->get('eyecatch_tmp'));
+        $this->assertEquals(base64_encode($testContent), $this->BcFileUploader->Session->read('Upload.' . $sessionKey . '.data'));
+        $this->assertEquals('image/jpeg', $this->BcFileUploader->Session->read('Upload.' . $sessionKey . '.type'));
+    }
+
+    /**
+     * test moveFileSessionToTmp returns false when session data is null
+     * セッションデータがnullの場合はfalseを返す（追加されたnullチェック）
+     */
+    public function testMoveFileSessionToTmpWithNullSession()
+    {
+        // セッションに何も書き込まない → null
+        $tmpFileName = 'nonexistent_session_file.jpg';
+        $data = [
+            '_bc_upload_id' => 'test_null_id',
+            'eyecatch_tmp' => $tmpFileName,
+        ];
+
+        $result = $this->BcFileUploader->moveFileSessionToTmp($data, 'eyecatch');
+
+        $this->assertFalse($result, 'セッションデータがnullの場合はfalseを返すべきです');
+    }
+
+    /**
+     * test rollbackFile with force=true
+     * $force=trueの場合、バリデーションエラーがなくても強制的にロールバックを実行する
+     */
+    public function testRollbackFileWithForce()
+    {
+        $BcFileUploader = new BcFileUploader();
+        $BcFileUploader->settings['fields'] = [
+            ['name' => 'image'],
+        ];
+        $BcFileUploader->setUploadingFiles([], 'test_force_id');
+
+        // エラーなしのエンティティ
+        $entity = new Entity(['image' => 'original_image.jpg', '_bc_upload_id' => 'test_force_id']);
+        $entity->clean();
+        $entity->set('image', 'new_image.jpg');
+
+        $this->assertFalse($entity->hasErrors());
+
+        // $force=false の場合: エラーなしなのでスキップ
+        $BcFileUploader->rollbackFile($entity, false);
+        $this->assertEquals('new_image.jpg', $entity->get('image'), '$force=falseでエラーなしの場合はロールバックしないべきです');
+
+        // $force=true の場合: エラーなしでも強制実行
+        $BcFileUploader->rollbackFile($entity, true);
+        $this->assertEquals('original_image.jpg', $entity->get('image'), '$force=trueでエラーなしでも元の値に戻るべきです');
+    }
+
+    /**
+     * test rollbackFile original tmp fallback
+     * entity->get('field_tmp')がnullのとき、getOriginal()のフォールバックが機能する
+     */
+    public function testRollbackFileOriginalTmpFallback()
+    {
+        $BcFileUploader = new BcFileUploader();
+        $BcFileUploader->settings['fields'] = [
+            ['name' => 'eyecatch'],
+        ];
+        $BcFileUploader->setUploadingFiles([], 'test_fallback_id');
+
+        // getOriginal()のみに_tmp値がある状態を再現:
+        // 1. eyecatch_tmpをoriginalに設定 (cleanにより元の値になる)
+        // 2. eyecatch_tmpをnullにdirtyにする (get()はnullを返す)
+        $entity = new Entity([
+            'eyecatch' => 'old.jpg',
+            'eyecatch_tmp' => 'original_tmp.jpg',
+            '_bc_upload_id' => 'test_fallback_id',
+        ]);
+        $entity->clean();
+        $entity->set('eyecatch_tmp', null); // get()はnull、getOriginal()は'original_tmp.jpg'
+        $entity->setError('eyecatch', ['validation error']);
+
+        $this->assertNull($entity->get('eyecatch_tmp'));
+        $this->assertEquals('original_tmp.jpg', $entity->getOriginal('eyecatch_tmp'));
+
+        $BcFileUploader->rollbackFile($entity);
+
+        // getOriginal()フォールバックで_tmp値が設定されていることを確認
+        $this->assertEquals('original_tmp.jpg', $entity->get('eyecatch_tmp'), 'getOriginal()フォールバックで_tmp値が設定されるべきです');
     }
 }

--- a/plugins/baser-core/tests/TestCase/View/Helper/BcBaserHelperTest.php
+++ b/plugins/baser-core/tests/TestCase/View/Helper/BcBaserHelperTest.php
@@ -1113,7 +1113,10 @@ class BcBaserHelperTest extends BcTestCase
      */
     public function testScripts()
     {
-        $themeConfigTag = '<link rel="stylesheet" type="text/css" href="/files/theme_configs/config.css" />';
+        $themeConfigTags = [
+            '<link rel="stylesheet" type="text/css" href="/files/theme_configs/config.css" />',
+            '<link rel="stylesheet" href="/files/theme_configs/config.css">'
+        ];
 
         // CSS
         $expected = '
@@ -1124,6 +1127,7 @@ class BcBaserHelperTest extends BcTestCase
         $this->BcBaser->css('admin/layout', false);
         $this->BcBaser->scripts();
         $result = ob_get_clean();
+        $result = str_replace($themeConfigTags, '', $result);
         $this->assertEquals($expected, $result);
 
         $view = $this->BcBaser->getView();
@@ -1140,7 +1144,7 @@ class BcBaserHelperTest extends BcTestCase
         ob_start();
         $this->BcBaser->scripts();
         $result = ob_get_clean();
-        $result = str_replace($themeConfigTag, '', $result);
+        $result = str_replace($themeConfigTags, '', $result);
         $this->assertEquals($expected, $result);
 
         $view->assign('script', '');

--- a/plugins/baser-core/tests/TestCase/View/Helper/BcFormHelperTest.php
+++ b/plugins/baser-core/tests/TestCase/View/Helper/BcFormHelperTest.php
@@ -808,4 +808,82 @@ class BcFormHelperTest extends BcTestCase
         $this->assertStringNotContainsString('<label>', $result);
     }
 
+    /**
+     * test control with table option
+     * tableオプションを使用したテーブル指定の動作確認
+     */
+    public function testControlWithTableOption()
+    {
+        // tableオプションを使用してアソシエーション先のテーブルを指定
+        $result = $this->BcForm->control('eyecatch', [
+            'type' => 'file',
+            'table' => 'Pages.content.eyecatch'
+        ]);
+
+        $this->assertStringContainsString('name="eyecatch"', $result, 'フィールド名が正しく出力されていません');
+        $this->assertStringContainsString('type="file"', $result, 'type属性が正しく出力されていません');
+    }
+
+    /**
+     * test file outputs hidden for _tmp value
+     * エンティティに{field}_tmp値がある場合、hidden[{field}_tmp]が出力される
+     */
+    public function testFileOutputsTmpHidden()
+    {
+        $contentsTable = $this->getTableLocator()->get('BaserCore.Contents');
+        $content = $contentsTable->newEmptyEntity();
+        $content->eyecatch_tmp = 'session_eyecatch_file.jpg';
+
+        $this->BcForm->create($content);
+        // BcUploadHelperにテーブルを指定（fileLink()が必要とする）
+        $result = $this->BcForm->file('eyecatch', ['table' => 'BaserCore.Contents']);
+
+        // _tmp hidden が出力されていることを確認
+        $this->assertStringContainsString('name="eyecatch_tmp"', $result, 'eyecatch_tmp hiddenが出力されていません');
+        $this->assertStringContainsString('value="session_eyecatch_file.jpg"', $result, '_tmpの値が正しくありません');
+    }
+
+    /**
+     * test file nested field outputs hidden for _tmp value
+     * ネストフィールド(content.eyecatch)でも_tmp hiddenが出力される
+     */
+    public function testFileNestedFieldTmpHidden()
+    {
+        PageFactory::make(['id' => 1])->persist();
+        ContentFactory::make(['id' => 1, 'plugin' => 'BaserCore', 'type' => 'Page', 'entity_id' => 1])->persist();
+
+        $pagesTable = $this->getTableLocator()->get('BaserCore.Pages');
+        $page = $pagesTable->find()->where(['Pages.id' => 1])->contain(['Contents'])->first();
+
+        // content.eyecatch_tmp を設定
+        $page->content->eyecatch_tmp = 'session_content_eyecatch.jpg';
+
+        $this->BcForm->create($page);
+        // BcUploadHelperにContentsTableを指定（ネストフィールドでも同じ）
+        $result = $this->BcForm->file('content.eyecatch', ['table' => 'BaserCore.Contents']);
+
+        // ネストフィールドの _tmp hidden が出力されていることを確認（CakePHP はブラケット記法を使用）
+        $this->assertStringContainsString('name="content[eyecatch_tmp]"', $result, 'content.eyecatch_tmp hiddenが出力されていません');
+        $this->assertStringContainsString('value="session_content_eyecatch.jpg"', $result, '_tmpの値が正しくありません');
+    }
+
+    /**
+     * test control type=file also outputs tmp hidden
+     * control()にtype='file'を指定した場合も_tmp hiddenが出力される
+     */
+    public function testControlTypeFileOutputsTmpHidden()
+    {
+        $contentsTable = $this->getTableLocator()->get('BaserCore.Contents');
+        $content = $contentsTable->newEmptyEntity();
+        $content->eyecatch_tmp = 'session_via_control.jpg';
+
+        $this->BcForm->create($content);
+        // BcUploadHelperにテーブルを指定（control(type=file)→file()経由でfileLink()が必要とする）
+        $result = $this->BcForm->control('eyecatch', ['type' => 'file', 'table' => 'BaserCore.Contents']);
+
+        // control(type='file')でも_tmp hiddenが出力されることを確認
+        $this->assertStringContainsString('name="eyecatch_tmp"', $result, 'control(type=file)でeyecatch_tmp hiddenが出力されていません');
+        $this->assertStringContainsString('value="session_via_control.jpg"', $result, '_tmpの値が正しくありません');
+    }
+
 }

--- a/plugins/baser-core/tests/TestCase/View/Helper/BcUploadHelperTest.php
+++ b/plugins/baser-core/tests/TestCase/View/Helper/BcUploadHelperTest.php
@@ -123,7 +123,7 @@ class BcUploadHelperTest extends BcTestCase
         $result = $this->BcUpload->uploadImage('image', new Content(['image' => 'template1.jpg']), $options);
         $this->assertMatchesRegularExpression('/^<a href=\"\/files\/contents\/template1\.jpg[^>]+?\"[^>]+?><img src=\"\/files\/contents\/template1\.jpg[^>]+?\"[^>]+?alt="" width="100" height="80"[^>]*?><\/a>/', $result);
 
-        // 一時ファイルへのリンク（デフォルトがリンク付だが、Aタグが出力されないのが正しい挙動）
+        // 一時ファイルへのリンク（デフォルトでは colorbox 付きリンクで拡大できる）
         $options = [
             'tmp' => true
         ];
@@ -131,7 +131,7 @@ class BcUploadHelperTest extends BcTestCase
             'eyecatch' => 'template1.jpg',
             'eyecatch_tmp' => 'test'
         ]), $options);
-        $expects = '<img src="/baser-core/uploads/tmp/medium/test" alt="">';
+        $expects = '<a href="/baser-core/uploads/tmp/test" rel="colorbox"><img src="/baser-core/uploads/tmp/medium/test" alt=""></a>';
         $this->assertEquals($expects, $result);
 
         $options = [
@@ -198,6 +198,66 @@ class BcUploadHelperTest extends BcTestCase
         $this->BcUpload->setTable('contents');
         // テーブルがセットされたかどうか確認する
         $this->assertEquals('contents', $this->getPrivateProperty($this->BcUpload, 'table')->getTable());
+    }
+
+    /**
+     * test fileLink with _tmp value
+     * {field}_tmp値がある場合、/baser-core/uploads/tmp/パスを使って優先表示する
+     */
+    public function testFileLinkWithTmpValue()
+    {
+        $data = [
+            'eyecatch' => 'original_image.jpg',
+            'eyecatch_tmp' => 'session_eyecatch_key.jpg',
+        ];
+        $result = $this->BcUpload->fileLink('eyecatch', new Content($data));
+
+        // セッション画像のパス(/baser-core/uploads/tmp/)が使われていることを確認
+        $this->assertStringContainsString('/baser-core/uploads/tmp/', $result, '_tmp値がある場合は/baser-core/uploads/tmp/パスを使うべきです');
+        // セッションキー変換: '.' と '/' が '_' に変換される
+        $expectedKey = str_replace('/', '_', 'session_eyecatch_key.jpg');
+        $this->assertStringContainsString($expectedKey, $result, 'セッションキーが正しく変換されていません');
+        $this->assertStringContainsString('rel="colorbox"', $result, 'tmp画像でもcolorboxリンクが付与されるべきです');
+    }
+
+    /**
+     * test uploadImage auto-detects _tmp value
+     * {field}_tmpがエンティティにセットされていれば、tmp=trueを明示しなくてもtmpパスで画像URLが生成される
+     */
+    public function testUploadImageAutoTmpValue()
+    {
+        $data = [
+            'eyecatch' => 'original_image.jpg',
+            'eyecatch_tmp' => 'session_og_image.jpg',
+        ];
+
+        // tmp=trueを明示しない（自動検出のテスト）
+        $result = $this->BcUpload->uploadImage('eyecatch', new Content($data));
+
+        // tmpパスが自動的に使われることを確認
+        $this->assertStringContainsString('/baser-core/uploads/tmp/', $result, '_tmp値がある場合は自動的にtmpパスを使うべきです');
+        // セッションキー変換: '.' と '/' が '_' に変換される
+        $expectedKey = str_replace('/', '_', 'session_og_image.jpg');
+        $this->assertStringContainsString($expectedKey, $result, 'セッションキーが正しく変換されていません');
+        $this->assertStringContainsString('href="/baser-core/uploads/tmp/' . $expectedKey . '"', $result, 'tmp画像の拡大リンク先は元サイズであるべきです');
+        $this->assertStringContainsString('rel="colorbox"', $result, 'tmp画像でもcolorboxリンクが付与されるべきです');
+    }
+
+    /**
+     * test uploadImage tmp with link false
+     * tmp画像でも link=false が明示された場合はリンクを出力しない
+     */
+    public function testUploadImageTmpWithLinkFalse()
+    {
+        $result = $this->BcUpload->uploadImage('eyecatch', new Content([
+            'eyecatch' => 'template1.jpg',
+            'eyecatch_tmp' => 'test'
+        ]), [
+            'tmp' => true,
+            'link' => false,
+        ]);
+
+        $this->assertEquals('<img src="/baser-core/uploads/tmp/medium/test" alt="">', $result);
     }
 
 }

--- a/plugins/bc-blog/tests/TestCase/Controller/BlogControllerTest.php
+++ b/plugins/bc-blog/tests/TestCase/Controller/BlogControllerTest.php
@@ -349,7 +349,9 @@ class BlogControllerTest extends BcTestCase
         $this->assertResponseSuccess();
         $vars = $this->_controller->viewBuilder()->getVars();
         $this->assertEquals('tag1', $vars['tag']);
-        $this->assertEquals(1, $vars['posts']->toArray()[0]->id);
+        $postIds = array_map(fn($post) => $post->id, $vars['posts']->toArray());
+        sort($postIds);
+        $this->assertSame([1, 2], $postIds);
     }
 
     /**

--- a/plugins/bc-blog/tests/TestCase/View/Helper/BlogHelperTest.php
+++ b/plugins/bc-blog/tests/TestCase/View/Helper/BlogHelperTest.php
@@ -973,7 +973,7 @@ class BlogHelperTest extends BcTestCase
         // 一時保存データと画像サイズのテスト
         $options = ['table' => 'BcBlog.BlogPosts', 'tmp' => true, 'imgsize' => 'mobile_thumb'];
         $result = $this->Blog->getEyeCatch($post, $options);
-        $expected = '/\<img src\=\"\/baser-core\/uploads\/tmp\/mobile_thumb\/test-eye_catch_jpg\"/';
+        $expected = '/\<img src\=\"\/baser-core\/uploads\/tmp\/mobile_thumb\/test-eye_catch\.jpg\"/';
         $this->assertMatchesRegularExpression($expected, $result, 'アイキャッチ画像を正しく取得できません');
 
         // class属性のテスト

--- a/plugins/bc-mail/src/Controller/MailController.php
+++ b/plugins/bc-mail/src/Controller/MailController.php
@@ -196,11 +196,23 @@ class MailController extends MailFrontAppController
                 $this->getRequest()->getData('captcha_id'),
                 $this->getRequest()->getData('auth_captcha')
             )) {
+                // 別途バリデーションを行い、キャプチャのエラーとマージしてセット
+                $mailMessagesService->setup($mailContent->id, $this->getRequest()->getData());
+                $validateEntity = $mailMessagesService->MailMessages->newEntity($this->getRequest()->getData());
+                if (!$validateEntity->getErrors()) {
+                    $validateEntity = $mailMessagesService->MailMessages->saveTmpFiles(
+                        $this->getRequest()->getData(),
+                        mt_rand(0, 99999999)
+                    );
+                }
+
                 // newEntity() だと配列が消えてしまうため、エンティティクラスで直接変換
                 $mailMessage = new MailMessage($this->getRequest()->getData(), ['source' => 'BcMail.MailMessages']);
-
-                // 別途バリデーションを行い、キャプチャのエラーとマージしてセット
-                $validateEntity = $mailMessagesService->MailMessages->newEntity($this->getRequest()->getData());
+                foreach ($validateEntity->toArray() as $key => $value) {
+                    if (str_ends_with((string) $key, '_tmp') && $value) {
+                        $mailMessage->set($key, $value);
+                    }
+                }
                 $errors = $validateEntity->getErrors();
                 $errors['auth_captcha'] = __d('baser_core', '画像の文字が間違っています。再度入力してください。');
                 $mailMessage->setErrors($errors);

--- a/plugins/bc-mail/src/Model/Table/MailMessagesTable.php
+++ b/plugins/bc-mail/src/Model/Table/MailMessagesTable.php
@@ -203,6 +203,14 @@ class MailMessagesTable extends MailAppTable
         $this->_validGroupComplete($entity);
         // バリデートグループエラーチェック
         $this->_validGroupErrorCheck($entity);
+
+        // バリデーションエラー時のファイルセッション保存（管理画面と同様）
+        if ($entity->getErrors() && $this->hasBehavior('BcUpload')) {
+            $behavior = $this->getBehavior('BcUpload');
+            if (isset($behavior->BcFileUploader[$this->getAlias()])) {
+                $behavior->BcFileUploader[$this->getAlias()]->rollbackFile($entity);
+            }
+        }
     }
 
     /**
@@ -449,7 +457,7 @@ class MailMessagesTable extends MailAppTable
         $dists = [];
         foreach($this->mailFields as $mailField) {
             // 対象フィールドがあれば、バリデートグループごとに配列に格納する
-            $valids = explode(',', $mailField->valid_ex);
+            $valids = explode(',', (string) $mailField->valid_ex);
             if (in_array('VALID_GROUP_COMPLATE', $valids)) {
                 $dists[$mailField->group_valid][] = [
                     'name' => $mailField->field_name,

--- a/plugins/bc-mail/src/Service/Front/MailFrontService.php
+++ b/plugins/bc-mail/src/Service/Front/MailFrontService.php
@@ -198,6 +198,14 @@ class MailFrontService implements MailFrontServiceInterface
             // newEntity() だと配列が消えてしまうため、エンティティクラスで直接変換
             $mailMessage = new MailMessage($postData, ['source' => 'BcMail.MailMessages']);
             $mailMessage->setErrors($message->getErrors());
+
+            // afterMarshal() が新規に設定した _tmp 値も含めて引き継ぐ
+            foreach ($message->toArray() as $key => $value) {
+                if (str_ends_with((string) $key, '_tmp') && $value) {
+                    $mailMessage->set($key, $value);
+                }
+            }
+
             throw new PersistenceFailedException($mailMessage, __d('baser_core', 'エラー : 入力内容を確認して再度送信してください。'));
         }
     }

--- a/plugins/bc-mail/src/View/Helper/MailformHelper.php
+++ b/plugins/bc-mail/src/View/Helper/MailformHelper.php
@@ -75,25 +75,18 @@ class MailformHelper extends BcFreezeHelper
         if(!empty($attributes['text_rows'])) $attributes['rows'] = $attributes['text_rows'];
         unset($attributes['options'], $attributes['regex'], $attributes['text_rows']);
 
-        if ($this->freezed) {
-            unset($attributes['type']);
-        }
-
         $out = '';
         switch ($type) {
-
             case 'text':
                 unset($attributes['rows']);
                 unset($attributes['empty']);
                 $out = $this->text($fieldName, $attributes);
                 break;
-
-			case 'email':
-				unset($attributes['rows']);
-				unset($attributes['empty']);
-				$out = $this->email($fieldName, $attributes);
-				break;
-
+            case 'email':
+                unset($attributes['rows']);
+                unset($attributes['empty']);
+                $out = $this->email($fieldName, $attributes);
+                break;
             case 'radio':
                 unset($attributes['size']);
                 unset($attributes['rows']);
@@ -108,7 +101,6 @@ class MailformHelper extends BcFreezeHelper
                 $out = $this->hidden($fieldName, ['value' => '']);
                 $out .= $this->radio($fieldName, $options, $attributes);
                 break;
-
             case 'select':
                 unset($attributes['size']);
                 unset($attributes['rows']);
@@ -129,7 +121,6 @@ class MailformHelper extends BcFreezeHelper
                 $attributes['empty'] = $showEmpty;
                 $out = $this->select($fieldName, $options, $attributes);
                 break;
-
             case 'pref':
                 unset($attributes['size']);
                 unset($attributes['rows']);
@@ -137,7 +128,6 @@ class MailformHelper extends BcFreezeHelper
                 unset($attributes['empty']);
                 $out = $this->prefTag($fieldName, null, $attributes, true);
                 break;
-
             case 'autozip':
                 unset($attributes['rows']);
                 unset($attributes['empty']);
@@ -157,7 +147,6 @@ class MailformHelper extends BcFreezeHelper
                         'style' => 'width:auto!important'
                     ]));
                 break;
-
             case 'check':
                 unset($attributes['size']);
                 unset($attributes['rows']);
@@ -165,7 +154,6 @@ class MailformHelper extends BcFreezeHelper
                 unset($attributes['empty']);
                 $out = $this->checkbox($fieldName, $attributes);
                 break;
-
             case 'multi_check':
                 unset($attributes['size']);
                 unset($attributes['rows']);
@@ -221,9 +209,7 @@ class MailformHelper extends BcFreezeHelper
                 unset($attributes['maxFileSize']);
                 unset($attributes['fileExt']);
                 $out .= $this->file($fieldName, $attributes);
-
                 break;
-
             case 'date_time_calender':
                 unset($attributes['size']);
                 unset($attributes['rows']);
@@ -231,7 +217,6 @@ class MailformHelper extends BcFreezeHelper
                 unset($attributes['empty']);
                 $out = $this->datepicker($fieldName, $attributes);
                 break;
-
             case 'textarea':
                 $attributes['cols'] = $attributes['size'];
                 unset($attributes['empty']);
@@ -241,14 +226,12 @@ class MailformHelper extends BcFreezeHelper
                 }
                 $out = $this->textarea($fieldName, $attributes);
                 break;
-
             case 'tel':
                 unset($attributes['rows']);
                 unset($attributes['empty']);
                 $attributes['type'] = 'tel';
                 $out = $this->tel($fieldName, $attributes);
                 break;
-
 			case 'number':
 				unset($attributes['separator']);
 				unset($attributes['rows']);
@@ -256,17 +239,16 @@ class MailformHelper extends BcFreezeHelper
 				$attributes['type'] = 'number';
 				$out = $this->number($fieldName, $attributes);
 				break;
-
             case 'password':
                 unset($attributes['rows']);
                 unset($attributes['empty']);
                 $out = $this->password($fieldName, $attributes);
                 break;
-
             case 'hidden':
                 unset($attributes['rows']);
                 unset($attributes['empty']);
                 $out = $this->hidden($fieldName, $attributes);
+                break;
         }
         return $out;
     }
@@ -292,6 +274,25 @@ class MailformHelper extends BcFreezeHelper
             $options['url'] = $this->BcContents->getPureUrl($options['url'], $this->_View->getRequest()->getAttribute('currentSite')->id);
         }
         return parent::create($context, $options);
+    }
+
+    /**
+     * ファイルタグを出力
+     *
+     * MailMessages テーブルの BcUpload 設定を利用して
+     * front 側でも tmp プレビューと確認画面のリンク表示を有効にする。
+     *
+     * @param string $fieldName
+     * @param array $options
+     * @return string
+     */
+    public function file($fieldName, $options = []): string
+    {
+        $options = array_merge([
+            'table' => 'BcMail.MailMessages'
+        ], $options);
+
+        return parent::file($fieldName, $options);
     }
 
     /**

--- a/plugins/bc-mail/tests/TestCase/Model/Table/MailMessagesTableTest.php
+++ b/plugins/bc-mail/tests/TestCase/Model/Table/MailMessagesTableTest.php
@@ -15,6 +15,7 @@ use BaserCore\TestSuite\BcTestCase;
 use BcMail\Model\Entity\MailMessage;
 use BcMail\Model\Table\MailFieldsTable;
 use BcMail\Model\Table\MailMessagesTable;
+use BcMail\Service\MailMessagesServiceInterface;
 use BcMail\Test\Factory\MailFieldsFactory;
 use BcMail\Test\Scenario\MailFieldsScenario;
 use BcMail\Test\TestCase\Model\Array;
@@ -701,6 +702,56 @@ class MailMessagesTableTest extends BcTestCase
         $this->MailMessage->afterMarshal($event);
         $entity = $event->getData('entity');
         $this->assertCount(1, $entity->getErrors()['_not_complate']);
+    }
+
+    /**
+     * test afterMarshal calls rollbackFile
+     * バリデーションエラー時にrollbackFile()が呼ばれることを確認
+     */
+    public function testAfterMarshalCallsRollbackFile()
+    {
+        // prepare
+        MailFieldsFactory::make([
+            'id' => 101,
+            'mail_content_id' => 1,
+            'field_name' => 'file',
+            'type' => 'file',
+            'use_field' => 1,
+            'valid' => '1', // 必須フィールド
+        ])->persist();
+        MailFieldsFactory::make([
+            'id' => 102,
+            'mail_content_id' => 1,
+            'field_name' => 'name',
+            'type' => 'text',
+            'use_field' => 1,
+            'valid' => '1', // 必須フィールド
+        ])->persist();
+
+        // テーブルを作成
+        $messagesService = $this->getService(MailMessagesServiceInterface::class);
+        $messagesService->createTable(1);
+
+        $this->MailMessage->setup(1, ['name' => '', 'file_tmp' => '1_file_1234567890.jpg']);
+
+        // バリデーションエラーを持つエンティティを作成（nameが空で必須エラー）
+        $mailMessage = $this->MailMessage->newEntity([
+            'name' => '', // 必須フィールドが空
+            'file_tmp' => '1_file_1234567890.jpg',
+        ]);
+
+        // _bc_upload_idを設定（BcUploadBehaviorが使用）
+        $mailMessage->_bc_upload_id = 'test_upload_id';
+
+        // バリデーションエラーがあることを確認
+        $this->assertTrue($mailMessage->hasErrors());
+
+        // file_tmp値が保持されることを確認（rollbackFile()が呼ばれた証拠）
+        $this->assertNotEmpty($mailMessage->get('file_tmp'));
+        $this->assertEquals('1_file_1234567890.jpg', $mailMessage->get('file_tmp'));
+
+        // テーブルを削除
+        $messagesService->dropTable(1);
     }
 
 }

--- a/plugins/bc-mail/tests/TestCase/Service/Front/MailFrontServiceTest.php
+++ b/plugins/bc-mail/tests/TestCase/Service/Front/MailFrontServiceTest.php
@@ -30,10 +30,12 @@ use BcMail\Test\Factory\MailContentFactory;
 use BcMail\Test\Scenario\MailContentsScenario;
 use BcMail\Test\Scenario\MailFieldsScenario;
 use Cake\ORM\Entity;
+use Cake\ORM\Exception\PersistenceFailedException;
 use Cake\TestSuite\EmailTrait;
 use Cake\TestSuite\IntegrationTestTrait;
 use CakephpFixtureFactories\Scenario\ScenarioAwareTrait;
 use InvalidArgumentException;
+use Laminas\Diactoros\UploadedFile;
 
 /**
  * MailContentsServiceTest
@@ -369,6 +371,167 @@ class MailFrontServiceTest extends BcTestCase
         $result = $this->MailFrontService->confirm($mailContent, $postData);
         $this->assertInstanceOf(MailMessage::class, $result);
         $this->assertEquals('Nghiem 1', $result['name_1']);
+    }
+
+    /**
+     * test confirm keeps tmp field on validation error
+     */
+    public function test_confirmKeepsTmpFieldOnValidationError()
+    {
+        $this->loadFixtureScenario(InitAppScenario::class);
+        $this->loadFixtureScenario(MailContentsScenario::class);
+        $this->loadFixtureScenario(MailFieldsScenario::class);
+
+        MailFieldsFactory::make([
+            'id' => 98,
+            'mail_content_id' => 1,
+            'name' => '添付',
+            'field_name' => 'file_1',
+            'type' => 'file',
+            'use_field' => 1,
+            'valid' => 0,
+            'options' => 'fileExt|jpg',
+            'valid_ex' => 'VALID_FILE_EXT',
+        ])->persist();
+        MailFieldsFactory::make([
+            'id' => 99,
+            'mail_content_id' => 1,
+            'name' => '必須項目',
+            'field_name' => 'required_name',
+            'type' => 'text',
+            'use_field' => 1,
+            'valid' => 1,
+        ])->persist();
+
+        $tmpFile = tempnam('/tmp', 'mail_front_service_');
+        $jpgFile = $tmpFile . '.jpg';
+        rename($tmpFile, $jpgFile);
+        file_put_contents($jpgFile, 'dummy');
+        $upload = new UploadedFile(
+            $jpgFile,
+            0,
+            UPLOAD_ERR_OK,
+            'dummy.jpg',
+            'image/jpeg'
+        );
+
+        $mailMessagesService = $this->getService(MailMessagesServiceInterface::class);
+        $mailMessagesService->createTable(1);
+        $postData = [
+            'name_1' => '姓',
+            'name_2' => '名',
+            'required_name' => '',
+            'file_1' => $upload,
+        ];
+        $mailMessagesService->setup(1, $postData);
+
+        $MailContentsService = $this->getService(MailContentsServiceInterface::class);
+        $mailContent = $MailContentsService->get(1);
+
+        $this->expectException(PersistenceFailedException::class);
+
+        try {
+            $this->MailFrontService->confirm($mailContent, $postData);
+        } catch (PersistenceFailedException $e) {
+            $entity = $e->getEntity();
+            $this->assertNotEmpty($entity->get('file_1_tmp'));
+            $this->assertStringEndsWith('.jpg', $entity->get('file_1_tmp'));
+            throw $e;
+        }
+    }
+
+    /**
+     * test confirm keeps tmp field on success
+     */
+    public function test_confirmKeepsTmpFieldOnSuccess()
+    {
+        $this->loadFixtureScenario(InitAppScenario::class);
+        $this->loadFixtureScenario(MailContentsScenario::class);
+        $this->loadFixtureScenario(MailFieldsScenario::class);
+
+        MailFieldsFactory::make([
+            'id' => 97,
+            'mail_content_id' => 1,
+            'name' => '添付',
+            'field_name' => 'file_1',
+            'type' => 'file',
+            'use_field' => 1,
+            'valid' => 0,
+            'options' => 'fileExt|jpg',
+            'valid_ex' => 'VALID_FILE_EXT',
+        ])->persist();
+
+        $tmpFile = tempnam('/tmp', 'mail_front_service_success_');
+        $jpgFile = $tmpFile . '.jpg';
+        rename($tmpFile, $jpgFile);
+        file_put_contents($jpgFile, 'dummy');
+        $upload = new UploadedFile(
+            $jpgFile,
+            0,
+            UPLOAD_ERR_OK,
+            'dummy.jpg',
+            'image/jpeg'
+        );
+
+        $mailMessagesService = $this->getService(MailMessagesServiceInterface::class);
+        $mailMessagesService->createTable(1);
+        $postData = [
+            'name_1' => '姓',
+            'name_2' => '名',
+            'file_1' => $upload,
+        ];
+        $mailMessagesService->setup(1, $postData);
+
+        $MailContentsService = $this->getService(MailContentsServiceInterface::class);
+        $mailContent = $MailContentsService->get(1);
+
+        $result = $this->MailFrontService->confirm($mailContent, $postData);
+
+        $this->assertInstanceOf(MailMessage::class, $result);
+        $this->assertNotEmpty($result->get('file_1_tmp'));
+        $this->assertNotEmpty($result->get('file_1'));
+    }
+
+    /**
+     * test confirm keeps existing tmp field without re-upload
+     */
+    public function test_confirmKeepsExistingTmpFieldWithoutReupload()
+    {
+        $this->loadFixtureScenario(InitAppScenario::class);
+        $this->loadFixtureScenario(MailContentsScenario::class);
+        $this->loadFixtureScenario(MailFieldsScenario::class);
+
+        MailFieldsFactory::make([
+            'id' => 96,
+            'mail_content_id' => 1,
+            'name' => '添付',
+            'field_name' => 'file_1',
+            'type' => 'file',
+            'use_field' => 1,
+            'valid' => 0,
+            'options' => 'fileExt|jpg',
+            'valid_ex' => 'VALID_FILE_EXT',
+        ])->persist();
+
+        $mailMessagesService = $this->getService(MailMessagesServiceInterface::class);
+        $mailMessagesService->createTable(1);
+        $postData = [
+            'name_1' => '姓',
+            'name_2' => '名',
+            'file_1_tmp' => '1_file_1234567890.jpg',
+        ];
+        $mailMessagesService->setup(1, $postData);
+
+        // rollback 後に再送される hidden 値だけの状態を再現
+        $entity = $mailMessagesService->MailMessages->newEntity($postData);
+        $this->assertEquals('1_file_1234567890.jpg', $entity->get('file_1_tmp'));
+
+        $MailContentsService = $this->getService(MailContentsServiceInterface::class);
+        $mailContent = $MailContentsService->get(1);
+
+        $result = $this->MailFrontService->confirm($mailContent, $postData);
+
+        $this->assertEquals('1_file_1234567890.jpg', $result->get('file_1_tmp'));
     }
 
     /**

--- a/plugins/bc-mail/tests/TestCase/View/Helper/MailformHelperTest.php
+++ b/plugins/bc-mail/tests/TestCase/View/Helper/MailformHelperTest.php
@@ -16,8 +16,11 @@ use BaserCore\TestSuite\BcTestCase;
 use BaserCore\View\Helper\BcBaserHelper;
 use BcMail\Model\Entity\MailField;
 use BcMail\Test\Factory\MailContentFactory;
+use BcMail\Test\Factory\MailFieldsFactory;
 use BcMail\Test\Factory\MailMessagesFactory;
+use BcMail\Service\MailMessagesServiceInterface;
 use BcMail\Service\MailFieldsServiceInterface;
+use BcMail\Model\Entity\MailMessage;
 use BcMail\View\Helper\MailformHelper;
 use BcMail\Test\Scenario\MailContentsScenario;
 use BcMail\Test\Scenario\MailFieldsScenario;
@@ -26,6 +29,9 @@ use Cake\ORM\ResultSet;
 use Cake\View\View;
 use CakephpFixtureFactories\Scenario\ScenarioAwareTrait;
 
+/**
+ * @property MailformHelper $MailformHelper
+ */
 class MailformHelperTest extends BcTestCase
 {
     /**
@@ -148,5 +154,42 @@ class MailformHelperTest extends BcTestCase
         $mailFields = $MailFieldsService->getIndex(1)->all();
         $rs = $this->MailformHelper->getGroupValidErrors($mailFields, 'field_name');
         $this->assertEquals([], $rs);
+    }
+
+    /**
+     * test file control renders tmp preview on front form
+     */
+    public function testControlFileWithTmpPreview()
+    {
+        $this->loadFixtureScenario(MailContentsScenario::class);
+        $this->loadFixtureScenario(MailFieldsScenario::class);
+        MailFieldsFactory::make([
+            'id' => 99,
+            'mail_content_id' => 1,
+            'name' => '添付',
+            'field_name' => 'file_1',
+            'type' => 'file',
+            'use_field' => 1,
+            'options' => 'fileExt|jpg',
+            'valid_ex' => 'VALID_FILE_EXT',
+        ])->persist();
+
+        $mailMessagesService = $this->getService(MailMessagesServiceInterface::class);
+        $mailMessagesService->setup(1, ['file_1_tmp' => '1_file_1234567890.jpg']);
+
+        $view = new MailFrontAppView($this->getRequest('/contact/'));
+        $view->setPlugin('BcMail');
+        $this->MailformHelper = new MailformHelper($view);
+        $this->MailformHelper->freeze();
+
+        $entity = new MailMessage([
+            'file_1_tmp' => '1_file_1234567890.jpg'
+        ], ['source' => 'BcMail.MailMessages']);
+
+        $this->MailformHelper->create($entity);
+        $result = $this->MailformHelper->control('file_1', ['type' => 'file']);
+
+        $this->assertStringContainsString('name="file_1_tmp"', $result);
+        $this->assertStringContainsString('/baser-core/uploads/tmp/', $result);
     }
 }

--- a/plugins/bc-seo/src/Event/BcSeoModelEventListener.php
+++ b/plugins/bc-seo/src/Event/BcSeoModelEventListener.php
@@ -17,6 +17,7 @@ use BaserCore\Utility\BcContainerTrait;
 use BaserCore\Utility\BcUtil;
 use Cake\Collection\CollectionInterface;
 use Cake\Core\Configure;
+use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
 use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\TableRegistry;
@@ -32,6 +33,7 @@ class BcSeoModelEventListener extends BcModelEventListener
     public $events = [
         'beforeFind',
         'beforeMarshal',
+        'afterMarshal',
     ];
 
     private bool $isEdit;
@@ -75,6 +77,52 @@ class BcSeoModelEventListener extends BcModelEventListener
                 }
                 return $results;
             });
+        }
+    }
+
+    /**
+     * afterMarshal
+     *
+     * バリデーションエラー時に SeoMetas の og_image などファイルフィールドを
+     * セッションにロールバックして次回レンダリング時に復元できるようにする
+     */
+    public function afterMarshal(EventInterface $event, EntityInterface $entity, ArrayObject $data, ArrayObject $options)
+    {
+        if (!$this->isEdit()) {
+            return;
+        }
+        if (!$entity->getErrors()) {
+            return;
+        }
+
+        // entity->seo_meta（CustomEntries など直接アソシエーション）
+        $seoMetaEntity = null;
+        if (isset($entity->seo_meta) && $entity->seo_meta instanceof EntityInterface) {
+            $seoMetaEntity = $entity->seo_meta;
+        // entity->content->seo_meta（Pages/BlogContents など Content 経由）
+        } elseif (isset($entity->content) && $entity->content instanceof EntityInterface
+            && isset($entity->content->seo_meta) && $entity->content->seo_meta instanceof EntityInterface
+        ) {
+            $seoMetaEntity = $entity->content->seo_meta;
+        }
+
+        if (!$seoMetaEntity) {
+            return;
+        }
+
+        $seoMetasTable = TableRegistry::getTableLocator()->get('BcSeo.SeoMetas');
+        if (!$seoMetasTable->hasBehavior('BcUpload')) {
+            return;
+        }
+
+        $uploadBehavior = $seoMetasTable->getBehavior('BcUpload');
+        $uploadBehavior->BcFileUploader[$seoMetasTable->getAlias()]->rollbackFile($seoMetaEntity, true);
+
+        // Pages/BlogContents などの content->seo_meta 経由の場合、
+        // フォームレンダリング時に context()->val('seo_meta.*') が entity->seo_meta を参照するため
+        // rollbackFile 後の seoMetaEntity で同期する
+        if (!isset($entity->seo_meta) || !($entity->seo_meta instanceof EntityInterface)) {
+            $entity->seo_meta = $seoMetaEntity;
         }
     }
 

--- a/plugins/bc-seo/tests/TestCase/Event/BcSeoModelEventListenerTest.php
+++ b/plugins/bc-seo/tests/TestCase/Event/BcSeoModelEventListenerTest.php
@@ -18,6 +18,7 @@ use BcBlog\Test\Factory\BlogPostFactory;
 use BcBlog\Test\Scenario\BlogContentScenario;
 use BcSeo\Event\BcSeoModelEventListener;
 use Cake\Event\Event;
+use Cake\ORM\Entity;
 use Cake\ORM\TableRegistry;
 use CakephpFixtureFactories\Scenario\ScenarioAwareTrait;
 
@@ -72,5 +73,127 @@ class BcSeoModelEventListenerTest extends BcTestCase
         $options = $event->getData('options');
         // associated確認
         $this->assertContains('SeoMetas', $options['associated']);
+    }
+
+    /**
+     * testAfterMarshal with direct seo_meta
+     * entity->seo_meta直接アソシエーション時にバリデーションエラーでog_image_tmpが保持される
+     */
+    public function testAfterMarshalWithDirectSeoMeta()
+    {
+        $this->loadFixtureScenario(BlogContentScenario::class, 1, 1, null, 'test', '/test');
+        BlogPostFactory::make(['id' => 1, 'blog_content_id' => 1, 'blog_category_id' => 1, 'status' => true])
+            ->persist();
+        $this->loginAdmin($this->getRequest('/baser/admin/bc-blog/blog_posts/edit/1/1'));
+        $blogPostsTable = TableRegistry::getTableLocator()->get('BcBlog.BlogPosts');
+        $seoMetasTable = TableRegistry::getTableLocator()->get('BcSeo.SeoMetas');
+
+        // SeoMetasTable に BcUpload がある場合のみテストを実行
+        if (!$seoMetasTable->hasBehavior('BcUpload')) {
+            $this->markTestSkipped('SeoMetasTableにBcUploadビヘイビアがありません');
+            return;
+        }
+
+        // entity->seo_meta を直接セット
+        $seoMeta = new Entity(['og_image' => 'old_og.jpg', 'og_image_tmp' => 'session_og_image.jpg', '_bc_upload_id' => 'test_direct_id']);
+        $seoMeta->clean(); // cleanしてoriginalに設定
+        $seoMeta->set('og_image', 'new_og.jpg'); // dirty（rollbackで元に戻るはず）
+
+        $entity = new Entity(['title' => '', '_bc_upload_id' => 'test_direct_entity_id']);
+        $entity->seo_meta = $seoMeta;
+        $entity->setError('title', ['required']);
+
+        $listener = new BcSeoModelEventListener();
+        $event = new Event('afterMarshal', $blogPostsTable, ['options' => []]);
+        $listener->afterMarshal($event, $entity, new ArrayObject(), new ArrayObject());
+
+        // entity->seo_meta.og_image_tmpが保持されていることを確認
+        $this->assertEquals(
+            'session_og_image.jpg',
+            $entity->seo_meta->get('og_image_tmp'),
+            'entity->seo_meta経由でog_image_tmpが保持されるべきです'
+        );
+        // og_imageが元の値にロールバックされていることを確認
+        $this->assertEquals(
+            'old_og.jpg',
+            $entity->seo_meta->get('og_image'),
+            'rollbackFileによりog_imageが元の値に戻るべきです'
+        );
+    }
+
+    /**
+     * testAfterMarshal with content->seo_meta
+     * entity->content->seo_meta経由でバリデーションエラー時にog_image_tmpが保持される
+     */
+    public function testAfterMarshalWithContentSeoMeta()
+    {
+        $this->loadFixtureScenario(BlogContentScenario::class, 1, 1, null, 'test', '/test');
+        BlogPostFactory::make(['id' => 1, 'blog_content_id' => 1, 'blog_category_id' => 1, 'status' => true])
+            ->persist();
+        $this->loginAdmin($this->getRequest('/baser/admin/bc-blog/blog_posts/edit/1/1'));
+        $blogPostsTable = TableRegistry::getTableLocator()->get('BcBlog.BlogPosts');
+        $seoMetasTable = TableRegistry::getTableLocator()->get('BcSeo.SeoMetas');
+
+        // SeoMetasTable に BcUpload がある場合のみテストを実行
+        if (!$seoMetasTable->hasBehavior('BcUpload')) {
+            $this->markTestSkipped('SeoMetasTableにBcUploadビヘイビアがありません');
+            return;
+        }
+
+        // entity->content->seo_meta 経由のアソシエーション
+        $seoMeta = new Entity(['og_image_tmp' => 'session_content_og.jpg', '_bc_upload_id' => 'test_content_seo_id']);
+        $content = new Entity();
+        $content->seo_meta = $seoMeta;
+
+        $entity = new Entity(['_bc_upload_id' => 'test_content_entity_id']);
+        $entity->content = $content;
+        $entity->setError('title', ['required']);
+
+        $listener = new BcSeoModelEventListener();
+        $event = new Event('afterMarshal', $blogPostsTable, ['options' => []]);
+        $listener->afterMarshal($event, $entity, new ArrayObject(), new ArrayObject());
+
+        // entity->seo_meta に同期されており、og_image_tmpが保持されていることを確認
+        $this->assertInstanceOf(Entity::class, $entity->seo_meta, 'entity->seo_metaが同期されているべきです');
+        $this->assertEquals(
+            'session_content_og.jpg',
+            $entity->seo_meta->get('og_image_tmp'),
+            'entity->content->seo_meta経由でog_image_tmpが保持されるべきです'
+        );
+    }
+
+    /**
+     * testAfterMarshal no action on success
+     * バリデーションエラーがない場合はafterMarshalは何もしない
+     */
+    public function testAfterMarshalNoActionOnSuccess()
+    {
+        $this->loadFixtureScenario(BlogContentScenario::class, 1, 1, null, 'test', '/test');
+        BlogPostFactory::make(['id' => 1, 'blog_content_id' => 1, 'blog_category_id' => 1, 'status' => true])
+            ->persist();
+        $this->loginAdmin($this->getRequest('/baser/admin/bc-blog/blog_posts/edit/1/1'));
+        $blogPostsTable = TableRegistry::getTableLocator()->get('BcBlog.BlogPosts');
+
+        // エラーなしエンティティ + seo_meta with dirty og_image
+        $seoMeta = new Entity(['og_image' => 'original_og.jpg']);
+        $seoMeta->clean();
+        $seoMeta->set('og_image', 'new_og.jpg'); // dirty状態
+
+        $entity = new Entity(['title' => 'valid title']);
+        $entity->seo_meta = $seoMeta;
+
+        // エラーなし確認
+        $this->assertFalse($entity->hasErrors());
+
+        $listener = new BcSeoModelEventListener();
+        $event = new Event('afterMarshal', $blogPostsTable, ['options' => []]);
+        $listener->afterMarshal($event, $entity, new ArrayObject(), new ArrayObject());
+
+        // エラーなしの場合はrollbackFileが呼ばれないため、og_imageが変更されたままであることを確認
+        $this->assertEquals(
+            'new_og.jpg',
+            $entity->seo_meta->get('og_image'),
+            'エラーなしの場合はrollbackFileが呼ばれず、og_imageが変更されたままであるべきです'
+        );
     }
 }

--- a/plugins/bc-theme-file/src/Service/ThemeFoldersService.php
+++ b/plugins/bc-theme-file/src/Service/ThemeFoldersService.php
@@ -108,11 +108,13 @@ class ThemeFoldersService extends BcThemeFileService implements ThemeFoldersServ
         $themeFiles = [];
         $folders = [];
         foreach($folder->getFolders() as $file) {
+            if (str_starts_with($file, '.')) continue;
             if (in_array($file, $excludeFolderList)) continue;
             $folders[] = $this->get($params['fullpath'] . $file);
         }
         $themeFilesService = $this->getService(ThemeFilesServiceInterface::class);
         foreach($folder->getFiles() as $file) {
+            if (str_starts_with($file, '.')) continue;
             if (in_array($file, $excludeFileList)) continue;
             $themeFiles[] = $themeFilesService->get($params['fullpath'] . $file);
         }


### PR DESCRIPTION
<!-- GitHub Copilot コードレビューへの指示: プルリクエストをレビューしてコメントする際には日本語でお願いします。 -->

BcUploadの一時ファイルに保存する処理でやってみました。どうでしょうか？