### PR TITLE
フィールド一覧画面に「必須」項目の削除

### DIFF
--- a/plugins/bc-admin-third/templates/plugin/BcCustomContent/Admin/element/CustomFields/index_list.php
+++ b/plugins/bc-admin-third/templates/plugin/BcCustomContent/Admin/element/CustomFields/index_list.php
@@ -57,12 +57,6 @@ $this->BcListTable->setColumnNumber(8);
       ], ['escape' => false, 'class' => 'btn-direction bca-table-listup__a']) ?>
     </th>
     <th class="bca-table-listup__thead-th">
-      <?php echo $this->Paginator->sort('required', [
-        'asc' => '<i class="bca-icon--asc"></i>' . __d('baser_core', '必須'),
-        'desc' => '<i class="bca-icon--desc"></i>' . __d('baser_core', '必須')
-      ], ['escape' => false, 'class' => 'btn-direction bca-table-listup__a']) ?>
-    </th>
-    <th class="bca-table-listup__thead-th">
       <?php echo $this->Paginator->sort('status', [
         'asc' => '<i class="bca-icon--asc"></i>' . __d('baser_core', '利用状況'),
         'desc' => '<i class="bca-icon--desc"></i>' . __d('baser_core', '利用状況')

--- a/plugins/bc-admin-third/templates/plugin/BcCustomContent/Admin/element/CustomFields/index_row.php
+++ b/plugins/bc-admin-third/templates/plugin/BcCustomContent/Admin/element/CustomFields/index_row.php
@@ -28,7 +28,6 @@
   </td>
   <td class="bca-table-listup__tbody-td"><?php echo h($entity->title) ?></td>
   <td class="bca-table-listup__tbody-td"><?php echo h($entity->getTypeTitle()) ?></td>
-  <td class="bca-table-listup__tbody-td"><?php echo $this->BcText->booleanMark($entity->required) ?></td>
   <td class="bca-table-listup__tbody-td"><?php echo $this->BcText->booleanMark($entity->status) ?></td>
 
   <?php echo $this->BcListTable->dispatchShowRow($entity) ?>


### PR DESCRIPTION
@ryuring 

BcCustomContentのフィールド一覧画面に「必須」という項目がありますが、フィールド編集画面の中に「必須」という項目が無いため全て「ー」になって並べ替えもできません。
そのため、「必須」項目は意味のない出力をしているため削除しました。

ご確認お願いします。