### PR TITLE
新規登録時に検索インデックスを作成していないため修正

### DIFF
--- a/plugins/bc-blog/src/Model/Table/BlogPostsTable.php
+++ b/plugins/bc-blog/src/Model/Table/BlogPostsTable.php
@@ -245,6 +245,13 @@ class BlogPostsTable extends BlogAppTable
             return;
         }
         $this->unsetExcluded();
+        // 新規登録時など blog_content が未ロードの場合は明示的に取得する
+        if (empty($entity->blog_content) && !empty($entity->blog_content_id)) {
+            $entity->blog_content = $this->BlogContents->find()
+                ->where(['BlogContents.id' => $entity->blog_content_id])
+                ->contain(['Contents'])
+                ->first();
+        }
         // 検索用テーブルに登録
         if ($entity->exclude_search
             || empty($entity->blog_content->content)


### PR DESCRIPTION
@ryuring 

## 概要

ブログ記事を新規作成した際にサイト内検索用の検索インデックス(`search_indexes`)が作成されず、サイト内検索にヒットしない不具合を修正しました。

## 原因
`BlogPostsTable::beforeSave()` で検索対象外かどうかを判定する際に `$entity->blog_content->content` を参照していますが、新規作成時（`BlogPostsService::create()`）は `blog_content`がロードされないまま保存されるため、`$entity->blog_content` が `null` になります。

`empty($entity->blog_content->content)` は `blog_content` が `null` の場合も `true` を返すため、常に「除外設定あり」と誤判定され、後続の `afterSave()`（BcSearchIndexプラグインのBehavior）で `saveSearchIndex()` ではなく `deleteSearchIndex()` が呼ばれてしまい、検索インデックスが作成されませんでした。

- 該当箇所: `plugins/bc-blog/src/Model/Table/BlogPostsTable.php` `beforeSave()`

## 修正内容

`beforeSave()` の除外判定の直前で、`blog_content` が未ロードかつ `blog_content_id` を持っている場合に、明示的に `Contents` を `contain` して取得しエンティティにセットするようにしました。


ご確認お願いします。