### PR TITLE
ブログの記事数やカテゴリ数が多い場合に、カテゴリ一覧ウィジェットを使用するとメモリオーバーエラーになる

### DIFF
--- a/plugins/bc-blog/src/Model/Table/BlogCategoriesTable.php
+++ b/plugins/bc-blog/src/Model/Table/BlogCategoriesTable.php
@@ -226,6 +226,7 @@ class BlogCategoriesTable extends BlogAppTable
             'conditions' => [],
             'threaded' => false,
             'categoryPostCounts' => [],
+        ], $options);
         if ($viewCount && !$options['threaded'] && empty($options['categoryPostCounts'])) {
             $options['categoryPostCounts'] = $this->getCategoryPostCounts($blogContentId);
         }

--- a/plugins/bc-blog/src/Model/Table/BlogCategoriesTable.php
+++ b/plugins/bc-blog/src/Model/Table/BlogCategoriesTable.php
@@ -226,8 +226,7 @@ class BlogCategoriesTable extends BlogAppTable
             'conditions' => [],
             'threaded' => false,
             'categoryPostCounts' => [],
-        ], $options);
-        if ($viewCount && empty($options['categoryPostCounts'])) {
+        if ($viewCount && !$options['threaded'] && empty($options['categoryPostCounts'])) {
             $options['categoryPostCounts'] = $this->getCategoryPostCounts($blogContentId);
         }
 

--- a/plugins/bc-blog/src/Model/Table/BlogCategoriesTable.php
+++ b/plugins/bc-blog/src/Model/Table/BlogCategoriesTable.php
@@ -224,8 +224,12 @@ class BlogCategoriesTable extends BlogAppTable
             'siteId' => null,
             'order' => 'BlogCategories.lft asc',
             'conditions' => [],
-            'threaded' => false
+            'threaded' => false,
+            'categoryPostCounts' => [],
         ], $options);
+        if ($viewCount && empty($options['categoryPostCounts'])) {
+            $options['categoryPostCounts'] = $this->getCategoryPostCounts($blogContentId);
+        }
 
         // 検索条件
         $conditions = $options['conditions'];
@@ -261,7 +265,6 @@ class BlogCategoriesTable extends BlogAppTable
 
         // 検索実行
         $query = $this->find($findType)
-            ->contain(['BlogPosts' => ['BlogContents' => ['Contents']]])
             ->where($conditions)
             ->select($fields)
             ->orderBy($options['order']);
@@ -280,20 +283,7 @@ class BlogCategoriesTable extends BlogAppTable
             foreach ($entities as $entity) {
                 // 表示件数
                 if ($viewCount) {
-                    $childrenIds = $this->find('list', keyField: 'id', valueField: 'id')
-                        ->where([
-                            ['BlogCategories.lft > ' => $entity->lft],
-                            ['BlogCategories.rght < ' => $entity->rght]
-                        ])->toArray();
-                    $categoryId = [$entity->id];
-                    if ($childrenIds) {
-                        $categoryId = array_merge($categoryId, $childrenIds);
-                    }
-                    $entity->count = $this->BlogPosts->find()
-                        ->where(array_merge(
-                            ['BlogPosts.blog_category_id IN' => $categoryId],
-                            $this->BlogPosts->getConditionAllowPublish()
-                        ))->count();
+                    $entity->count = $options['categoryPostCounts'][$entity->id] ?? 0;
                 }
                 // 子カテゴリ
                 if ($current < $depth) {
@@ -311,6 +301,66 @@ class BlogCategoriesTable extends BlogAppTable
             }
         }
         return $entities;
+    }
+
+    /**
+     * カテゴリごとの記事数を集計
+     *
+     * @param int|null $blogContentId
+     * @return array
+     */
+    private function getCategoryPostCounts(?int $blogContentId): array
+    {
+        $conditions = [];
+        if ($blogContentId) {
+            $conditions['BlogCategories.blog_content_id'] = $blogContentId;
+        }
+        $categories = $this->find()
+            ->select(['id', 'lft', 'rght'])
+            ->where($conditions)
+            ->all()
+            ->toList();
+        if (!$categories) {
+            return [];
+        }
+
+        $postCounts = [];
+        $postConditions = [
+            'blog_category_id IN' => array_column($categories, 'id'),
+            ...$this->BlogPosts->getConditionAllowPublish()
+        ];
+        $query = $this->BlogPosts->find()
+            ->select([
+                'blog_category_id',
+                'post_count' => $this->BlogPosts->find()->func()->count('*')
+            ])
+            ->where($postConditions)
+            ->groupBy('blog_category_id');
+        foreach ($query as $countRow) {
+            $postCounts[$countRow['blog_category_id']] = $countRow['post_count'];
+        }
+
+        $categoryPostCounts = [];
+        foreach ($categories as $category) {
+            $categoryId = $category['id'];
+            $totalCount = $postCounts[$categoryId] ?? 0;
+
+            // 子カテゴリの記事件数を親へ加算
+            foreach ($categories as $targetCategory) {
+                $targetCategoryId = $targetCategory['id'];
+                if ($targetCategoryId === $categoryId) {
+                    continue;
+                }
+                if ($targetCategory['lft'] <= $category['lft'] || $targetCategory['rght'] >= $category['rght']) {
+                    continue;
+                }
+                $totalCount += $postCounts[$targetCategoryId] ?? 0;
+            }
+
+            $categoryPostCounts[$categoryId] = $totalCount;
+        }
+
+        return $categoryPostCounts;
     }
 
     /**

--- a/plugins/bc-blog/src/Model/Table/BlogCategoriesTable.php
+++ b/plugins/bc-blog/src/Model/Table/BlogCategoriesTable.php
@@ -328,10 +328,10 @@ class BlogCategoriesTable extends BlogAppTable
             'blog_category_id IN' => array_column($categories, 'id'),
             ...$this->BlogPosts->getConditionAllowPublish()
         ];
-        $query = $this->BlogPosts->find()
-            ->select([
+        $query = $this->BlogPosts->find();
+        $query->select([
                 'blog_category_id',
-                'post_count' => $this->BlogPosts->find()->func()->count('*')
+                'post_count' => $query->func()->count('*'),
             ])
             ->where($postConditions)
             ->groupBy('blog_category_id');


### PR DESCRIPTION
<!-- GitHub Copilot コードレビューへの指示: プルリクエストをレビューしてコメントする際には日本語でお願いします。 -->

メモリの問題は、BlogCategoriesTableの以下の行を削除することで解決しました。

```
->contain(['BlogPosts' => ['BlogContents' => ['Contents']]])
```

ただ、それだけだとデータ量が多い場合に数十秒ほど処理時間がかかってしまうため、さらに以下の調整を行っています。

- カテゴリ毎に記事数をカウントしている箇所の削除
- 代わりに1回のクエリでカテゴリ毎の記事数を取得するように変更

確認の際に使用したデータ量は以下です。

- カテゴリ数: 109
- 記事数: 300,009

ご確認お願いします。
