### PR TITLE
fix #4406 【メール】メール設定で管理者メールアドレスをカンマ区切りで複数設定するとエラーになる問題を解決

### DIFF
--- a/plugins/bc-mail/src/Mailer/MailMessageMailer.php
+++ b/plugins/bc-mail/src/Mailer/MailMessageMailer.php
@@ -49,14 +49,7 @@ class MailMessageMailer extends BcMailer
         $options = array_merge([
             'toAdmin' => [],
         ], $options);
-        if (strpos($adminMail, ',') !== false) {
-            $adminMails = array_map('trim', explode(',', $adminMail));
-            $adminMails = array_values(array_filter($adminMails, static fn($mail) => $mail !== ''));
-            $fromAdmin = $adminMails[0] ?? $adminMail;
-            $toAdmin = $adminMails;
-        } else {
-            $toAdmin = $adminMail;
-        }
+        [$fromAdmin, $toAdmin] = $this->parseAndNormalizeMailAddresses($adminMail);
         $data['other']['mode'] = 'admin';
         $this->setTo($toAdmin)
             ->setFrom($fromAdmin, $this->getFrom($mailContent))
@@ -69,9 +62,10 @@ class MailMessageMailer extends BcMailer
         if($mailContent->sender_2) {
             $this->setBcc(strpos($mailContent->sender_2, ',') === false? $mailContent->sender_2: explode(',', $mailContent->sender_2));
         }
-        if($userMail) {
+        [$replyToUser] = $this->parseAndNormalizeMailAddresses($userMail);
+        if($replyToUser) {
             // カンマ区切りで複数設定されていた場合先頭のアドレスをreplayToに利用
-            $this->setReplyTo(strpos($userMail, ',') === false? $userMail : strstr($userMail, ',', true));
+            $this->setReplyTo($replyToUser);
         }
         if (empty($options['toAdmin'])) return;
         foreach($options['toAdmin'] as $key => $value) {
@@ -104,13 +98,10 @@ class MailMessageMailer extends BcMailer
         $options = array_merge([
             'toUser' => [],
         ], $options);
-        if (strpos($adminMail, ',') !== false) {
-            [$fromAdmin] = array_map('trim', explode(',', $adminMail));
-        } else {
-            $fromAdmin = $adminMail;
-        }
+        [$fromAdmin] = $this->parseAndNormalizeMailAddresses($adminMail);
+        [, $toUser] = $this->parseAndNormalizeMailAddresses($userMail);
         $data['other']['mode'] = 'user';
-        $this->setTo($userMail)
+        $this->setTo($toUser)
             ->setFrom($fromAdmin, $this->getFrom($mailContent))
             ->setReplyTo($fromAdmin)
             ->setSubject($mailContent->subject_user)
@@ -140,6 +131,22 @@ class MailMessageMailer extends BcMailer
     public function getFrom(EntityInterface $mailContent) {
         if($mailContent->sender_name) return $mailContent->sender_name;
         return $mailContent->content->site->display_name;
+    }
+
+    /**
+     * メールアドレス文字列を分割・正規化する
+     *
+     * @param string $mailAddresses
+     * @return array{0: string, 1: array}
+     */
+    private function parseAndNormalizeMailAddresses(string $mailAddresses): array
+    {
+        $recipients = array_values(array_filter(
+            array_map('trim', explode(',', $mailAddresses)),
+            static fn($mail) => $mail !== ''
+        ));
+        $primaryAddress = $recipients[0] ?? '';
+        return [$primaryAddress, $recipients];
     }
 
 }

--- a/plugins/bc-mail/src/Mailer/MailMessageMailer.php
+++ b/plugins/bc-mail/src/Mailer/MailMessageMailer.php
@@ -50,12 +50,15 @@ class MailMessageMailer extends BcMailer
             'toAdmin' => [],
         ], $options);
         if (strpos($adminMail, ',') !== false) {
-            [$fromAdmin] = explode(',', $adminMail);
+            $adminMails = array_map('trim', explode(',', $adminMail));
+            $adminMails = array_values(array_filter($adminMails, static fn($mail) => $mail !== ''));
+            $fromAdmin = $adminMails[0] ?? $adminMail;
+            $toAdmin = $adminMails;
         } else {
-            $fromAdmin = $adminMail;
+            $toAdmin = $adminMail;
         }
         $data['other']['mode'] = 'admin';
-        $this->setTo($adminMail)
+        $this->setTo($toAdmin)
             ->setFrom($fromAdmin, $this->getFrom($mailContent))
             ->setSubject($mailContent->subject_admin)
             ->setAttachments($attachments)
@@ -102,7 +105,7 @@ class MailMessageMailer extends BcMailer
             'toUser' => [],
         ], $options);
         if (strpos($adminMail, ',') !== false) {
-            [$fromAdmin] = explode(',', $adminMail);
+            [$fromAdmin] = array_map('trim', explode(',', $adminMail));
         } else {
             $fromAdmin = $adminMail;
         }

--- a/plugins/bc-mail/src/Mailer/MailMessageMailer.php
+++ b/plugins/bc-mail/src/Mailer/MailMessageMailer.php
@@ -64,7 +64,7 @@ class MailMessageMailer extends BcMailer
         }
         [$replyToUser] = $this->parseAndNormalizeMailAddresses($userMail);
         if($replyToUser) {
-            // カンマ区切りで複数設定されていた場合先頭のアドレスをreplayToに利用
+            // カンマ区切りで複数設定されていた場合先頭のアドレスをreplyToに利用
             $this->setReplyTo($replyToUser);
         }
         if (empty($options['toAdmin'])) return;

--- a/plugins/bc-mail/tests/TestCase/Mailer/MailMessageMailerTest.php
+++ b/plugins/bc-mail/tests/TestCase/Mailer/MailMessageMailerTest.php
@@ -84,6 +84,47 @@ class MailMessageMailerTest extends BcTestCase
         $this->assertEquals('fields test', $vars['mailFields']);
         $this->assertEquals('admin', $vars['other']['mode']);
     }
+    /**
+     * test sendFormToAdmin with comma separated admin mail
+     */
+    public function testSendFormToAdminWithMultipleRecipients()
+    {
+        //準備
+        $data['message'] = 'message test';
+        $data['mailContent'] = 'content test';
+        $data['mailFields'] = 'fields test';
+        $mailContent = MailContentFactory::make([
+            'description' => 'description test',
+            'sender_1' => 'sender_1',
+            'sender_name' => 'name 111',
+            'subject_user' => 'subject_user 111',
+            'subject_admin' => 'subject_admin 111',
+            'form_template' => 'default',
+            'mail_template' => 'mail_default',
+            'redirect_url' => '/',
+        ])->getEntity();
+
+        //テスト
+        $this->MailMessageMailer->sendFormToAdmin(
+            $mailContent,
+            'abc@example.com,def@example.com',
+            'abcUser@example.com',
+            $data,
+            [],
+            []
+        );
+
+        //戻り値を確認
+        $this->assertEquals([
+            'abc@example.com' => 'abc@example.com',
+            'def@example.com' => 'def@example.com',
+        ], $this->MailMessageMailer->getTo());
+        $this->assertEquals(['abcUser@example.com' => 'abcUser@example.com'], $this->MailMessageMailer->getReplyTo());
+
+        $vars = $this->MailMessageMailer->viewBuilder()->getVars();
+        $this->assertEquals('admin', $vars['other']['mode']);
+    }
+
 
     /**
      * test sendFormToUser

--- a/plugins/bc-mail/tests/TestCase/Mailer/MailMessageMailerTest.php
+++ b/plugins/bc-mail/tests/TestCase/Mailer/MailMessageMailerTest.php
@@ -125,6 +125,44 @@ class MailMessageMailerTest extends BcTestCase
         $this->assertEquals('admin', $vars['other']['mode']);
     }
 
+    /**
+     * test sendFormToAdmin trims and filters empty addresses
+     */
+    public function testSendFormToAdminTrimsAndFiltersRecipients()
+    {
+        //準備
+        $data['message'] = 'message test';
+        $data['mailContent'] = 'content test';
+        $data['mailFields'] = 'fields test';
+        $mailContent = MailContentFactory::make([
+            'description' => 'description test',
+            'sender_1' => 'sender_1',
+            'sender_name' => 'name 111',
+            'subject_user' => 'subject_user 111',
+            'subject_admin' => 'subject_admin 111',
+            'form_template' => 'default',
+            'mail_template' => 'mail_default',
+            'redirect_url' => '/',
+        ])->getEntity();
+
+        //テスト
+        $this->MailMessageMailer->sendFormToAdmin(
+            $mailContent,
+            'abc@example.com, def@example.com,',
+            ' abcUser@example.com, ',
+            $data,
+            [],
+            []
+        );
+
+        //戻り値を確認
+        $this->assertEquals([
+            'abc@example.com' => 'abc@example.com',
+            'def@example.com' => 'def@example.com',
+        ], $this->MailMessageMailer->getTo());
+        $this->assertEquals(['abcUser@example.com' => 'abcUser@example.com'], $this->MailMessageMailer->getReplyTo());
+    }
+
 
     /**
      * test sendFormToUser
@@ -147,7 +185,7 @@ class MailMessageMailerTest extends BcTestCase
         ])->getEntity();
 
         //テスト
-        $this->MailMessageMailer->sendFormToUser($mailContent, 'abc@example.com', 'abcUser@example.com', $data, [], []);
+        $this->MailMessageMailer->sendFormToUser($mailContent, 'abc@example.com', 'abcUser@example.com', $data, []);
 
         //戻り値を確認
         $this->assertEquals(['abc@example.com' => 'abc@example.com'], $this->MailMessageMailer->getReplyTo());
@@ -158,6 +196,43 @@ class MailMessageMailerTest extends BcTestCase
         $this->assertEquals('content test', $vars['mailContent']);
         $this->assertEquals('fields test', $vars['mailFields']);
         $this->assertEquals('user', $vars['other']['mode']);
+    }
+
+    /**
+     * test sendFormToUser trims and filters empty addresses
+     */
+    public function testSendFormToUserTrimsAndFiltersRecipients()
+    {
+        //準備
+        $data['message'] = 'message test';
+        $data['mailContent'] = 'content test';
+        $data['mailFields'] = 'fields test';
+        $mailContent = MailContentFactory::make([
+            'description' => 'description test',
+            'sender_1' => 'sender_1',
+            'sender_name' => 'name 111',
+            'subject_user' => 'subject_user 111',
+            'subject_admin' => 'subject_admin 111',
+            'form_template' => 'default',
+            'mail_template' => 'mail_default',
+            'redirect_url' => '/',
+        ])->getEntity();
+
+        //テスト
+        $this->MailMessageMailer->sendFormToUser(
+            $mailContent,
+            'abc@example.com, def@example.com,',
+            'abcUser@example.com, defUser@example.com,',
+            $data,
+            []
+        );
+
+        //戻り値を確認
+        $this->assertEquals(['abc@example.com' => 'abc@example.com'], $this->MailMessageMailer->getReplyTo());
+        $this->assertEquals([
+            'abcUser@example.com' => 'abcUser@example.com',
+            'defUser@example.com' => 'defUser@example.com',
+        ], $this->MailMessageMailer->getTo());
     }
 
     /**


### PR DESCRIPTION
<!-- GitHub Copilot コードレビューへの指示: プルリクエストをレビューしてコメントする際には日本語でお願いします。 -->

不具合であることを前提に改修を入れています。
御確認ください