### PR TITLE
ブログ記事一覧が1件しか表示されない不具合を修正

### DIFF
--- a/plugins/baser-core/src/View/Helper/BcArrayHelper.php
+++ b/plugins/baser-core/src/View/Helper/BcArrayHelper.php
@@ -43,8 +43,10 @@ class BcArrayHelper extends Helper
     public function first($array, int $key)
     {
         if($array instanceof Query) {
-            // CakePHP 5.2 で ResultSet はクローン不可のため配列化して扱う
-            $array = $array->toArray();
+            // Query を実行すると、反復中の ResultSet を消費してしまい
+            // 呼び出し元の foreach が2件目以降を取得できなくなる。
+            // Query の反復は 0 起点の連番キーとなるため、キーの比較のみで判定する。
+            return $key === 0;
         }
         reset($array);
         $first = key($array);
@@ -68,6 +70,7 @@ class BcArrayHelper extends Helper
     public function last($array, $key)
     {
         if($array instanceof Query) {
+            // count() は件数取得用のクエリを別途発行するため、反復中の ResultSet を消費しない
             $end = $array->count() - 1;
         } else {
             end($array);

--- a/plugins/baser-core/tests/TestCase/View/Helper/BcArrayHelperTest.php
+++ b/plugins/baser-core/tests/TestCase/View/Helper/BcArrayHelperTest.php
@@ -63,12 +63,14 @@ class BcArrayHelperTest extends BcTestCase
 
     public function testFirstWithQuery()
     {
-        // CakePHP 5.2 で ResultSet はクローン不可のため、first() は Query を toArray() で配列化して判定する
+        // Query の反復は 0 起点の連番キーとなる。
+        // ここで Query を実行してしまうと呼び出し元の foreach が
+        // 2件目以降を取得できなくなるため、実行せずにキーのみで判定する。
         $mockQuery = $this->createMock(Query::class);
-        $mockQuery->method('toArray')->willReturn([1 => 'a', 2 => 'b', 3 => 'c']);
+        $mockQuery->expects($this->never())->method('toArray');
 
-        $this->assertTrue($this->Helper->first($mockQuery, 1));
-        $this->assertFalse($this->Helper->first($mockQuery, 2));
+        $this->assertTrue($this->Helper->first($mockQuery, 0));
+        $this->assertFalse($this->Helper->first($mockQuery, 1));
     }
 
     /**


### PR DESCRIPTION
<!-- GitHub Copilot コードレビューへの指示: プルリクエストをレビューしてコメントする際には日本語でお願いします。 -->

fix #4501

## 原因

`BcArrayHelper::first()` は `Query` を受け取ると `toArray()` で実行していました。

CakePHP 5.2 の `ResultSet` はイテレータを共有するため、テンプレートの `foreach` が1件目を取り出した直後に `first()` が同じ ResultSet を最後まで読み切ってしまいます。結果として `foreach` に戻った時点で残りが消費済みとなり、2件目以降が描画されずループが終了していました。

```php
foreach ($posts as $key => $post):
    if ($this->BcArray->first($posts, $key)):   // ここで Query が実行される
```

## 修正

`Query` の反復は 0 起点の連番キーとなるため、実行せずキーの比較のみで判定するようにしました。

```php
if($array instanceof Query) {
    return $key === 0;
}
```

`last()` の `count()` は件数取得用のクエリを別途発行し、反復中の ResultSet を消費しないため変更していません（意図が伝わるようコメントのみ追加）。

## Issue の修正案との違い

Issue では恒久対応として `BlogHelper::getPosts()` での配列化が挙げられていますが、下記の理由から `BcArrayHelper` 側での修正としました。

- 根本原因である「反復中のイテレータ消費」を1箇所で解消できる
- `getPosts()` の戻り値の型（`Query`）を変えずに済む。`getIndex(): Query` との一貫性が保てる
- テンプレートを修正しなくても直るため、**サードパーティのテーマも救われる**

## テストについて

既存の `testFirstWithQuery` は、`toArray()` が **1起点のキー配列**を返すモックを前提としていました。実際の `Query` の反復は **0 起点**であり、モックが実態と異なっていたため本件を検出できていませんでした。

実データで反復キーが 0 起点であることを確認したうえで、「`toArray()` を呼ばないこと」と「0 起点で判定すること」を検証する形に改めています。修正前の実装に戻すとこのテストが失敗することも確認済みです。

## 動作確認

BcColumn テーマのトップページで、works / news / topics の各一覧が **1件 → 4件**（`blogPosts(..., 4)` の指定どおり）になることを確認しました。`first` / `last` のクラス付与も正しく機能しています。

`BcArrayHelperTest` は8件すべて成功します。
