### PR TITLE
名前[姓]/名前[名]に半角・全角スペースが登録できてしまう件の修正 

### DIFF
--- a/plugins/baser-core/src/Model/Table/UsersTable.php
+++ b/plugins/baser-core/src/Model/Table/UsersTable.php
@@ -79,6 +79,11 @@ class UsersTable extends AppTable
             (isset($data['password_2']) && $data['password_2'] !== '')) {
             $data['password'] = $data['password_1'];
         }
+        foreach(['real_name_1', 'real_name_2'] as $field) {
+            if (isset($data[$field]) && is_string($data[$field])) {
+                $data[$field] = preg_replace('/^[ 　]+|[ 　]+$/u', '', $data[$field]);
+            }
+        }
     }
 
     /**
@@ -151,25 +156,11 @@ class UsersTable extends AppTable
             ->scalar('real_name_1')
             ->maxLength('real_name_1', 50, __d('baser_core', '名前[姓]は50文字以内で入力してください。'))
             ->requirePresence('real_name_1', 'create', __d('baser_core', '名前[姓]を入力してください。'))
-            ->notEmptyString('real_name_1', __d('baser_core', '名前[姓]を入力してください。'))
-            ->add('real_name_1', [
-                'noWhitespace' => [
-                    'rule' => function ($value) {
-                        return !preg_match('/[ 　]/u', $value);
-                    },
-                    'message' => __d('baser_core', '名前[姓]に半角・全角スペースは使用できません。')
-                ]]);
+            ->notEmptyString('real_name_1', __d('baser_core', '名前[姓]を入力してください。'));
         $validator
             ->scalar('real_name_2')
             ->maxLength('real_name_2', 50, __d('baser_core', '名前[名]は50文字以内で入力してください。'))
-            ->allowEmptyString('real_name_2')
-            ->add('real_name_2', [
-                'noWhitespace' => [
-                    'rule' => function ($value) {
-                        return !preg_match('/[ 　]/u', $value);
-                    },
-                    'message' => __d('baser_core', '名前[名]に半角・全角スペースは使用できません。')
-                ]]);
+            ->allowEmptyString('real_name_2');
         $validator
             ->scalar('nickname')
             ->maxLength('nickname', 255, __d('baser_core', 'ニックネームは255文字以内で入力してください。'))

--- a/plugins/baser-core/src/Model/Table/UsersTable.php
+++ b/plugins/baser-core/src/Model/Table/UsersTable.php
@@ -151,11 +151,25 @@ class UsersTable extends AppTable
             ->scalar('real_name_1')
             ->maxLength('real_name_1', 50, __d('baser_core', '名前[姓]は50文字以内で入力してください。'))
             ->requirePresence('real_name_1', 'create', __d('baser_core', '名前[姓]を入力してください。'))
-            ->notEmptyString('real_name_1', __d('baser_core', '名前[姓]を入力してください。'));
+            ->notEmptyString('real_name_1', __d('baser_core', '名前[姓]を入力してください。'))
+            ->add('real_name_1', [
+                'noWhitespace' => [
+                    'rule' => function ($value) {
+                        return !preg_match('/[\s　]/u', $value);
+                    },
+                    'message' => __d('baser_core', '名前[姓]に半角・全角スペースは使用できません。')
+                ]]);
         $validator
             ->scalar('real_name_2')
             ->maxLength('real_name_2', 50, __d('baser_core', '名前[名]は50文字以内で入力してください。'))
-            ->allowEmptyString('real_name_2');
+            ->allowEmptyString('real_name_2')
+            ->add('real_name_2', [
+                'noWhitespace' => [
+                    'rule' => function ($value) {
+                        return !preg_match('/[\s　]/u', $value);
+                    },
+                    'message' => __d('baser_core', '名前[名]に半角・全角スペースは使用できません。')
+                ]]);
         $validator
             ->scalar('nickname')
             ->maxLength('nickname', 255, __d('baser_core', 'ニックネームは255文字以内で入力してください。'))

--- a/plugins/baser-core/src/Model/Table/UsersTable.php
+++ b/plugins/baser-core/src/Model/Table/UsersTable.php
@@ -155,7 +155,7 @@ class UsersTable extends AppTable
             ->add('real_name_1', [
                 'noWhitespace' => [
                     'rule' => function ($value) {
-                        return !preg_match('/[\s　]/u', $value);
+                        return !preg_match('/[ 　]/u', $value);
                     },
                     'message' => __d('baser_core', '名前[姓]に半角・全角スペースは使用できません。')
                 ]]);
@@ -166,7 +166,7 @@ class UsersTable extends AppTable
             ->add('real_name_2', [
                 'noWhitespace' => [
                     'rule' => function ($value) {
-                        return !preg_match('/[\s　]/u', $value);
+                        return !preg_match('/[ 　]/u', $value);
                     },
                     'message' => __d('baser_core', '名前[名]に半角・全角スペースは使用できません。')
                 ]]);

--- a/plugins/baser-core/tests/TestCase/Model/Table/UsersTableTest.php
+++ b/plugins/baser-core/tests/TestCase/Model/Table/UsersTableTest.php
@@ -93,6 +93,37 @@ class UsersTableTest extends BcTestCase
     }
 
     /**
+     * Test beforeMarshal
+     *
+     * real_name_1/real_name_2 は前後の半角・全角スペースのみ除去し、間のスペースは保持すること
+     */
+    public function testBeforeMarshalTrimsRealName()
+    {
+        $user = $this->Users->newEntity([
+            'real_name_1' => " 　山田　太郎 　",
+            'real_name_2' => " 　鈴木　一郎 　",
+        ], ['validate' => false]);
+        $this->assertEquals('山田　太郎', $user->real_name_1);
+        $this->assertEquals('鈴木　一郎', $user->real_name_2);
+    }
+
+    /**
+     * Test beforeMarshal
+     *
+     * real_name_1/real_name_2 がスペースのみの場合、トリムされて空文字になり、
+     * real_name_1 は必須バリデーションでエラーになり、real_name_2 は空文字を許容してエラーにならないこと
+     */
+    public function testBeforeMarshalRealNameOnlySpace()
+    {
+        $user = $this->Users->newEntity([
+            'real_name_1' => '   ',
+            'real_name_2' => '　　　',
+        ]);
+        $this->assertNotEmpty($user->getError('real_name_1'));
+        $this->assertEmpty($user->getError('real_name_2'));
+    }
+
+    /**
      * Test afterMarshal
      */
     public function testAfterMarshal()


### PR DESCRIPTION
@ryuring
以下の改修を行いましたので、レビューお願いします。

改修内容：
- 名前に全角または半角スペースを入力して保存すると、「名前[姓]に半角・全角スペースは使用できません。」というバリデーションチェックが行われるようにする。