### PR TITLE
絞り込み検索でクリアを実行しても、検索条件が戻らないため修正

### DIFF
--- a/plugins/bc-admin-third/templates/Admin/element/search/permissions_index.php
+++ b/plugins/bc-admin-third/templates/Admin/element/search/permissions_index.php
@@ -32,7 +32,6 @@
 		<?php echo $this->BcAdminForm->label('permission_group_type', __d('baser_core', 'タイプ'), ['class' => 'bca-search__input-item-label']) ?>
     <?php echo $this->BcAdminForm->control('permission_group_type', [
       'type' => 'radio',
-      'hiddenField' => false,
       'options' => $this->BcAdminForm->getControlSource('Permissions.permission_group_type')
     ]) ?>
   </span>


### PR DESCRIPTION
@ryuring 

こちらご確認お願いします。

## 原因
検索条件はセッションに保持され、次回リクエストと array_merge されます。この仕組みでは、キー自体が送信されないと古い値が上書きされず残ります。
「アクセスルールグループ（タイプ）」のラジオに 'hiddenField' => false が指定されており、未選択のまま検索すると permission_group_type キーが送信されず、セッションの古い絞り込み条件が残ってクリアが効きませんでした。

## 修正内容
'hiddenField' => false を削除し、未選択時も空文字が送信されるようにしました。


issue
https://github.com/baserproject/basercms/issues/4452