### PR TITLE
fix #4355 【プラグイン】BcSeoHelperEventListener のネストループで break が内側しか抜けていない問題を解消

### DIFF
--- a/plugins/bc-seo/src/Event/BcSeoHelperEventListener.php
+++ b/plugins/bc-seo/src/Event/BcSeoHelperEventListener.php
@@ -83,7 +83,7 @@ class BcSeoHelperEventListener extends BcHelperEventListener
                 foreach ($seoForm['eventIds'] as $configEventId) {
                     if ($eventId === $configEventId) {
                         $type = $configType;
-                        break;
+                        break 2;
                     }
                 }
             }


### PR DESCRIPTION
よろしくお願いします。

<!-- GitHub Copilot コードレビューへの指示: プルリクエストをレビューしてコメントする際には日本語でお願いします。 -->
