### PR TITLE
fix: isValidSchemaFile が FQN の BcSchema 継承を受理するよう修正

### DIFF
--- a/plugins/baser-core/src/Service/BcDatabaseService.php
+++ b/plugins/baser-core/src/Service/BcDatabaseService.php
@@ -1186,7 +1186,10 @@ class BcDatabaseService implements BcDatabaseServiceInterface
 
             public function enterNode(Node $node) {
                 if ($node instanceof Node\Stmt\Class_) {
-                    if ($node->extends && $node->extends->toString() === 'BcSchema') {
+                    // 短縮名 'BcSchema' に加え、完全修飾名 'BaserCore\Database\Schema\BcSchema' も受理する
+                    // （BcDbMigrator 等が FQN で extends を生成するケースに対応。判定対象は同一クラスであり検証意図は変わらない）
+                    $extendsName = $node->extends ? ltrim($node->extends->toString(), '\\') : null;
+                    if ($extendsName === 'BcSchema' || $extendsName === BcSchema::class) {
                         $this->result['extendsBcSchema'] = true;
                         foreach ($node->getMethods() as $method) {
                             $methodName = $method->name->toString();

--- a/plugins/baser-core/tests/TestCase/Service/BcDatabaseServiceTest.php
+++ b/plugins/baser-core/tests/TestCase/Service/BcDatabaseServiceTest.php
@@ -681,6 +681,55 @@ class UserActionsSchema extends BcSchema
     }
 
     /**
+     * Test loadSchema with fully qualified BcSchema
+     *
+     * BcDbMigrator 等が `extends \BaserCore\Database\Schema\BcSchema`（完全修飾名・use 文なし）で
+     * スキーマファイルを生成するケースでも、isValidSchemaFile が受理して読み込めることを検証する。
+     */
+    public function test_loadSchema_withFullyQualifiedBcSchema()
+    {
+        $path = TMP . 'schema' . DS;
+        $fileName = 'UserActionsFqnSchema.php';
+        $schemaFile = new BcFile($path . $fileName, true);
+        $table = 'user_actions_fqn';
+        // 完全修飾名（use 文なし）でスキーマファイルを生成
+        $schemaFile->write("<?php
+class UserActionsFqnSchema extends \\BaserCore\\Database\\Schema\\BcSchema
+{
+    public \$table = '$table';
+    public \$fields = [
+        'id' => ['type' => 'integer', 'autoIncrement' => true],
+        'contents' => ['type' => 'text', 'length' => 100],
+        '_constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
+        ],
+        '_options' => [
+            'engine' => 'InnoDB',
+            'collation' => 'utf8_general_ci'
+        ]
+    ];
+}");
+        // Create処理実行（例外が投げられなければ FQN が受理されている）
+        $this->BcDatabaseService->loadSchema(['type' => 'create', 'path' => $path, 'file' => $fileName]);
+        $tableList = $this->getTableLocator()
+            ->get('BaserCore.App')
+            ->getConnection()
+            ->getSchemaCollection()
+            ->listTables();
+        $this->assertContains($table, $tableList);
+        // Drop処理実行
+        $this->BcDatabaseService->loadSchema(['type' => 'drop', 'path' => $path, 'file' => $fileName]);
+        $tableList = $this->getTableLocator()
+            ->get('BaserCore.App')
+            ->getConnection()
+            ->getSchemaCollection()
+            ->listTables();
+        $this->assertNotContains($table, $tableList);
+        // スキーマファイルを削除
+        $schemaFile->delete();
+    }
+
+    /**
      * Test getDatasourceName
      * @param $value
      * @param $expected


### PR DESCRIPTION
## 背景

`BcDatabaseService::isValidSchemaFile()` は、スキーマファイルの `extends` を AST で検査する際、**短縮名 `BcSchema` の完全一致のみ**を許可していました。

そのため、スキーマファイルが完全修飾名（FQN）で定義されている場合:

```php
class FooSchema extends \BaserCore\Database\Schema\BcSchema
```

`$node->extends->toString()` が `BaserCore\Database\Schema\BcSchema` を返し、`'BcSchema'` と一致しないため、`無効なスキーマファイル: BcSchema を継承し、drop/create メソッドをオーバーライドしてはいけません` として弾かれ、`loadSchema()` が失敗します。

これは **BcDbMigrator** が変換時に FQN 形式で `extends` を生成するため、変換済みバックアップの復元/読込で顕在化します。

## 修正内容

extends の判定を、短縮名 `BcSchema` に加え **FQN（`BcSchema::class`）も受理**するよう変更しました。判定対象は同一クラスであり、検証意図（BcSchema を継承し drop/create をオーバーライドしていないこと）は変わりません。

## テスト

`BcDatabaseServiceTest::test_loadSchema_withFullyQualifiedBcSchema` を追加し、FQN 形式（`use` 文なし）のスキーマで `loadSchema` が create/drop とも成功することを検証しています（修正前は当該例外で RED になることを確認済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)