### PR TITLE
【アップローダー】アップロード管理画面で既存ファイルを上書き更新できるようにしたい #4320

### DIFF
--- a/plugins/bc-uploader/src/Service/UploaderFilesService.php
+++ b/plugins/bc-uploader/src/Service/UploaderFilesService.php
@@ -225,6 +225,28 @@ class UploaderFilesService implements UploaderFilesServiceInterface
         $name = str_replace(['/', '&', '?', '=', '#', ':', '%', '+'], '_', h($name));
         $postData['name'] = new UploadedFile($file->getStream(), $file->getSize(), $file->getError(), $name, $file->getClientMediaType());
         $postData['alt'] = $name;
+        // delete() の前に savePathを取得・保持
+        $fileUploader = $this->UploaderFiles->getFileUploader();
+        $savePath = $fileUploader ? $fileUploader->savePath : null;
+        // 同名レコードが存在し編集権限がある場合は削除して上書き
+        $existingEntity = $this->UploaderFiles->find()->where(['UploaderFiles.name' => $name])->first();
+        if ($existingEntity && $this->isEditable($existingEntity->toArray())) {
+            $this->UploaderFiles->delete($existingEntity);
+        }
+        // DBレコードなしで物理ファイルが残っている場合（孤立ファイル）も直接削除して上書きする
+        if ($savePath) {
+            $info = pathinfo($name);
+            $basename = $info['filename'];
+            $ext = $info['extension'];
+            $sizes = ['large', 'midium', 'small', 'mobile_large', 'mobile_small'];
+            foreach ([$savePath, $savePath . 'limited' . DS] as $dir) {
+                if (file_exists($dir . $name)) unlink($dir . $name);
+                foreach ($sizes as $size) {
+                    $thumb = $basename . '__' . $size . '.' . $ext;
+                    if (file_exists($dir . $thumb)) unlink($dir . $thumb);
+                }
+            }
+        }
         $entity = $this->UploaderFiles->patchEntity($this->getNew(), $postData);
         return $this->UploaderFiles->saveOrFail($entity);
     }

--- a/plugins/bc-uploader/src/View/Helper/UploaderHelper.php
+++ b/plugins/bc-uploader/src/View/Helper/UploaderHelper.php
@@ -77,6 +77,8 @@ class UploaderHelper extends Helper
         $ext = $pathInfo['extension'];
         $_options = ['alt' => $uploaderFile->alt];
         $options = array_merge($_options, $options);
+        // ブラウザキャッシュ対策: modified を元にしたクエリパラメータを付与
+        $cacheBuster = $uploaderFile->modified ? '?t=' . $uploaderFile->modified->getTimestamp() : '';
         if (in_array(strtolower($ext), ['gif', 'jpg', 'png'])) {
             if (isset($options['size'])) {
                 $resizeName = $pathInfo['filename'] . '__' . $options['size'] . '.' . $ext;
@@ -86,9 +88,11 @@ class UploaderHelper extends Helper
                     $savePath = $this->savePath . $resizeName;
                 }
                 if (file_exists($savePath)) {
-                    $imgUrl = $this->getFileUrl($resizeName);
+                    $imgUrl = $this->getFileUrl($resizeName) . $cacheBuster;
                     unset($options['size']);
                 }
+            } else {
+                $imgUrl .= $cacheBuster;
             }
             return $this->Html->image($imgUrl, $options);
         } else {


### PR DESCRIPTION
@ryuring 

[こちらのissue](https://github.com/baserproject/basercms/issues/4320)の改修を行いました。レビューお願いします。

/bc-uploader/src/View/Helper/UploaderHelper.phpの変更は、ブラウザキャッシュを削除（command+shif+R）しなくてもファイルが差し替えられるように、タイムスタンプをクエリパラメータとして付与しました。