### PR TITLE
ユーザー登録時グループを選択せず保存した場合のエラーメッセージに「 データベース処理中にエラーが発生しました。」と表示される件を修正

### DIFF
--- a/plugins/baser-core/src/Controller/Admin/UsersController.php
+++ b/plugins/baser-core/src/Controller/Admin/UsersController.php
@@ -24,6 +24,7 @@ use Cake\Http\Exception\ForbiddenException;
 use Cake\Http\Exception\NotFoundException;
 use Cake\Http\Response;
 use Cake\ORM\Exception\PersistenceFailedException;
+use BaserCore\Error\BcException;
 use Cake\Routing\Router;
 use BaserCore\Annotation\NoTodo;
 use BaserCore\Annotation\Checked;
@@ -328,6 +329,8 @@ class UsersController extends BcAdminAppController
             } catch (\Cake\ORM\Exception\PersistenceFailedException $e) {
                 $user = $e->getEntity();
                 $this->BcMessage->setError(__d('baser_core', '入力エラーです。内容を修正してください。'));
+            } catch (BcException $e) {
+                $this->BcMessage->setError($e->getMessage());
             } catch (\Throwable $e) {
                 $this->BcMessage->setError(__d('baser_core', 'データベース処理中にエラーが発生しました。') . $e->getMessage());
             }
@@ -377,6 +380,8 @@ class UsersController extends BcAdminAppController
             } catch (PersistenceFailedException $e) {
                 $user = $e->getEntity();
                 $this->BcMessage->setError(__d('baser_core', '入力エラーです。内容を修正してください。'));
+            } catch (BcException $e) {
+                $this->BcMessage->setError($e->getMessage());
             } catch (\Throwable $e) {
                 $this->BcMessage->setError(__d('baser_core', 'データベース処理中にエラーが発生しました。') . $e->getMessage());
             }

--- a/plugins/baser-core/src/Controller/Admin/UsersController.php
+++ b/plugins/baser-core/src/Controller/Admin/UsersController.php
@@ -24,7 +24,6 @@ use Cake\Http\Exception\ForbiddenException;
 use Cake\Http\Exception\NotFoundException;
 use Cake\Http\Response;
 use Cake\ORM\Exception\PersistenceFailedException;
-use BaserCore\Error\BcException;
 use Cake\Routing\Router;
 use BaserCore\Annotation\NoTodo;
 use BaserCore\Annotation\Checked;
@@ -329,8 +328,6 @@ class UsersController extends BcAdminAppController
             } catch (\Cake\ORM\Exception\PersistenceFailedException $e) {
                 $user = $e->getEntity();
                 $this->BcMessage->setError(__d('baser_core', '入力エラーです。内容を修正してください。'));
-            } catch (BcException $e) {
-                $this->BcMessage->setError($e->getMessage());
             } catch (\Throwable $e) {
                 $this->BcMessage->setError(__d('baser_core', 'データベース処理中にエラーが発生しました。') . $e->getMessage());
             }
@@ -380,8 +377,6 @@ class UsersController extends BcAdminAppController
             } catch (PersistenceFailedException $e) {
                 $user = $e->getEntity();
                 $this->BcMessage->setError(__d('baser_core', '入力エラーです。内容を修正してください。'));
-            } catch (BcException $e) {
-                $this->BcMessage->setError($e->getMessage());
             } catch (\Throwable $e) {
                 $this->BcMessage->setError(__d('baser_core', 'データベース処理中にエラーが発生しました。') . $e->getMessage());
             }

--- a/plugins/baser-core/src/Service/UsersService.php
+++ b/plugins/baser-core/src/Service/UsersService.php
@@ -192,10 +192,7 @@ class UsersService implements UsersServiceInterface
     public function create(array $postData): ?EntityInterface
     {
         $loginUser = BcUtil::loginUser();
-        if(empty($postData['user_groups']['_ids'])) {
-            throw new BcException(__d('baser_core', 'ユーザーグループを指定してください。'));
-        }
-        if(in_array(Configure::read('BcApp.adminGroupId'), $postData['user_groups']['_ids'])) {
+        if(!empty($postData['user_groups']['_ids']) && in_array(Configure::read('BcApp.adminGroupId'), $postData['user_groups']['_ids'])) {
             if(BcUtil::isInstalled() && !$loginUser->isAddableToAdminGroup()) {
                 throw new BcException(__d('baser_core', '特権エラーが発生しました。'));
             }


### PR DESCRIPTION
@ryuring 

こちらのレビューをお願い致します。

改修内容：
ユーザー登録時にグループを選択せず保存した場合のエラーメッセージを「 データベース処理中にエラーが発生しました。ユーザーグループを指定してください。」→「ユーザーグループを指定してください。」へ修正

要因：
ユーザー登録時（`UsersController::add()`）のcatchが`PersistenceFailedException`と`Throwable`の2種類しか分岐しておらず、BcExceptionがThrowableの派生型のようなので後者のThrowableのcatchが適用され「 データベース処理中にエラーが発生しました。」というエラーメッセージが表示されているようでした。

改修方法：
`catch (BcException $e)`をPersistenceFailedExceptionと\Throwableの間に追加し、「ユーザーグループを指定してください。」というエラーメッセージのみ表示されるようにいたしました。


