### PR TITLE
fix #4363 【ユーザー管理】ログインパスワードの複雑度のチェックを行う・行わないでヘルプの表示を変更

### DIFF
--- a/plugins/baser-core/resources/locales/baser_core.pot
+++ b/plugins/baser-core/resources/locales/baser_core.pot
@@ -4566,6 +4566,16 @@ msgstr ""
 msgid "半角英数字(英字は大文字小文字を区別)とスペース、記号(._-:/()#,@[]+=&;{}!$*)のみで入力してください"
 msgstr ""
 
+#: ./plugins/bc-admin-third/templates/Admin/Users/edit_password.php:56
+#: ./plugins/bc-admin-third/templates/Admin/element/Users/form.php:149
+msgid "{0}文字以上で入力してください。"
+msgstr ""
+
+#: ./plugins/bc-admin-third/templates/Admin/Users/edit_password.php:63
+#: ./plugins/bc-admin-third/templates/Admin/element/Users/form.php:156
+msgid "{0}を含む必要があります。"
+msgstr ""
+
 #: ./plugins/bc-admin-third/templates/Admin/Users/index.php:24
 msgid "ユーザー一覧"
 msgstr ""

--- a/plugins/baser-core/resources/locales/en/baser_core.po
+++ b/plugins/baser-core/resources/locales/en/baser_core.po
@@ -5059,6 +5059,16 @@ msgstr ""
 "Please enter only with half-size alphabets and numbers (alphabets are "
 "distinct by large or small), spaces, symbols (._-:/()#,@[]+=&;{}!$*)."
 
+#: plugins/bc-admin-third/templates/Admin/Users/edit_password.php:56
+#: plugins/bc-admin-third/templates/Admin/element/Users/form.php:149
+msgid "{0}文字以上で入力してください。"
+msgstr "Please enter {0} or more characters."
+
+#: plugins/bc-admin-third/templates/Admin/Users/edit_password.php:63
+#: plugins/bc-admin-third/templates/Admin/element/Users/form.php:156
+msgid "{0}を含む必要があります。"
+msgstr "{0} is required."
+
 #: plugins/bc-admin-third/templates/Admin/Users/index.php:24
 msgid "ユーザー一覧"
 msgstr "User List"

--- a/plugins/bc-admin-third/templates/Admin/Users/edit_password.php
+++ b/plugins/bc-admin-third/templates/Admin/Users/edit_password.php
@@ -9,8 +9,10 @@
  * @license       https://basercms.net/license/index.html MIT License
  */
 
-use BaserCore\View\BcAdminAppView;
 use BaserCore\Model\Entity\User;
+use BaserCore\Utility\BcSiteConfig;
+use BaserCore\View\BcAdminAppView;
+use Cake\Core\Configure;
 
 /**
  * Users Edit
@@ -51,6 +53,28 @@ $this->BcAdmin->setTitle(__d('baser_core', 'パスワード編集'));
               <?php endif; ?>
               <?php echo __d('baser_core', '確認のため２回入力してください。') ?></li>
             <li><?php echo __d('baser_core', '半角英数字(英字は大文字小文字を区別)とスペース、記号(._-:/()#,@[]+=&;{}!$*)のみで入力してください') ?></li>
+            <li>
+              <?php if (BcSiteConfig::get('allow_simple_password')): ?>
+                <?php echo __d('baser_core', '{0}文字以上で入力してください。', 6) ?>
+              <?php else: ?>
+                <?php echo __d('baser_core', '{0}文字以上で入力してください。', Configure::read('BcApp.passwordRule.minLength') ?: 12) ?>
+              <?php endif ?>
+            </li>
+            <?php if (!BcSiteConfig::get('allow_simple_password')): ?>
+              <?php
+              $requiredCharacterTypeNames = [
+                'numeric'   => __d('baser_core', '数字'),
+                'uppercase' => __d('baser_core', '大文字英字'),
+                'lowercase' => __d('baser_core', '小文字英字'),
+                'symbol'    => __d('baser_core', '記号'),
+              ];
+              $requiredTypes = Configure::read('BcApp.passwordRule.requiredCharacterTypes') ?: [];
+              $requiredNames = array_values(array_intersect_key($requiredCharacterTypeNames, array_flip($requiredTypes)));
+              ?>
+              <?php if ($requiredNames): ?>
+                <li><?php echo __d('baser_core', '{0}を含む必要があります。', implode('・', $requiredNames)) ?></li>
+              <?php endif ?>
+            <?php endif ?>
           </ul>
         </div>
         <?php echo $this->BcAdminForm->error('password') ?>

--- a/plugins/bc-admin-third/templates/Admin/element/Users/form.php
+++ b/plugins/bc-admin-third/templates/Admin/element/Users/form.php
@@ -10,7 +10,9 @@
  */
 
 use BaserCore\Model\Entity\User;
+use BaserCore\Utility\BcSiteConfig;
 use BaserCore\View\BcAdminAppView;
+use Cake\Core\Configure;
 
 /**
  * Users Form
@@ -144,6 +146,28 @@ $this->BcBaser->js('admin/users/form.bundle', false);
               <?php endif; ?>
               <?php echo __d('baser_core', '確認のため２回入力してください。') ?></li>
             <li><?php echo __d('baser_core', '半角英数字(英字は大文字小文字を区別)とスペース、記号(._-:/()#,@[]+=&;{}!$*)のみで入力してください') ?></li>
+            <li>
+              <?php if (BcSiteConfig::get('allow_simple_password')): ?>
+                <?php echo __d('baser_core', '{0}文字以上で入力してください。', 6) ?>
+              <?php else: ?>
+                <?php echo __d('baser_core', '{0}文字以上で入力してください。', Configure::read('BcApp.passwordRule.minLength') ?: 12) ?>
+              <?php endif ?>
+            </li>
+            <?php if (!BcSiteConfig::get('allow_simple_password')): ?>
+              <?php
+              $requiredCharacterTypeNames = [
+                'numeric'   => __d('baser_core', '数字'),
+                'uppercase' => __d('baser_core', '大文字英字'),
+                'lowercase' => __d('baser_core', '小文字英字'),
+                'symbol'    => __d('baser_core', '記号'),
+              ];
+              $requiredTypes = Configure::read('BcApp.passwordRule.requiredCharacterTypes') ?: [];
+              $requiredNames = array_values(array_intersect_key($requiredCharacterTypeNames, array_flip($requiredTypes)));
+              ?>
+              <?php if ($requiredNames): ?>
+                <li><?php echo __d('baser_core', '{0}を含む必要があります。', implode('・', $requiredNames)) ?></li>
+              <?php endif ?>
+            <?php endif ?>
           </ul>
         </div>
         <?php echo $this->BcAdminForm->error('password') ?>


### PR DESCRIPTION
よろしくお願いします。

<img width="939" height="547" alt="スクリーンショット 2026-05-22 18 21 21" src="https://github.com/user-attachments/assets/acaf34ca-671f-42b4-934d-5659b84a625a" />

<img width="842" height="534" alt="スクリーンショット 2026-05-22 18 24 45" src="https://github.com/user-attachments/assets/eee3e7eb-a0ac-4c68-a6af-622a7259a8d1" />

<!-- GitHub Copilot コードレビューへの指示: プルリクエストをレビューしてコメントする際には日本語でお願いします。 -->
