### PR TITLE
カスタムコンテンツの一覧表示件数　必須項目だがバリデーションエラーが設定されていないため設定

### DIFF
--- a/plugins/bc-custom-content/src/Model/Table/CustomContentsTable.php
+++ b/plugins/bc-custom-content/src/Model/Table/CustomContentsTable.php
@@ -62,6 +62,7 @@ class CustomContentsTable extends AppTable
         $validator->setProvider('bc', 'BaserCore\Model\Validation\BcValidation');
         $validator->allowEmptyString('list_count')
             ->range('list_count', [0, 100], __d('baser_core', '一覧表示件数は100までの数値で入力してください。'))
+            ->notEmptyString('list_count', '一覧表示件数を入力してください。')
             ->add('list_count', 'halfText', [
                 'provider' => 'bc',
                 'rule' => 'halfText',

--- a/plugins/bc-custom-content/tests/TestCase/Model/Table/CustomContentsTableTest.php
+++ b/plugins/bc-custom-content/tests/TestCase/Model/Table/CustomContentsTableTest.php
@@ -93,6 +93,15 @@ class CustomContentsTableTest extends BcTestCase
         $this->assertEquals([
             'range' => '一覧表示件数は100までの数値で入力してください。',
         ], $errors['list_count']);
+
+        //空文字を入力した場合
+        $validator = $this->CustomContentsTable->getValidator('withTable');
+        $errors = $validator->validate([
+            'list_count' => ''
+        ]);
+        $this->assertEquals([
+            '_empty' => '一覧表示件数を入力してください。'
+        ], $errors['list_count']);
     }
 
     /**


### PR DESCRIPTION
@ryuring 

カスタムコンテンツの一覧表示件数　必須項目ですがバリデーションエラーが設定されていなかったため追加しています。
ご確認お願いします。