### PR TITLE
ユーザーグループ登録時に半角スペースが登録できてしまう件の改修

### DIFF
--- a/plugins/baser-core/src/Model/Table/UserGroupsTable.php
+++ b/plugins/baser-core/src/Model/Table/UserGroupsTable.php
@@ -90,6 +90,12 @@ class UserGroupsTable extends AppTable
                     'provider' => 'bc',
                     'message' => __d('baser_core', 'ユーザーグループ名は半角のみで入力してください。')
                 ],
+                'noWhitespace' => [
+                    'rule' => function ($value) {
+                        return !preg_match('/[ 　]/u', $value);
+                    },
+                    'message' => __d('baser_core', 'ユーザーグループ名にスペースは使用できません。')
+                ],
                 'name_unique' => [
                     'rule' => 'validateUnique',
                     'provider' => 'table',


### PR DESCRIPTION
@ryuring 
こちらの確認をお願いします！

改修内容：
半角/全角スペースを入力して登録すると、「ユーザーグループ名にスペースは使用できません。」というバリデーションチェックがでるよう追加。
