### PR TITLE
fix #4499 【システム】TRUST_PROXY=true 環境で BcUtil::isSameOriginAsCurrent() …

### DIFF
--- a/plugins/baser-core/src/Utility/BcUtil.php
+++ b/plugins/baser-core/src/Utility/BcUtil.php
@@ -2127,7 +2127,14 @@ class BcUtil
      */
     public static function isSameOriginAsCurrent()
     {
-        $https = !empty($_SERVER['HTTPS']) && strtolower((string)$_SERVER['HTTPS']) !== 'off';
+        // 【応急パッチ】TRUST_PROXY=true 環境では $_SERVER['HTTPS'] がリバースプロキシ配下で
+        // 設定されないため、BcRequestFilterMiddleware が trustProxy 済みで上書きする
+        // $request->is('https') を優先して使う（CakePHPの標準検出名は 'ssl' ではなく 'https'）。
+        // 取得できない場合のみ従来通り $_SERVER を見る。
+        $request = Router::getRequest();
+        $https = $request
+            ? $request->is('https')
+            : (!empty($_SERVER['HTTPS']) && strtolower((string)$_SERVER['HTTPS']) !== 'off');
         $host = $_SERVER['HTTP_HOST'] ?? '';
         if ($host === '') {
             return false;

--- a/plugins/baser-core/src/Utility/BcUtil.php
+++ b/plugins/baser-core/src/Utility/BcUtil.php
@@ -2127,10 +2127,10 @@ class BcUtil
      */
     public static function isSameOriginAsCurrent()
     {
-        // 【応急パッチ】TRUST_PROXY=true 環境では $_SERVER['HTTPS'] がリバースプロキシ配下で
+        // TRUST_PROXY=true 環境では $_SERVER['HTTPS'] がリバースプロキシ配下で
         // 設定されないため、BcRequestFilterMiddleware が trustProxy 済みで上書きする
-        // $request->is('https') を優先して使う（CakePHPの標準検出名は 'ssl' ではなく 'https'）。
-        // 取得できない場合のみ従来通り $_SERVER を見る。
+        // $request->is('https') を優先して使う。
+        // 取得できない場合のみ $_SERVER を見る。
         $request = Router::getRequest();
         $https = $request
             ? $request->is('https')

--- a/plugins/baser-core/tests/TestCase/Utility/BcUtilTest.php
+++ b/plugins/baser-core/tests/TestCase/Utility/BcUtilTest.php
@@ -1606,6 +1606,10 @@ class BcUtilTest extends BcTestCase
      */
     public function testIsSameOriginAsCurrent(array $server, bool $expected)
     {
+        // 準備：他のテスト(test_getViewPath等)が残した Router::setRequest() の残留状態が
+        // Router::getRequest() 経由の判定に影響しないよう、リクエストをクリアする
+        Router::reload();
+
         // 準備：判定に使う $_SERVER をクリアしてから流し込む
         foreach (['HTTPS', 'HTTP_HOST', 'HTTP_ORIGIN', 'HTTP_REFERER'] as $key) {
             unset($_SERVER[$key]);


### PR DESCRIPTION
…の HTTPS 判定が $_SERVER['HTTPS'] を直接参照しており、コアプラグインAPIが常にForbiddenになる問題を解決

<!-- GitHub Copilot コードレビューへの指示: プルリクエストをレビューしてコメントする際には日本語でお願いします。 -->

※ 5.3.xにプルリクを出していますが、5.4.xに変更していただいても構いません。