### PR TITLE
ユーザーグループ登録時に表示名に半角・全角スペースが使用できてしまう件を解消

### DIFF
--- a/plugins/baser-core/src/Model/Table/UserGroupsTable.php
+++ b/plugins/baser-core/src/Model/Table/UserGroupsTable.php
@@ -107,6 +107,12 @@ class UserGroupsTable extends AppTable
                     'rule' => 'validateUnique',
                     'provider' => 'table',
                     'message' => __d('baser_core', '既に登録のある表示名です。')
+                ],
+                'noWhitespace' => [
+                    'rule' => function ($value) {
+                        return !preg_match('/[ 　]/u', $value);
+                    },
+                    'message' => __d('baser_core', '表示名に半角・全角スペースは使用できません。')
                 ]]);
 
         $validator


### PR DESCRIPTION
@ryuring 

改修内容：
ユーザーグループ登録時に表示名に半角・全角スペースを入力すると、「表示名に半角・全角スペースは使用できません。」というバリデーションがチェックが働くようにする。
