### PR TITLE
「上書きを許容する」にチェックをし、アップロードしたファイルと同一のファイルを選択すると、エラーが発生するため修正

### DIFF
--- a/plugins/bc-uploader/src/Service/UploaderFilesService.php
+++ b/plugins/bc-uploader/src/Service/UploaderFilesService.php
@@ -243,7 +243,7 @@ class UploaderFilesService implements UploaderFilesServiceInterface
      */
     public function update(EntityInterface $entity, array $postData)
     {
-        if(!$this->isEditable($postData)) {
+        if(!$this->isEditable($entity->toArray())) {
             throw new BcException(__d('baser_core', 'ファイルの変更権限がありません。' ));
         }
         if(!empty($postData['overwrite']) && !empty($postData['file'])) {


### PR DESCRIPTION
@ryuring 

アップローダー設定の「投稿者本人か管理者のみ編集可」の制限（use_permission）を有効にした場合に発生します。
UploaderFilesService::update() 内の権限チェック isEditable() に、画面から送信された生データ（$postData）を渡していましたが、上書きアップロード時は対象ファイルの所有者情報（user_id）が含まれていないため、常に「権限なし」と判定され、エラーになっていました。

対応として削除の処理に合わせて、送信データからエンティティの情報を渡すように修正しました。

ご確認お願いします。

