### PR TITLE
カスタムコンテンツ：フィールド編集：日付（年月日）のプレビュー　説明を削除

### DIFF
--- a/plugins/bc-custom-content/plugins/BcCcDate/src/View/Helper/BcCcDateHelper.php
+++ b/plugins/bc-custom-content/plugins/BcCcDate/src/View/Helper/BcCcDateHelper.php
@@ -68,7 +68,7 @@ class BcCcDateHelper extends Helper
         $options = [
             'v-model' => "entity.default_value"
         ];
-        return $this->control($link, $options) . '<br>※ 初期値はハイフン区切りで入力してください。';
+        return $this->control($link, $options);
     }
 
     /**


### PR DESCRIPTION
@ryuring 

初期値の説明がプレビューに出力されていたため削除しています。
ご確認お願いします。