### PR TITLE
代理ログインをダブルクリックすると、強制ログアウトしてしまうため修正

### DIFF
--- a/plugins/baser-core/src/Controller/Admin/BcAdminAppController.php
+++ b/plugins/baser-core/src/Controller/Admin/BcAdminAppController.php
@@ -78,6 +78,8 @@ class BcAdminAppController extends AppController
 
         // ログインユーザ再読込
         if (!$usersService->reload($this->request)) {
+            // 代理ログイン中に強制ログアウトとなる場合、セッションを残さないよう削除する。
+            $this->request->getSession()->delete('AuthAgent');
             $event->setResult($this->redirect($this->Authentication->logout()));
             return;
         }

--- a/plugins/baser-core/src/Controller/Admin/BcAdminAppController.php
+++ b/plugins/baser-core/src/Controller/Admin/BcAdminAppController.php
@@ -78,8 +78,6 @@ class BcAdminAppController extends AppController
 
         // ログインユーザ再読込
         if (!$usersService->reload($this->request)) {
-            // 代理ログイン中に強制ログアウトとなる場合、セッションを残さないよう削除する。
-            $this->request->getSession()->delete('AuthAgent');
             $event->setResult($this->redirect($this->Authentication->logout()));
             return;
         }

--- a/plugins/baser-core/src/Service/UsersService.php
+++ b/plugins/baser-core/src/Service/UsersService.php
@@ -554,14 +554,14 @@ class UsersService implements UsersServiceInterface
             $user = $this->Users->find('available')->where([
                 'Users.id' => $sessionUser->id
             ])->first();
-            if($user) {
-                $session->write($sessionKey, $user);
-                return true;
-            } else {
-                $session->delete($sessionKey);
-                return false;
-            }
         } catch (Exception $e) {
+            $user = null;
+        }
+        if($user) {
+            $session->write($sessionKey, $user);
+            return true;
+        } else {
+            $session->delete('AuthAgent');
             $session->delete($sessionKey);
             return false;
         }


### PR DESCRIPTION
@ryuring 

こちらレビューお願いいたします

## 概要

代理ログイン中にリンクを連打するなどしてリクエストが競合すると、強制的にログアウトされ、その際 `AuthAgent` セッションが削除されずに残留してしまっていた。この結果、再ログイン後も「既に代理ログイン中」エラーや「元のユーザーに戻る」ボタンの表示が発生し続けています。

## 原因

セッション再検証(`UsersService::reload()`)に失敗した際の強制ログアウト処理(`BcAdminAppController::beforeFilter()`)で、`AuthAgent` を削除していなかったことが原因です。

## 修正

強制ログアウト時にも `AuthAgent` セッションを削除するようにしました。