### PR TITLE
未認証でのブログ・カスタムコンテンツ非公開記事の閲覧（preview/status）を修正

### DIFF
--- a/plugins/baser-core/src/Controller/Api/BcApiController.php
+++ b/plugins/baser-core/src/Controller/Api/BcApiController.php
@@ -66,6 +66,24 @@ class BcApiController extends AppController
     }
 
     /**
+     * 未認証ユーザーによる非公開データへのアクセスを制限する（API 版）
+     *
+     * 公開APIでは preview は認証済みのプレビュー機能でのみ利用可能なため、
+     * preview パラメータが指定された場合は拒否する。
+     *
+     * @return void
+     * @noTodo
+     * @checked
+     * @unitTest
+     */
+    protected function restrictNonPublicAccess(): void
+    {
+        if (array_key_exists('preview', $this->getRequest()->getQueryParams())) {
+            throw new ForbiddenException();
+        }
+    }
+
+    /**
      * トークンを取得する
      * @param ResultInterface $result
      * @return array

--- a/plugins/baser-core/src/Controller/Api/BcApiController.php
+++ b/plugins/baser-core/src/Controller/Api/BcApiController.php
@@ -78,7 +78,10 @@ class BcApiController extends AppController
      */
     protected function restrictNonPublicAccess(): void
     {
-        if (array_key_exists('preview', $this->getRequest()->getQueryParams())) {
+        // __cleanupQueryParams() による amp; 正規化を悪用したバイパスを防ぐため、
+        // amp; プレフィックス付きのキーも拒否する
+        $query = $this->getRequest()->getQueryParams();
+        if (array_key_exists('preview', $query) || array_key_exists('amp;preview', $query)) {
             throw new ForbiddenException();
         }
     }

--- a/plugins/baser-core/src/Controller/AppController.php
+++ b/plugins/baser-core/src/Controller/AppController.php
@@ -142,6 +142,9 @@ class AppController extends BaseController
         parent::beforeFilter($event);
         if ($event->getResult()) return;
 
+        // 未認証ユーザーによる非公開データ（preview / status）へのアクセスを制限する
+        $this->restrictNonPublicAccess();
+
         // index.php をつけたURLの場合、base の値が正常でなくなり、
         // 内部リンクが影響を受けておかしくなってしまうため強制的に Not Found とする
         if (preg_match('/\/index\.php\//', $this->getRequest()->getAttribute('base'))) {
@@ -192,6 +195,33 @@ class AppController extends BaseController
         if ($this->request->is('ajax') || BcUtil::loginUser()) {
             $this->setResponse($this->getResponse()->withDisabledCache());
         }
+    }
+
+    /**
+     * 未認証ユーザーによる非公開データへのアクセスを制限する
+     *
+     * 未認証ユーザーが preview / status を利用して非公開データを閲覧することを防ぐ。
+     * デフォルト（フロント・管理画面）では、未認証時にこれらのパラメータを除去し、
+     * 公開データのみに強制する。認証済み（正規のプレビュー機能を含む）はそのまま許可する。
+     * API では BcApiController でオーバーライドし、preview を拒否（Forbidden）する。
+     *
+     * @return void
+     * @noTodo
+     * @checked
+     * @unitTest
+     */
+    protected function restrictNonPublicAccess(): void
+    {
+        $request = $this->getRequest();
+        $query = $request->getQueryParams();
+        // preview / status が指定されていなければ何もしない（不要な認証判定を避ける）
+        if (!array_key_exists('preview', $query) && !array_key_exists('status', $query)) {
+            return;
+        }
+        // 認証済み（正規のプレビュー機能を含む）はそのまま許可する
+        if (BcUtil::loginUser()) return;
+        unset($query['preview'], $query['status']);
+        $this->setRequest($request->withQueryParams($query));
     }
 
     /**

--- a/plugins/baser-core/src/Controller/AppController.php
+++ b/plugins/baser-core/src/Controller/AppController.php
@@ -215,13 +215,15 @@ class AppController extends BaseController
         $request = $this->getRequest();
         $query = $request->getQueryParams();
         // preview / status が指定されていなければ何もしない（不要な認証判定を避ける）
-        if (!array_key_exists('preview', $query) && !array_key_exists('status', $query)) {
+        // __cleanupQueryParams() による amp; 正規化を悪用したバイパスを防ぐため、
+        // amp; プレフィックス付きのキーも対象にする
+        $targets = array_flip(['preview', 'status', 'amp;preview', 'amp;status']);
+        if (!array_intersect_key($query, $targets)) {
             return;
         }
         // 認証済み（正規のプレビュー機能を含む）はそのまま許可する
         if (BcUtil::loginUser()) return;
-        unset($query['preview'], $query['status']);
-        $this->setRequest($request->withQueryParams($query));
+        $this->setRequest($request->withQueryParams(array_diff_key($query, $targets)));
     }
 
     /**

--- a/plugins/baser-core/tests/TestCase/Controller/Api/BcApiControllerTest.php
+++ b/plugins/baser-core/tests/TestCase/Controller/Api/BcApiControllerTest.php
@@ -95,6 +95,23 @@ class BcApiControllerTest extends BcTestCase
     }
 
     /**
+     * test restrictNonPublicAccess
+     * 公開APIでは preview パラメータを拒否（Forbidden）することを検証する
+     */
+    public function test_restrictNonPublicAccess()
+    {
+        // preview 無し：例外は発生しない
+        $controller = new BcApiController($this->getRequest('/baser/api/baser-core/contents/index.json'));
+        $this->execPrivateMethod($controller, 'restrictNonPublicAccess');
+        $this->assertTrue(true);
+
+        // preview あり：ForbiddenException
+        $this->expectException(\Cake\Http\Exception\ForbiddenException::class);
+        $controller = new BcApiController($this->getRequest('/baser/api/baser-core/contents/index.json?preview=1'));
+        $this->execPrivateMethod($controller, 'restrictNonPublicAccess');
+    }
+
+    /**
      * test getAccessToken
      */
     public function testGetAccessToken()

--- a/plugins/baser-core/tests/TestCase/Controller/Api/BcApiControllerTest.php
+++ b/plugins/baser-core/tests/TestCase/Controller/Api/BcApiControllerTest.php
@@ -112,6 +112,16 @@ class BcApiControllerTest extends BcTestCase
     }
 
     /**
+     * test restrictNonPublicAccess（amp; プレフィックスによる正規化バイパス対策）
+     */
+    public function test_restrictNonPublicAccess_ampBypass()
+    {
+        $this->expectException(\Cake\Http\Exception\ForbiddenException::class);
+        $controller = new BcApiController($this->getRequest('/baser/api/baser-core/contents/index.json?amp;preview=1'));
+        $this->execPrivateMethod($controller, 'restrictNonPublicAccess');
+    }
+
+    /**
      * test getAccessToken
      */
     public function testGetAccessToken()

--- a/plugins/baser-core/tests/TestCase/Controller/AppControllerTest.php
+++ b/plugins/baser-core/tests/TestCase/Controller/AppControllerTest.php
@@ -253,6 +253,14 @@ class AppControllerTest extends BcTestCase
         $this->assertArrayNotHasKey('status', $result);
         $this->assertArrayHasKey('keyword', $result);
 
+        // __cleanupQueryParams による正規化を悪用した amp; プレフィックス付きキーも除去される
+        $this->AppController->setRequest($this->getRequest('/news/archives/1?amp;preview=1&amp;status=0&keyword=abc'));
+        $this->execPrivateMethod($this->AppController, 'restrictNonPublicAccess');
+        $result = $this->AppController->getRequest()->getQueryParams();
+        $this->assertArrayNotHasKey('amp;preview', $result);
+        $this->assertArrayNotHasKey('amp;status', $result);
+        $this->assertArrayHasKey('keyword', $result);
+
         // preview / status が無ければ何もしない
         $this->AppController->setRequest($this->getRequest('/news/archives/1?keyword=abc'));
         $this->execPrivateMethod($this->AppController, 'restrictNonPublicAccess');

--- a/plugins/baser-core/tests/TestCase/Controller/AppControllerTest.php
+++ b/plugins/baser-core/tests/TestCase/Controller/AppControllerTest.php
@@ -240,6 +240,34 @@ class AppControllerTest extends BcTestCase
     }
 
     /**
+     * test restrictNonPublicAccess
+     * 未認証時は preview / status を除去し、認証済み時・パラメータ無し時は変更しないことを検証する
+     */
+    public function test_restrictNonPublicAccess()
+    {
+        // 未認証：preview / status が除去され、他のパラメータは保持される
+        $this->AppController->setRequest($this->getRequest('/news/archives/1?preview=1&status=0&keyword=abc'));
+        $this->execPrivateMethod($this->AppController, 'restrictNonPublicAccess');
+        $result = $this->AppController->getRequest()->getQueryParams();
+        $this->assertArrayNotHasKey('preview', $result);
+        $this->assertArrayNotHasKey('status', $result);
+        $this->assertArrayHasKey('keyword', $result);
+
+        // preview / status が無ければ何もしない
+        $this->AppController->setRequest($this->getRequest('/news/archives/1?keyword=abc'));
+        $this->execPrivateMethod($this->AppController, 'restrictNonPublicAccess');
+        $this->assertEquals(['keyword' => 'abc'], $this->AppController->getRequest()->getQueryParams());
+
+        // 認証済み：preview / status は保持される
+        $request = $this->loginAdmin($this->getRequest('/news/archives/1?preview=1&status=0'));
+        $this->AppController->setRequest($request);
+        $this->execPrivateMethod($this->AppController, 'restrictNonPublicAccess');
+        $result = $this->AppController->getRequest()->getQueryParams();
+        $this->assertArrayHasKey('preview', $result);
+        $this->assertArrayHasKey('status', $result);
+    }
+
+    /**
      * test notFound
      */
     public function test_notFound()

--- a/plugins/bc-blog/tests/TestCase/Controller/Api/BlogPostsControllerTest.php
+++ b/plugins/bc-blog/tests/TestCase/Controller/Api/BlogPostsControllerTest.php
@@ -121,4 +121,21 @@ class BlogPostsControllerTest extends BcTestCase
         $this->assertResponseCode(403);
     }
 
+    /**
+     * 公開APIでは preview パラメータを拒否する（未認証の非公開データ閲覧対策）
+     */
+    public function test_preview_forbidden_on_public_api()
+    {
+        $this->loadFixtureScenario(BlogContentScenario::class, 1, 1, null, 'test', '/test');
+        BlogPostFactory::make(['id' => '1', 'blog_content_id' => '1', 'title' => 'blog post', 'status' => true])->persist();
+        ContentFactory::make(['type' => 'BlogContent', 'entity_id' => 1])->persist();
+        PermissionFactory::make()->allowGuest('/baser/api/*')->persist();
+
+        // 一覧・単一とも preview を指定すると 403
+        $this->get('/baser/api/bc-blog/blog_posts/index/1.json?preview=1');
+        $this->assertResponseCode(403);
+        $this->get('/baser/api/bc-blog/blog_posts/view/1.json?preview=1');
+        $this->assertResponseCode(403);
+    }
+
 }

--- a/plugins/bc-blog/tests/TestCase/Controller/Api/BlogPostsControllerTest.php
+++ b/plugins/bc-blog/tests/TestCase/Controller/Api/BlogPostsControllerTest.php
@@ -136,6 +136,10 @@ class BlogPostsControllerTest extends BcTestCase
         $this->assertResponseCode(403);
         $this->get('/baser/api/bc-blog/blog_posts/view/1.json?preview=1');
         $this->assertResponseCode(403);
+
+        // amp; プレフィックスによる正規化を悪用したバイパスも 403
+        $this->get('/baser/api/bc-blog/blog_posts/index/1.json?amp;preview=1');
+        $this->assertResponseCode(403);
     }
 
 }

--- a/plugins/bc-blog/tests/TestCase/Controller/BlogControllerTest.php
+++ b/plugins/bc-blog/tests/TestCase/Controller/BlogControllerTest.php
@@ -223,6 +223,53 @@ class BlogControllerTest extends BcTestCase
     }
 
     /**
+     * 未認証のフロントアクセスで preview / status により非公開記事が閲覧できないことを検証する
+     * （JVN未報告・preview/status 情報漏洩対策）
+     */
+    public function test_preview_status_disclosure_unauthenticated()
+    {
+        $this->loadFixtureScenario(InitAppScenario::class);
+        ContentFactory::make([
+            'id' => 1,
+            'url' => '/news/',
+            'site_id' => 1,
+            'status' => true,
+            'entity_id' => 1,
+            'plugin' => 'BcBlog',
+            'type' => 'BlogContent',
+            'lft' => 1,
+            'rght' => 2,
+            'publish_begin' => '2020-01-27 12:00:00',
+            'layout_template' => 'default',
+            'publish_end' => '9000-01-27 12:00:00'
+        ])->persist();
+        BlogContentFactory::make(['id' => 1, 'list_direction' => 'DESC', 'template' => 'default'])->persist();
+        // 公開記事（no=1）
+        BlogPostFactory::make([
+            'id' => 1, 'blog_content_id' => 1, 'no' => 1, 'user_id' => 1,
+            'name' => 'public-post', 'title' => '公開記事',
+            'posted' => '2023-01-11 12:57:59', 'status' => true
+        ])->persist();
+        // 非公開記事（no=2）
+        BlogPostFactory::make([
+            'id' => 2, 'blog_content_id' => 1, 'no' => 2, 'user_id' => 1,
+            'name' => 'secret-post', 'title' => '非公開記事',
+            'posted' => '2023-01-12 12:57:59', 'status' => false
+        ])->persist();
+
+        // 未認証で非公開記事を preview 指定しても閲覧できない（404）
+        $this->get('/news/archives/2?preview=1');
+        $this->assertResponseCode(404);
+
+        // 未認証で status=0（非公開のみ列挙）を指定しても非公開記事は返らない
+        $this->get('/news/archives/date/2023?status=0');
+        $vars = $this->_controller->viewBuilder()->getVars();
+        $names = array_map(fn($post) => $post->name, $vars['posts']->toArray());
+        $this->assertNotContains('secret-post', $names);
+        $this->assertContains('public-post', $names);
+    }
+
+    /**
      * test posts
      */
     public function test_posts()

--- a/plugins/bc-blog/tests/TestCase/Controller/BlogControllerTest.php
+++ b/plugins/bc-blog/tests/TestCase/Controller/BlogControllerTest.php
@@ -261,6 +261,10 @@ class BlogControllerTest extends BcTestCase
         $this->get('/news/archives/2?preview=1');
         $this->assertResponseCode(404);
 
+        // amp; プレフィックスによる正規化（__cleanupQueryParams）を悪用したバイパスも塞ぐ（404）
+        $this->get('/news/archives/2?amp;preview=1');
+        $this->assertResponseCode(404);
+
         // 未認証で status=0（非公開のみ列挙）を指定しても非公開記事は返らない
         $this->get('/news/archives/date/2023?status=0');
         $vars = $this->_controller->viewBuilder()->getVars();

--- a/plugins/bc-custom-content/tests/TestCase/Controller/Api/CustomEntriesControllerTest.php
+++ b/plugins/bc-custom-content/tests/TestCase/Controller/Api/CustomEntriesControllerTest.php
@@ -109,6 +109,10 @@ class CustomEntriesControllerTest extends BcTestCase
         // レスポンスを確認
         $this->assertResponseCode(403);
 
+        //preview パラメータは公開APIで拒否される（未認証の非公開データ閲覧対策）
+        $this->get('/baser/api/bc-custom-content/custom_entries/index.json?custom_table_id=1&preview=1');
+        $this->assertResponseCode(403);
+
         //不要なテーブルを削除
         $dataBaseService->dropTable('custom_entry_1_recruit_categories');
     }


### PR DESCRIPTION
## 概要

未認証のフロント／公開APIリクエストで `preview` / `status` パラメータを悪用すると、**非公開（下書き・承認待ち等）の記事が閲覧できていた**問題を修正します。ブログ・カスタムコンテンツの両方が対象です。

## 原因

`preview` は本来、認証済みの `PreviewController`（`BcAdminAppController` 継承）経由でフロントを内部描画する設計ですが、フロントルートや公開APIを**直接叩くと未認証のまま同じ処理が動作**していました。公開APIは `status` / `contain` を `ForbiddenException` で弾いていましたが、`preview` は素通しでした。

- `?preview=1`：archives / tags / single 全経路で非公開記事が閲覧可能
- `?status=0`：非公開記事だけを列挙
- 公開API：`?preview=1` が getIndex に届き、非公開記事が返る

## 修正

`AppController::restrictNonPublicAccess()` を新設し `beforeFilter` から呼びます（テンプレートメソッド＋オーバーライドで責務分担。AppController は API の存在を知りません）。

- **フロント・管理画面（デフォルト実装）**：未認証時に `preview` / `status` をクエリから除去し、公開データのみに強制
- **公開API（`BcApiController` でオーバーライド）**：`preview` が指定されたら `ForbiddenException`（403）で拒否
- **認証済み**（正規のプレビュー機能を含む）は従来どおり許可（`BcUtil::loginUser()` で判定）
- `preview` / `status` が指定されていないリクエストでは認証判定（`loginUser()`）を行わず、全リクエストでの不要なDBアクセスによる副作用を回避

## 変更ファイル

- `plugins/baser-core/src/Controller/AppController.php`
- `plugins/baser-core/src/Controller/Api/BcApiController.php`
- テスト（統合3・単体2）

## テスト

- フロント除去・公開API 403 を検証する統合テスト（BlogControllerTest / Api\BlogPostsControllerTest / Api\CustomEntriesControllerTest）
- `restrictNonPublicAccess` のメソッド単体テスト（AppControllerTest / BcApiControllerTest）
- 正規プレビュー（PreviewControllerTest）を含む回帰、フルスイート 4864 件が緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)
