### PR TITLE
カスタムコンテンツのテーブルのタイトルで半角・全角スペースが登録できてしまうのでバリデーションエラー追加

### DIFF
--- a/plugins/bc-custom-content/src/Model/Table/CustomTablesTable.php
+++ b/plugins/bc-custom-content/src/Model/Table/CustomTablesTable.php
@@ -116,7 +116,14 @@ class CustomTablesTable extends AppTable
         $validator
             ->scalar('title')
             ->maxLength('title', 255, __d('baser_core', '255文字以内で入力してください。'))
-            ->notEmptyString('title', __d('baser_core', 'タイトルを入力してください。'));
+            ->notEmptyString('title', __d('baser_core', 'タイトルを入力してください。'))
+            ->add('title', [
+                'bcUtileUrlencodeBlank' => [
+                    'rule' => ['bcUtileUrlencodeBlank'],
+                    'provider' => 'bc',
+                    'message' => __d('baser_core', 'タイトルはスペース、全角スペース及び、指定の記号(\\\'|`^"(){}[];/?:@&=+$,%<>#!)だけの名前は付けられません。')
+                ]
+            ]);
 
         return $validator;
     }

--- a/plugins/bc-custom-content/tests/TestCase/Model/Table/CustomTablesTableTest.php
+++ b/plugins/bc-custom-content/tests/TestCase/Model/Table/CustomTablesTableTest.php
@@ -98,6 +98,11 @@ class CustomTablesTableTest extends BcTestCase
             'name' => 'あ',
         ]);
         $this->assertEquals('識別名は半角英数小文字とアンダースコアのみで入力してください。', current($errors['name']));
+        //タイトルが半角スペース、全角スペースのみで構成されている
+        $errors = $validator->validate([
+            'title' => '　 ',
+        ]);
+        $this->assertEquals('タイトルはスペース、全角スペース及び、指定の記号(\\\'|`^"(){}[];/?:@&=+$,%<>#!)だけの名前は付けられません。', current($errors['title']));
         //正常系実行
         $errors = $validator->validate([
             'name' => 'test',


### PR DESCRIPTION
@ryuring 

カスタムコンテンツのテーブルのタイトルで半角・全角スペースが登録できてしまうのでバリデーションエラー追加追加しています。記述方法は既存のplugins/baser-core/src/Model/Table/ContentsTable.phpの書き方と合わせています。

ご確認お願いします。