### PR TITLE
fix #3579 【メールフィールド新規登録・編集：5.1.x】詳細設定にある「グループ名」と「グループ入力チェック」にハイフンを入れるとエラーになる件を修正

### DIFF
--- a/plugins/bc-mail/src/Model/Table/MailFieldsTable.php
+++ b/plugins/bc-mail/src/Model/Table/MailFieldsTable.php
@@ -126,8 +126,8 @@ class MailFieldsTable extends MailAppTable
             ->scalar('group_field')
             ->maxLength('group_field', 255, __d('baser_core', 'グループ名は255文字以内で入力してください。'))
             ->add('group_field', [
-                'halfTextMailField' => [
-                    'rule' => 'halfTextMailField',
+                'halfTextMailGroupField' => [
+                    'rule' => 'halfTextMailGroupField',
                     'provider' => 'table',
                     'message' => __d('baser_core', 'グループ名は半角英数字、ハイフン、アンダースコアで入力してください。')
                 ]]);
@@ -135,8 +135,8 @@ class MailFieldsTable extends MailAppTable
             ->scalar('group_valid')
             ->maxLength('group_valid', 255, __d('baser_core', 'グループ入力チェックは255文字以内で入力してください。'))
             ->add('group_valid', [
-                'halfTextMailField' => [
-                    'rule' => 'halfTextMailField',
+                'halfTextMailGroupField' => [
+                    'rule' => 'halfTextMailGroupField',
                     'provider' => 'table',
                     'message' => __d('baser_core', 'グループ入力チェックは半角英数字、ハイフン、アンダースコアで入力してください。')
                 ]]);
@@ -233,7 +233,7 @@ class MailFieldsTable extends MailAppTable
 
     /**
      * メールフィールドの値として正しい文字列か検証する
-     * 半角小文字英数-_
+     * 半角小文字英数字とアンダースコアを許容
      * メールフィールドは、DBテーブルのフィールドとして利用されるため、
      * 大文字を利用した場合にクォートを入れないとエラーとなってしまう
      *
@@ -352,6 +352,22 @@ class MailFieldsTable extends MailAppTable
             $sourceList[] = preg_replace("/(^\s+|\r|\n\s+$)/u", '', $value);
         }
         return implode("\n", $sourceList);
+    }
+
+    /**
+     * グループ系フィールドの値として正しい文字列か検証する
+     * 半角英数字、ハイフン、アンダースコアを許容
+     *
+     * @param string $value
+     * @return bool
+     * @checked
+     * @noTodo
+     * @unitTest
+     */
+    public function halfTextMailGroupField(string $value): bool
+    {
+        $pattern = "/^[a-zA-Z0-9_-]*$/";
+        return preg_match($pattern, $value) === 1;
     }
 
 }

--- a/plugins/bc-mail/tests/TestCase/Model/Table/MailFieldsTableTest.php
+++ b/plugins/bc-mail/tests/TestCase/Model/Table/MailFieldsTableTest.php
@@ -146,6 +146,23 @@ class MailFieldsTableTest extends BcTestCase
         $this->assertEquals('グループ入力チェックは半角英数字、ハイフン、アンダースコアで入力してください。', current($errors['group_valid']));
     }
 
+    public function test_validationDefaultAllowHyphenOnlyForGroupFields()
+    {
+        $validator = $this->MailFieldsTable->getValidator('default');
+        $errors = $validator->validate([
+            'name' => 'test',
+            'mail_content_id' => 999,
+            'type' => 'text',
+            'field_name' => 'field-name',
+            'group_field' => 'Group-Name',
+            'group_valid' => 'Group-Valid'
+        ]);
+
+        $this->assertEquals('フィールド名は小文字の半角英数字、アンダースコアのみで入力してください。', current($errors['field_name']));
+        $this->assertArrayNotHasKey('group_field', $errors);
+        $this->assertArrayNotHasKey('group_valid', $errors);
+    }
+
     public function test_validationDefaultDuplicate()
     {
         MailFieldsFactory::make(['mail_content_id' => 1, 'field_name' => 'field_1'])->persist();
@@ -212,7 +229,7 @@ class MailFieldsTableTest extends BcTestCase
 
     /**
      * メールフィールドの値として正しい文字列か検証する
-     * 半角英数-_
+     * 半角小文字英数字とアンダースコア
      */
     public function testHalfTextMailField()
     {
@@ -224,6 +241,27 @@ class MailFieldsTableTest extends BcTestCase
         //case false
         $string = 'abcABC123_';
         $result = $this->MailFieldsTable->halfTextMailField($string);
+        $this->assertFalse($result);
+
+        //case false
+        $string = 'abc123-_';
+        $result = $this->MailFieldsTable->halfTextMailField($string);
+        $this->assertFalse($result);
+    }
+
+    /**
+     * グループ系フィールドの値として正しい文字列か検証する
+     */
+    public function testHalfTextMailGroupField()
+    {
+        //case true
+        $string = 'abcABC123-_';
+        $result = $this->MailFieldsTable->halfTextMailGroupField($string);
+        $this->assertTrue($result);
+
+        //case false
+        $string = 'abcABC123-_:!';
+        $result = $this->MailFieldsTable->halfTextMailGroupField($string);
         $this->assertFalse($result);
     }
 


### PR DESCRIPTION
よろしくお願いします！

<!-- GitHub Copilot コードレビューへの指示: プルリクエストをレビューしてコメントする際には日本語でお願いします。 -->
