### PR TITLE
fix #4284 【プラグイン】カスタムコンテンツ:テーブル管理のテーブル登録・編集で識別名に半角大文字が使えない件のヘルプを修正

### DIFF
--- a/docker/docker-compose.yml.default
+++ b/docker/docker-compose.yml.default
@@ -35,7 +35,7 @@ services:
 
   bc-smtp:
     container_name: bc-smtp
-    image: schickling/mailcatcher
+    image: sj26/mailcatcher:latest
     ports:
       - "1080:1080"
       - "1025:1025"

--- a/plugins/baser-core/resources/locales/baser_core.pot
+++ b/plugins/baser-core/resources/locales/baser_core.pot
@@ -7529,6 +7529,7 @@ msgstr ""
 
 #: ./plugins/bc-admin-third/templates/plugin/BcCustomContent/Admin/element/CustomFields/form.php:60
 #: ./plugins/bc-admin-third/templates/plugin/BcCustomContent/Admin/element/CustomLinks/form.php:118
+#: ./plugins/bc-admin-third/templates/plugin/BcCustomContent/Admin/element/CustomTables/form.php:87
 msgid "半角小文字英数字とアンダースコア（ _ ）のみ利用可能です。"
 msgstr ""
 
@@ -7842,10 +7843,6 @@ msgstr ""
 #: ./plugins/bc-admin-third/templates/plugin/BcCustomContent/Admin/element/CustomTables/form.php:80
 #: ./plugins/bc-admin-third/templates/plugin/BcCustomContent/Admin/element/CustomTables/index_list.php:29
 msgid "識別名"
-msgstr ""
-
-#: ./plugins/bc-admin-third/templates/plugin/BcCustomContent/Admin/element/CustomTables/form.php:87
-msgid "半角英数字とアンダースコアのみ利用できます。"
 msgstr ""
 
 #: ./plugins/bc-admin-third/templates/plugin/BcCustomContent/Admin/element/CustomTables/form.php:106
@@ -10529,7 +10526,7 @@ msgid "識別名を入力してください。"
 msgstr ""
 
 #: ./plugins/bc-custom-content/src/Model/Table/CustomTablesTable.php:101
-msgid "識別名は半角英数字とアンダースコアのみで入力してください。"
+msgid "識別名は半角英数小文字とアンダースコアのみで入力してください。"
 msgstr ""
 
 #: ./plugins/bc-custom-content/src/Model/Table/CustomTablesTable.php:106

--- a/plugins/baser-core/resources/locales/en/baser_core.po
+++ b/plugins/baser-core/resources/locales/en/baser_core.po
@@ -8684,6 +8684,7 @@ msgstr "Field Name"
 
 #: plugins/bc-admin-third/templates/plugin/BcCustomContent/Admin/element/CustomFields/form.php:60
 #: plugins/bc-admin-third/templates/plugin/BcCustomContent/Admin/element/CustomLinks/form.php:118
+#: plugins/bc-admin-third/templates/plugin/BcCustomContent/Admin/element/CustomTables/form.php:87
 msgid "半角小文字英数字とアンダースコア（ _ ）のみ利用可能です。"
 msgstr ""
 "Only half-width alphanumeric characters and underscores (_ ) are allowed."
@@ -9087,13 +9088,6 @@ msgstr ""
 #: plugins/bc-admin-third/templates/plugin/BcCustomContent/Admin/element/CustomTables/index_list.php:29
 msgid "識別名"
 msgstr "Distinguished Name"
-
-#: plugins/bc-admin-third/templates/plugin/BcCustomContent/Admin/element/CustomTables/form.php:87
-#, fuzzy
-#| msgid "半角小文字英数字とアンダースコア（ _ ）のみ利用可能です。"
-msgid "半角英数字とアンダースコアのみ利用できます。"
-msgstr ""
-"Only half-width alphanumeric characters and underscores (_ ) are allowed."
 
 #: plugins/bc-admin-third/templates/plugin/BcCustomContent/Admin/element/CustomTables/form.php:106
 msgid "表示名称フィールド"
@@ -12312,9 +12306,9 @@ msgid "識別名を入力してください。"
 msgstr "Please enter a distinguished name."
 
 #: plugins/bc-custom-content/src/Model/Table/CustomTablesTable.php:101
-msgid "識別名は半角英数字とアンダースコアのみで入力してください。"
+msgid "識別名は半角英数小文字とアンダースコアのみで入力してください。"
 msgstr ""
-"Please enter the distinguished name only with single-byte alphanumeric "
+"Please enter the distinguished name only with single-byte lowercase alphanumeric "
 "characters and underscores."
 
 #: plugins/bc-custom-content/src/Model/Table/CustomTablesTable.php:106

--- a/plugins/bc-admin-third/templates/plugin/BcCustomContent/Admin/element/CustomTables/form.php
+++ b/plugins/bc-admin-third/templates/plugin/BcCustomContent/Admin/element/CustomTables/form.php
@@ -84,7 +84,7 @@ $this->BcAdmin->setHelp('custom_tables_form');
         <?php echo $this->BcAdminForm->control('name', ['type' => 'text', 'size' => 40, 'maxlength' => 255]) ?>
         <i class="bca-icon--question-circle bca-help"></i>
         <div class="bca-helptext">
-          <?php echo __d('baser_core', '半角英数字とアンダースコアのみ利用できます。') ?>
+          <?php echo __d('baser_core', '半角英数小文字とアンダースコアのみ利用できます。') ?>
         </div>
         <?php echo $this->BcAdminForm->error('name') ?>
       </td>

--- a/plugins/bc-custom-content/src/Model/Table/CustomTablesTable.php
+++ b/plugins/bc-custom-content/src/Model/Table/CustomTablesTable.php
@@ -98,7 +98,7 @@ class CustomTablesTable extends AppTable
             ->scalar('name')
             ->maxLength('name', 255, __d('baser_core', '255文字以内で入力してください。'))
             ->notEmptyString('name', __d('baser_core', '識別名を入力してください。'))
-            ->regex('name', '/^[a-z0-9_]+$/', __d('baser_core', '識別名は半角英数字とアンダースコアのみで入力してください。'))
+            ->regex('name', '/^[a-z0-9_]+$/', __d('baser_core', '識別名は半角英数小文字とアンダースコアのみで入力してください。'))
             ->add('name', [
                 'validateUnique' => [
                     'rule' => ['validateUnique'],

--- a/plugins/bc-custom-content/tests/TestCase/Controller/Admin/Api/CustomTablesControllerTest.php
+++ b/plugins/bc-custom-content/tests/TestCase/Controller/Admin/Api/CustomTablesControllerTest.php
@@ -174,7 +174,7 @@ class CustomTablesControllerTest extends BcTestCase
         $result = json_decode((string)$this->_response->getBody());
         $this->assertEquals('入力エラーです。内容を修正してください。', $result->message);
         $this->assertEquals(
-            '識別名は半角英数字とアンダースコアのみで入力してください。',
+            '識別名は半角英数小文字とアンダースコアのみで入力してください。',
             $result->errors->name->regex);
     }
 
@@ -219,7 +219,7 @@ class CustomTablesControllerTest extends BcTestCase
         $result = json_decode((string)$this->_response->getBody());
         $this->assertEquals('入力エラーです。内容を修正してください。', $result->message);
         $this->assertEquals(
-            '識別名は半角英数字とアンダースコアのみで入力してください。',
+            '識別名は半角英数小文字とアンダースコアのみで入力してください。',
             $result->errors->name->regex);
 
         //不要なテーブルを削除

--- a/plugins/bc-custom-content/tests/TestCase/Model/Table/CustomTablesTableTest.php
+++ b/plugins/bc-custom-content/tests/TestCase/Model/Table/CustomTablesTableTest.php
@@ -97,7 +97,7 @@ class CustomTablesTableTest extends BcTestCase
         $errors = $validator->validate([
             'name' => 'あ',
         ]);
-        $this->assertEquals('識別名は半角英数字とアンダースコアのみで入力してください。', current($errors['name']));
+        $this->assertEquals('識別名は半角英数小文字とアンダースコアのみで入力してください。', current($errors['name']));
         //正常系実行
         $errors = $validator->validate([
             'name' => 'test',

--- a/plugins/bc-custom-content/tests/TestCase/Service/CustomTablesServiceTest.php
+++ b/plugins/bc-custom-content/tests/TestCase/Service/CustomTablesServiceTest.php
@@ -298,7 +298,7 @@ class CustomTablesServiceTest extends BcTestCase
             'name' => 'お問い合わせタイトル',
         ];
         $this->expectException(PersistenceFailedException::class);
-        $this->expectExceptionMessage('Entity save failure. Found the following errors (name.regex: "識別名は半角英数字とアンダースコアのみで入力してください。")');
+        $this->expectExceptionMessage('Entity save failure. Found the following errors (name.regex: "識別名は半角英数小文字とアンダースコアのみで入力してください。")');
         $this->CustomTablesService->create($data);
     }
 
@@ -363,7 +363,7 @@ class CustomTablesServiceTest extends BcTestCase
 
         //エラーする時をテスト
         $this->expectException(PersistenceFailedException::class);
-        $this->expectExceptionMessage('Entity save failure. Found the following errors (name.regex: "識別名は半角英数字とアンダースコアのみで入力してください。")');
+        $this->expectExceptionMessage('Entity save failure. Found the following errors (name.regex: "識別名は半角英数小文字とアンダースコアのみで入力してください。")');
         $this->CustomTablesService->update($this->CustomTablesService->get(1), ['name' => 'あああああ']);
     }
 


### PR DESCRIPTION
よろしくお願いします。

<!-- GitHub Copilot コードレビューへの指示: プルリクエストをレビューしてコメントする際には日本語でお願いします。 -->
