### PR TITLE
ユーザーグループ登録ページの認証プレフィックス[ Admin Web API ]の初期値を「限定アクセス」に指定する

### DIFF
--- a/plugins/baser-core/src/Service/UserGroupsService.php
+++ b/plugins/baser-core/src/Service/UserGroupsService.php
@@ -81,7 +81,7 @@ class UserGroupsService implements UserGroupsServiceInterface
     {
         return $this->UserGroups->newEntity([
             'auth_prefix' => 'Admin',
-            'auth_prefix_settings' => '{"Admin":{"type":"2"},"Api":{"type":"2"}}'
+            'auth_prefix_settings' => '{"Admin":{"type":"2"},"Api/Admin":{"type":"2"}}'
         ], [
             'validate' => false,
         ]);


### PR DESCRIPTION
@ryuring 

こちらのコードレビューをお願いします！

[改修内容]
ユーザーグループ登録ページの、認証プレフィックス[ Admin Web API ]のラジオボタン初期値を「限定アクセス」に指定されるように修正