### PR TITLE
非公開のサブサイトを開いた際のエラーが505→404になるように修正

### DIFF
--- a/plugins/baser-core/src/View/Helper/BcBaserHelper.php
+++ b/plugins/baser-core/src/View/Helper/BcBaserHelper.php
@@ -1163,6 +1163,9 @@ class BcBaserHelper extends Helper
      */
     public function isHome()
     {
+        if($this->getView()->getName() === 'Error') {
+            return false;
+        }
         $request = $this->_View->getRequest();
         if (empty($request->getAttribute('currentSite'))) {
             return false;


### PR DESCRIPTION
@ryuring 

以下のレビューをお願いします！

改修内容：
非公開のサブサイトもトップページの判定がtrueになりエレメントが呼び出されてしまう→エラー画面描画時はトップページ判定がfalseになるように修正。