### PR TITLE
閉じタグ忘れが原因でサイト内検索でエラーが起きるため修正

### DIFF
--- a/plugins/bc-front/templates/element/list_counter.php
+++ b/plugins/bc-front/templates/element/list_counter.php
@@ -29,6 +29,7 @@
           '<strong>{{start}}</strong>',
           '<strong>{{end}}</strong>',
           '{{count}}'
+        )
       ) ?>
   </div>
 <?php endif ?>


### PR DESCRIPTION
@ryuring 

サイト検索の箇所で検索を押した際にエラーが発生しておりました。
原因は閉じタグ忘れです。ご確認をお願いします。