### PR TITLE
コンテンツリンク編集ページのリンク先URLに必須ラベルを表示する

### DIFF
--- a/plugins/bc-admin-third/templates/plugin/BcContentLink/Admin/ContentLinks/edit.php
+++ b/plugins/bc-admin-third/templates/plugin/BcContentLink/Admin/ContentLinks/edit.php
@@ -25,7 +25,10 @@ $this->BcAdmin->setTitle(__d('baser_core', 'リンク編集'));
 
 <table class="form-table bca-form-table">
   <tr>
-    <th class="bca-form-table__label"><?php echo __d('baser_core', 'リンク先URL') ?></th>
+    <th class="bca-form-table__label">
+      <?php echo __d('baser_core', 'リンク先URL') ?>
+      &nbsp;<span class="bca-label" data-bca-label-type="required"><?php echo __d('baser_core', '必須') ?></span>
+    </th>
     <td class=" bca-form-table__input">
       <?php echo $this->BcAdminForm->control('url', ['type' => 'text', 'size' => 60, 'placeholder' => 'https://']) ?>
       <br>


### PR DESCRIPTION
@ryuring 

こちらのレビューを宜しくお願いします。

改修内容：
コンテンツリンク編集ページの「リンク先URL」に必須ラベルを表示させる