### PR TITLE
選択リスト入力箇所　必須項目に対して、必須マークがなかったため追加

### DIFF
--- a/plugins/bc-admin-third/templates/plugin/BcMail/Admin/element/MailFields/form.php
+++ b/plugins/bc-admin-third/templates/plugin/BcMail/Admin/element/MailFields/form.php
@@ -156,7 +156,9 @@
     </tr>
     <tr id="RowSource">
       <th
-        class="col-head bca-form-table__label"><?php echo $this->BcAdminForm->label('source', __d('baser_core', '選択リスト')) ?></th>
+        class="col-head bca-form-table__label"><?php echo $this->BcAdminForm->label('source', __d('baser_core', '選択リスト')) ?>
+        &nbsp;<span class="bca-label" data-bca-label-type="required"><?php echo __d('baser_core', '必須') ?></span>
+      </th>
       <td class="col-input bca-form-table__input">
         <?php echo $this->BcAdminForm->control('source', ['type' => 'textarea', 'cols' => 35, 'rows' => 4]) ?>
         <i class="bca-icon--question-circle bca-help"></i>

--- a/plugins/bc-admin-third/templates/plugin/BcMail/Admin/element/MailFields/form.php
+++ b/plugins/bc-admin-third/templates/plugin/BcMail/Admin/element/MailFields/form.php
@@ -157,6 +157,7 @@
     <tr id="RowSource">
       <th
         class="col-head bca-form-table__label"><?php echo $this->BcAdminForm->label('source', __d('baser_core', '選択リスト')) ?>
+        &nbsp;<span class="bca-label" data-bca-label-type="required"><?php echo __d('baser_core', '必須') ?></span>
       </th>
       <td class="col-input bca-form-table__input">
         <?php echo $this->BcAdminForm->control('source', ['type' => 'textarea', 'cols' => 35, 'rows' => 4]) ?>

--- a/plugins/bc-admin-third/templates/plugin/BcMail/Admin/element/MailFields/form.php
+++ b/plugins/bc-admin-third/templates/plugin/BcMail/Admin/element/MailFields/form.php
@@ -157,7 +157,6 @@
     <tr id="RowSource">
       <th
         class="col-head bca-form-table__label"><?php echo $this->BcAdminForm->label('source', __d('baser_core', '選択リスト')) ?>
-        &nbsp;<span class="bca-label" data-bca-label-type="required"><?php echo __d('baser_core', '必須') ?></span>
       </th>
       <td class="col-input bca-form-table__input">
         <?php echo $this->BcAdminForm->control('source', ['type' => 'textarea', 'cols' => 35, 'rows' => 4]) ?>


### PR DESCRIPTION
@ryuring 

メールフィールドの登録箇所において、選択リストが必須項目にも関わらず、必須マークがついていなかったため追加しました。

ご確認お願いします。