### PR TITLE
プラグイン初期化後のメッセージを変更

### DIFF
--- a/plugins/baser-core/src/Controller/Admin/PluginsController.php
+++ b/plugins/baser-core/src/Controller/Admin/PluginsController.php
@@ -327,7 +327,7 @@ class PluginsController extends BcAdminAppController
             $service->resetDb($this->request->getData('name'), $this->request->getData('connection') ?? 'default');
             $usersService->reLogin($this->request, $this->response);
             $this->BcMessage->setSuccess(
-                __d('baser_core', '{0} プラグインのデータを初期化しました。', $plugin->title)
+                __d('baser_core', 'プラグイン「{0}」のデータを初期化しました。', $plugin->title)
             );
         } catch(\Exception $e) {
             $this->BcMessage->setError(__d('baser_core', 'リセット処理中にエラーが発生しました。') . $e->getMessage());


### PR DESCRIPTION
@ryuring 

改修内容：
プラグイン初期化後のメッセージを[`プラグイン名プラグインのデータを初期化しました。`→`プラグイン「プラグイン名」のデータを初期化しました。`に変更