### PR TITLE
ファイルの公開期間外に設定するとフロントで500エラーになる不具合の修正

### DIFF
--- a/plugins/baser-core/src/Controller/BcErrorController.php
+++ b/plugins/baser-core/src/Controller/BcErrorController.php
@@ -24,6 +24,7 @@ use Cake\Event\EventManagerInterface;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\ORM\TableRegistry;
+use Throwable;
 
 /**
  * BcErrorController
@@ -108,6 +109,18 @@ class BcErrorController extends BcFrontAppController
         $this->viewBuilder()->setTemplatePath('Error');
         // プラグイン等のイベントが残っているとエラー画面が正常に表示されない場合があるため、イベントを削除する
         EventManager::instance()->off('View.beforeRender');
+    }
+
+    /**
+     * NotFoundException のエラーページを描画する
+     *
+     * @param Throwable|null $error
+     * @return void
+     * @noTodo
+     */
+    public function notFound(?Throwable $error = null): void
+    {
+        $this->viewBuilder()->setTemplate('error400');
     }
 
 }

--- a/plugins/bc-uploader/src/Controller/UploaderFilesController.php
+++ b/plugins/bc-uploader/src/Controller/UploaderFilesController.php
@@ -54,10 +54,6 @@ class UploaderFilesController extends BcFrontAppController
             }
         }
 
-        if ($display && !file_exists(WWW_ROOT . 'files' . DS . 'uploads' . DS . 'limited' . DS . $filename)) {
-            $display = false;
-        }
-
         if ($display) {
             $info = pathinfo($filename);
             $ext = $info['extension'];

--- a/plugins/bc-uploader/src/Controller/UploaderFilesController.php
+++ b/plugins/bc-uploader/src/Controller/UploaderFilesController.php
@@ -54,6 +54,10 @@ class UploaderFilesController extends BcFrontAppController
             }
         }
 
+        if ($display && !file_exists(WWW_ROOT . 'files' . DS . 'uploads' . DS . 'limited' . DS . $filename)) {
+            $display = false;
+        }
+
         if ($display) {
             $info = pathinfo($filename);
             $ext = $info['extension'];


### PR DESCRIPTION
@ryuring 

## 概要

アップロードファイル一覧で、画像の公開設定の開始日付を期間外にして、URLを別リンク（シークレットウィンドゥ）で開くと404ではなく500エラーになっておりました

## 原因
`plugins/bc-uploader/src/Controller/UploaderFilesController.php`の`view_limited_file()` で、公開期間かどうかを判定して`$display`をtrue/falseにしています。falseの際に404にする使用ですが、$displayがtrueの場合に、最後に、`new Stream(WWW_ROOT . 'files/uploads/limited/' . $filename)`を呼び出していますが、ここでそのファイルが存在するかをチェックせずにファイルを読み出すためファイル読み込みでエラーが発生し、それが原因で500エラーになっておりました


## 修正内容
実ファイルのチェック処理を追加しました。

ご確認お願いします。