### PR TITLE
fix #3999 【アップロード管理】一覧でコピーした時に50文字を超えると通常のエラーメッセージではなくデータベースのエラーが出てしまう件を修正

### DIFF
--- a/plugins/bc-uploader/src/Controller/Admin/UploaderCategoriesController.php
+++ b/plugins/bc-uploader/src/Controller/Admin/UploaderCategoriesController.php
@@ -169,9 +169,14 @@ class UploaderCategoriesController extends BcAdminAppController
                 $entity = $service->get($id);
                 $this->BcMessage->setSuccess(__d('baser_core', 'アップロードカテゴリ「{0}」をコピーしました。', $entity->name));
             } else {
-                $this->BcMessage->setError(__d('baser_core', 'データベース処理中にエラーが発生しました。'));
+                $this->BcMessage->setError(__d('baser_core', 'データが見つかりません。'));
             }
-        } catch (\Throwable $e) {
+        } catch (PersistenceFailedException $e) {
+            $errors = $e->getEntity()->getErrors();
+            $nameErrors = $errors['name'] ?? null;
+            $message = $nameErrors ? (string)current($nameErrors) : __d('baser_core', '入力エラーです。内容を修正してください。');
+            $this->BcMessage->setError($message);
+        } catch (Throwable $e) {
             $this->BcMessage->setError(__d('baser_core', 'データベース処理中にエラーが発生しました。') . $e->getMessage());
         }
         return $this->redirect(['action' => 'index']);

--- a/plugins/bc-uploader/src/Controller/Api/Admin/UploaderCategoriesController.php
+++ b/plugins/bc-uploader/src/Controller/Api/Admin/UploaderCategoriesController.php
@@ -170,26 +170,33 @@ class UploaderCategoriesController extends BcAdminApiController
     {
         $this->request->allowMethod(['patch', 'post', 'put']);
         $uploaderCategory = null;
+        $errors = null;
         try {
             $uploaderCategory = $service->copy($id);
             if ($uploaderCategory) {
                 $message = __d('baser_core', 'アップロードカテゴリ「{0}」をコピーしました。', $uploaderCategory->name);
                 $this->BcMessage->setSuccess($message, true, false);
             } else {
-                $this->setResponse($this->response->withStatus(400));
-                $message = __d('baser_core', 'データベース処理中にエラーが発生しました。');
+                $this->setResponse($this->response->withStatus(404));
+                $message = __d('baser_core', 'データが見つかりません。');
             }
+        } catch (PersistenceFailedException $e) {
+            $uploaderCategory = $e->getEntity();
+            $errors = $uploaderCategory->getErrors();
+            $message = __d('baser_core', '入力エラーです。内容を修正してください。');
+            $this->setResponse($this->response->withStatus(400));
         } catch (\Throwable $e) {
-            $message = __d('baser_core', 'データベース処理中にエラーが発生しました。' . $e->getMessage());
+            $message = __d('baser_core', 'データベース処理中にエラーが発生しました。') . $e->getMessage();
             $this->setResponse($this->response->withStatus(500));
         }
 
         $this->set([
             'message' => $message,
-            'uploaderCategory' => $uploaderCategory
+            'uploaderCategory' => $uploaderCategory,
+            'errors' => $errors
         ]);
 
-        $this->viewBuilder()->setOption('serialize', ['message', 'uploaderCategory']);
+        $this->viewBuilder()->setOption('serialize', ['message', 'uploaderCategory', 'errors']);
     }
 
     /**

--- a/plugins/bc-uploader/src/Model/Table/UploaderCategoriesTable.php
+++ b/plugins/bc-uploader/src/Model/Table/UploaderCategoriesTable.php
@@ -68,6 +68,7 @@ class UploaderCategoriesTable extends AppTable
             ->allowEmptyString('id', null, 'create');
         $validator
             ->scalar('name')
+            ->maxLength('name', 50, __d('baser_core', 'カテゴリ名は50文字以内で入力してください。'))
             ->add('name', [
                 'notBlankOnlyString' => [
                     'rule' => ['notBlankOnlyString'],
@@ -89,9 +90,17 @@ class UploaderCategoriesTable extends AppTable
      * @noTodo
      * @unitTest
      */
-    public function copy($id = null, $entity = [])
+    public function copy($id = null, $entity = null)
     {
-        if ($id) $entity = $this->find()->where(['UploaderCategories.id' => $id])->first();
+        if ($id) {
+            $entity = $this->find()->where(['UploaderCategories.id' => $id])->first();
+            if (!$entity) {
+                return false;
+            }
+        }
+        if (!$entity) {
+            return false;
+        }
         $oldEntity = clone $entity;
 
         // EVENT UploaderCategories.beforeCopy
@@ -121,10 +130,6 @@ class UploaderCategoriesTable extends AppTable
 
             return $entity;
         } catch (PersistenceFailedException $e) {
-            $entity = $e->getEntity();
-            if($entity->getError('name')) {
-                return $this->copy(null, $entity);
-            }
             throw $e;
         } catch (\Throwable $e) {
             throw $e;

--- a/plugins/bc-uploader/tests/TestCase/Controller/Admin/UploaderCategoriesControllerTest.php
+++ b/plugins/bc-uploader/tests/TestCase/Controller/Admin/UploaderCategoriesControllerTest.php
@@ -13,6 +13,7 @@ namespace BcUploader\Test\TestCase\Controller\Admin;
 
 use BaserCore\Test\Scenario\InitAppScenario;
 use BaserCore\TestSuite\BcTestCase;
+use BcUploader\Test\Factory\UploaderCategoryFactory;
 use BcUploader\Test\Scenario\UploaderCategoriesScenario;
 use Cake\Datasource\ConnectionManager;
 use Cake\Event\Event;
@@ -240,6 +241,23 @@ class UploaderCategoriesControllerTest extends BcTestCase
         //異常系実行
         $this->post('/baser/admin/bc-uploader/uploader_categories/copy/10');
         $this->assertResponseCode(302);
-        $this->assertFlashMessage('データベース処理中にエラーが発生しました。__clone method called on non-object');
+        $this->assertFlashMessage(__d('baser_core', 'データが見つかりません。'));
+    }
+
+    /**
+     * test copy max length error
+     */
+    public function test_copy_max_length_error()
+    {
+        $this->enableSecurityToken();
+        $this->enableCsrfToken();
+
+        UploaderCategoryFactory::make(['id' => 1, 'name' => str_repeat('a', 48)])->persist();
+
+        $this->post('/baser/admin/bc-uploader/uploader_categories/copy/1');
+        $this->assertResponseCode(302);
+        $this->assertFlashMessage(__d('baser_core', 'カテゴリ名は50文字以内で入力してください。'));
+        $this->assertRedirect('/baser/admin/bc-uploader/uploader_categories/index');
+        $this->assertEquals(1, TableRegistry::getTableLocator()->get('BcUploader.UploaderCategories')->find()->count());
     }
 }

--- a/plugins/bc-uploader/tests/TestCase/Controller/Api/UploaderCategoriesControllerTest.php
+++ b/plugins/bc-uploader/tests/TestCase/Controller/Api/UploaderCategoriesControllerTest.php
@@ -116,17 +116,18 @@ class UploaderCategoriesControllerTest extends BcTestCase
         $this->assertEquals('入力エラーです。内容を修正してください。', $result->message);
         $this->assertEquals('カテゴリ名を入力してください。', $result->errors->name->_empty);
 
-        //500エラーを確認
+        //400エラーを確認
         $data = [
             'name' => 'name...................................................'
         ];
         //APIを呼ぶ
         $this->post("/baser/api/admin/bc-uploader/uploader_categories/add.json?token=" . $this->accessToken, $data);
         //ステータスを確認
-        $this->assertResponseCode(500);
+        $this->assertResponseCode(400);
         //戻る値を確認
         $result = json_decode((string)$this->_response->getBody());
-        $this->assertEquals("データベース処理中にエラーが発生しました。SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'name' at row 1", $result->message);
+        $this->assertEquals('入力エラーです。内容を修正してください。', $result->message);
+        $this->assertEquals('カテゴリ名は50文字以内で入力してください。', $result->errors->name->maxLength);
     }
 
     /**
@@ -183,17 +184,28 @@ class UploaderCategoriesControllerTest extends BcTestCase
         $this->assertResponseSuccess();
         //戻る値を確認
         $result = json_decode((string)$this->_response->getBody());
-        $this->assertEquals('アップロードカテゴリ「blog_copy」をコピーしました。', $result->message);
+        $this->assertEquals(__d('baser_core', 'アップロードカテゴリ「{0}」をコピーしました。', 'blog_copy'), $result->message);
         $this->assertEquals('blog_copy', $result->uploaderCategory->name);
 
         //無効なアップロードカテゴリIDを指定した場合、
         //APIを呼ぶ
         $this->post("/baser/api/admin/bc-uploader/uploader_categories/copy/11.json?token=" . $this->accessToken);
         //ステータスを確認
-        $this->assertResponseCode(500);
+        $this->assertResponseCode(404);
         //戻る値を確認
         $result = json_decode((string)$this->_response->getBody());
-        $this->assertEquals('データベース処理中にエラーが発生しました。__clone method called on non-object', $result->message);
+        $this->assertEquals(__d('baser_core', 'データが見つかりません。'), $result->message);
+
+        // 48文字名をコピーすると _copy 付与で50文字超過になるため入力エラーになる
+        $uploaderCategories = $this->getTableLocator()->get('BcUploader.UploaderCategories');
+        $uploaderCategory = $uploaderCategories->get(1);
+        $uploaderCategory->name = str_repeat('a', 48);
+        $uploaderCategories->saveOrFail($uploaderCategory);
+        $this->post("/baser/api/admin/bc-uploader/uploader_categories/copy/1.json?token=" . $this->accessToken);
+        $this->assertResponseCode(400);
+        $result = json_decode((string)$this->_response->getBody());
+        $this->assertEquals(__d('baser_core', '入力エラーです。内容を修正してください。'), $result->message);
+        $this->assertEquals(__d('baser_core', 'カテゴリ名は50文字以内で入力してください。'), $result->errors->name->maxLength);
     }
 
     /**

--- a/plugins/bc-uploader/tests/TestCase/Model/Table/UploaderCategoriesTableTest.php
+++ b/plugins/bc-uploader/tests/TestCase/Model/Table/UploaderCategoriesTableTest.php
@@ -15,6 +15,7 @@ use BaserCore\TestSuite\BcTestCase;
 use BcUploader\Model\Table\UploaderCategoriesTable;
 use BcUploader\Test\Factory\UploaderCategoryFactory;
 use Cake\Event\Event;
+use Cake\ORM\Exception\PersistenceFailedException;
 use Cake\ORM\TableRegistry;
 
 /**
@@ -125,5 +126,21 @@ class UploaderCategoriesTableTest extends BcTestCase
         $rs = $this->UploaderCategoriesTable->copy(1);
         //イベントに入るかどうか確認
         $this->assertEquals('AfterCopy', $rs->name);
+    }
+
+    /**
+     * test copy max length error
+     */
+    public function testCopyMaxLengthError()
+    {
+        UploaderCategoryFactory::make(['id' => 1, 'name' => str_repeat('a', 48)])->persist();
+
+        try {
+            $this->UploaderCategoriesTable->copy(1);
+            $this->fail('PersistenceFailedException が発生しませんでした。');
+        } catch (PersistenceFailedException $e) {
+            $this->assertArrayHasKey('name', $e->getEntity()->getErrors());
+            $this->assertArrayHasKey('maxLength', $e->getEntity()->getErrors()['name']);
+        }
     }
 }

--- a/plugins/bc-uploader/tests/TestCase/Service/UploadCategoriesServiceTest.php
+++ b/plugins/bc-uploader/tests/TestCase/Service/UploadCategoriesServiceTest.php
@@ -198,6 +198,22 @@ class UploadCategoriesServiceTest extends BcTestCase
     }
 
     /**
+     * test copy max length error
+     */
+    public function test_copy_max_length_error()
+    {
+        UploaderCategoryFactory::make(['id' => 1, 'name' => str_repeat('a', 48)])->persist();
+
+        try {
+            $this->UploaderCategoriesService->copy(1);
+            $this->fail('PersistenceFailedException が発生しませんでした。');
+        } catch (PersistenceFailedException $e) {
+            $this->assertArrayHasKey('name', $e->getEntity()->getErrors());
+            $this->assertArrayHasKey('maxLength', $e->getEntity()->getErrors()['name']);
+        }
+    }
+
+    /**
      * test batch
      */
     public function test_batch()


### PR DESCRIPTION

<!-- GitHub Copilot コードレビューへの指示: プルリクエストをレビューしてコメントする際には日本語でお願いします。 -->
