### PR TITLE
Mailにて、ファイルを送信した際の複数のバグ #1852.  確認画面でダウンロードできない不具合の修正

### DIFF
--- a/lib/Baser/View/Helper/BcUploadHelper.php
+++ b/lib/Baser/View/Helper/BcUploadHelper.php
@@ -101,6 +101,13 @@ class BcUploadHelper extends BcAppHelper
 					return false;
 				}
 			}
+		} else {
+			$sessionKey = $this->value($fieldName . '_tmp');
+			if ($sessionKey && $value === $sessionKey) {
+				$tmp = true;
+				$value = str_replace('/', '_', $sessionKey);
+				$basePath = '/uploads/tmp/';
+			}
 		}
 
 		/* ファイルのパスを取得 */


### PR DESCRIPTION
@ryuring 

https://github.com/baserproject/basercms/issues/1852 　の修正です。
ご確認お願いします。

89行目、is_array($value) が配列かをチェックしていて、配列の場合 /uploads/tmp/ 以下を basePath に置き換えていますが、文字列の場合は /files/ 配下を見ているため 404 エラーとなっておりました。

文字列になる理由は、setupRequestDataの178行目で、配列からファイル名の文字列に変換され、
さらにその後 saveTmpFile で生成された一時ファイル名の文字列に上書きされるためです（L1070）。

確認画面の時点では、$value は既に saveTmpFiles によって文字列になっていたにもかかわらず、文字列の場合の判定を行っていなかったため、/files/mail/limited/.../のリンクが生成され、 404 になっていました。