### PR TITLE
fix #3012 【API】BcUtil::isAdminSystem でAPI経由で処理しているURLが管理画面ではないと判断される件を修正

### DIFF
--- a/plugins/baser-core/src/Utility/BcUtil.php
+++ b/plugins/baser-core/src/Utility/BcUtil.php
@@ -572,8 +572,18 @@ class BcUtil
                 return false;
             }
         }
-        $adminPrefix = BcUtil::getPrefix(true);
-        return (boolean)(preg_match('/^(|\/)' . $adminPrefix . '\//', $url) || preg_match('/^(|\/)' . $adminPrefix . '$/', $url));
+        $baserCorePrefix = (string) BcUtil::getBaserCorePrefix();
+        $adminAlias = Configure::read('BcPrefixAuth.Admin.alias') ?: '/' . BcUtil::getAdminPrefix();
+        $apiAdminAlias = Configure::read('BcPrefixAuth.Api/Admin.alias')
+            ?: '/' . (string) Configure::read('BcApp.apiPrefix') . '/admin';
+
+        $prefixes = [
+            $baserCorePrefix . $adminAlias,
+            $baserCorePrefix . $apiAdminAlias,
+        ];
+        $prefixes = array_map(fn($prefix) => preg_quote(ltrim($prefix, '/'), '/'), $prefixes);
+
+        return (bool) preg_match('/^\/?(?:' . implode('|', $prefixes) . ')(?:$|\/)/', $url);
     }
 
     /**

--- a/plugins/baser-core/tests/TestCase/Utility/BcUtilTest.php
+++ b/plugins/baser-core/tests/TestCase/Utility/BcUtilTest.php
@@ -349,14 +349,26 @@ class BcUtilTest extends BcTestCase
      *
      * @param string $url 対象URL
      * @param bool $expect 期待値
+     * @param string|null $apiPrefix APIプレフィックス
      * @dataProvider isAdminSystemDataProvider
      */
-    public function testIsAdminSystem($url, $expect)
+    public function testIsAdminSystem($url, $expect, ?string $apiPrefix = null)
     {
         $this->loadFixtureScenario(InitAppScenario::class);
-        $this->getRequest($url);
-        $result = BcUtil::isAdminSystem();
-        $this->assertEquals($expect, $result, '正しく管理システムかチェックできません');
+        $currentApiPrefix = Configure::read('BcApp.apiPrefix');
+        $currentApiAdminAlias = Configure::read('BcPrefixAuth.Api/Admin.alias');
+        if ($apiPrefix !== null) {
+            Configure::write('BcApp.apiPrefix', $apiPrefix);
+            Configure::write('BcPrefixAuth.Api/Admin.alias', '/' . $apiPrefix . '/admin');
+        }
+        try {
+            $this->getRequest($url);
+            $result = BcUtil::isAdminSystem();
+            $this->assertEquals($expect, $result, '正しく管理システムかチェックできません');
+        } finally {
+            Configure::write('BcApp.apiPrefix', $currentApiPrefix);
+            Configure::write('BcPrefixAuth.Api/Admin.alias', $currentApiAdminAlias);
+        }
     }
 
     /**
@@ -371,6 +383,13 @@ class BcUtilTest extends BcTestCase
             ['baser/admin/hoge', true],
             ['/baser/admin/hoge', true],
             ['baser/admin/', true],
+            ['baser/api/admin', true],
+            ['baser/api/admin/hoge', true],
+            ['/baser/api/admin/hoge', true],
+            ['baser/api/admin/', true],
+            ['baser/rest/admin/hoge', true, 'rest'],
+            ['baser/api/admin/hoge', false, 'rest'],
+            ['baser/api', false],
             ['hoge', false],
             ['hoge/', false],
         ];
@@ -1545,7 +1564,7 @@ class BcUtilTest extends BcTestCase
     public static function isSameReferrerAsCurrentDataProvider()
     {
         return [
-            // refererがnullの場合　
+            // refererがnullの場合
             [null, false],
             // referer!=$siteDomainの場合
             ["/baser/admin", false],


### PR DESCRIPTION
よろしくお願いします！
<!-- GitHub Copilot コードレビューへの指示: プルリクエストをレビューしてコメントする際には日本語でお願いします。 -->
