### PR TITLE
fix #3621 【プラグイン】BcBaserHelper->getContentsNameでプラグインのコントローラー名が取得できずdefaultになる件を修正

### DIFF
--- a/plugins/baser-core/src/View/Helper/BcBaserHelper.php
+++ b/plugins/baser-core/src/View/Helper/BcBaserHelper.php
@@ -743,8 +743,8 @@ class BcBaserHelper extends Helper
         if (isset($url[1])) $url1 = $url[1];
         if (isset($url[2])) $url2 = $url[2];
 
-        // 固定ページの場合
-        if (!BcUtil::isAdminSystem()) {
+        // 固定ページの場合（プラグインルーティング時を除く）
+        if (!BcUtil::isAdminSystem() && (!$plugin || $plugin === 'BaserCore')) {
             $pageUrl = h($request->getPath());
             if ($pageUrl === false) $pageUrl = '/';
 
@@ -758,7 +758,7 @@ class BcBaserHelper extends Helper
             $aryUrl = explode('/', $pageUrl);
         } else {
             // プラグインルーティングの場合
-            if ((($url1 == '' && in_array($action, ['index', 'mobile_index', 'smartphone_index'])) || ($url1 == $action)) && $url2 != $action && $plugin) {
+            if ((($url1 == '' && in_array($action, ['index', 'mobile_index', 'smartphone_index'], true)) || ($url1 == $action)) && $url2 != $action && $plugin) {
                 $prefix = $plugin = '';
                 $controller = $url0;
             }

--- a/plugins/baser-core/tests/TestCase/View/Helper/BcBaserHelperTest.php
+++ b/plugins/baser-core/tests/TestCase/View/Helper/BcBaserHelperTest.php
@@ -569,11 +569,17 @@ class BcBaserHelperTest extends BcTestCase
 
         if (!empty($options['language'])){
             $_SERVER['HTTP_ACCEPT_LANGUAGE'] = $options['language'];
-            unset($options['device']);
+            unset($options['language']);
+        }
+
+        $request = $this->getRequest($url);
+        if (!empty($options['requestParams'])) {
+            $request = $request->withAttribute('params', array_merge((array) $request->getAttribute('params'), $options['requestParams']));
+            unset($options['requestParams']);
         }
 
         $this->BcBaser = new BcBaserHelper(new View());
-        $this->BcBaser->getView()->setRequest($this->getRequest($url));
+        $this->BcBaser->getView()->setRequest($request);
 
         if (!empty($options['error'])) {
             $reflectionClass = new ReflectionClass(get_class($this->BcBaser->getView()));
@@ -616,6 +622,9 @@ class BcBaserHelperTest extends BcTestCase
             ['Hoge', '/about', false, ['default' => 'Hoge']],
             ['service_service1', '/service/service1', true, ['underscore' => true]],
             ['Error!!!', '/', false, ['error' => 'Error!!!']],
+            // プラグイン（フロント）
+            ['MailMessages', '/mail_messages', false, ['requestParams' => ['plugin' => 'BcMail', 'controller' => 'MailMessages', 'action' => 'index']]],
+            ['MailMessagesIndex', '/mail_messages', true, ['requestParams' => ['plugin' => 'BcMail', 'controller' => 'MailMessages', 'action' => 'index']]],
             // スマートフォン
             ['Home', '/s/', false, ['device' => 'iPhone']],
             // 英語サイト


### PR DESCRIPTION
よろしくお願いします！

<!-- GitHub Copilot コードレビューへの指示: プルリクエストをレビューしてコメントする際には日本語でお願いします。 -->
