### PR TITLE
fix: クラウドセッションの Setup script がタイムアウトで失敗する問題を修正

### DIFF
--- a/docker/bin/cloud-up.sh
+++ b/docker/bin/cloud-up.sh
@@ -125,7 +125,11 @@ wait_for_dockerd() {
 if ! docker info >/dev/null 2>&1; then
     log "Starting dockerd."
     cleanup_stale_docker_pids
-    service docker start >/dev/null 2>&1 || dockerd >>/tmp/dockerd.log 2>&1 &
+    # `&` は `||` リスト全体に掛かり、bash が fork するサブシェルは呼び出し元の
+    # stdio を継承したまま dockerd を wait し続ける。呼び出し元が出力を読んで
+    # いると EOF が来なくなるため、波括弧で囲んで stdio を切り離す。
+    # 詳細は docs/cloud/setup-script.sh の同箇所のコメントを参照。
+    { service docker start >/dev/null 2>&1 || dockerd >>/tmp/dockerd.log 2>&1; } </dev/null >/dev/null 2>&1 &
     wait_for_dockerd
 fi
 

--- a/docs/cloud/setup-script.sh
+++ b/docs/cloud/setup-script.sh
@@ -20,10 +20,19 @@ SETUP_STARTED_AT=$(date +%s)
 step() { echo "[+$(( $(date +%s) - SETUP_STARTED_AT ))s] $*"; }
 
 # dockerd はこのあとも常駐させる必要があるため、バックグラウンドで起動する。
-# `&` は `service docker start || dockerd ...` の || リスト全体に掛かるので、
-# service 側が失敗すると dockerd がこのシェルのジョブとして残り続ける。
+#
+# 【重要】`{ ... } </dev/null >/dev/null 2>&1 &` の形を崩してはいけない。
+# `&` は `service docker start || dockerd ...` の || リスト全体に掛かるため、
+# bash はリスト用のサブシェルを fork する。このサブシェルは Setup script の
+# 標準出力（環境側がセットアップログとして読むパイプ）を継承したまま dockerd を
+# wait し続ける。リダイレクトを内側の dockerd だけに書くと、リダイレクトは孫の
+# dockerd にしか効かず、サブシェルはパイプを握ったまま残る。すると exit 0 した
+# 後もパイプが閉じないため、環境側はセットアップの完了を検知できない。
+# 実際にこれで「[+43s] setup script finished」まで正常に出力して終了したのに、
+# 5分のタイムアウトまで待たされ、セッションの起動が失敗した。
+# 波括弧でリスト全体を囲み、その stdio を親から切り離すこと。
 step "starting dockerd"
-service docker start >/dev/null 2>&1 || dockerd >/tmp/dockerd.log 2>&1 &
+{ service docker start >/dev/null 2>&1 || dockerd >/tmp/dockerd.log 2>&1; } </dev/null >/dev/null 2>&1 &
 for i in $(seq 1 30); do docker info >/dev/null 2>&1 && break; sleep 1; done
 step "dockerd ready"
 


### PR DESCRIPTION
<!-- GitHub Copilot コードレビューへの指示: プルリクエストをレビューしてコメントする際には日本語でお願いします。 -->

## 概要

Claude Code on the web のクラウドセッションで、初回起動時に Setup script が 5 分のタイムアウトまで待たされ、セッションの起動が失敗する問題を修正します。

Setup script 自体は 43 秒で正常終了（`exit 0`）しているにもかかわらず、環境側がその完了を検知できず、タイムアウト後に `end_task_run_failure` となっていました。リトライ（resume モード）では初期化スクリプトがスキップされるため 2 回目は即座に起動し、結果として毎回「最初の 1 回が 5 分かけて失敗する」状態になっていました。

## 原因

`docs/cloud/setup-script.sh` の dockerd 起動箇所です。

```sh
service docker start >/dev/null 2>&1 || dockerd >/tmp/dockerd.log 2>&1 &
```

`&` は `||` リスト全体に掛かるため、bash はリスト用のサブシェルを fork します。リダイレクト `>/tmp/dockerd.log 2>&1` は内側の `dockerd`（孫プロセス）にしか効かず、**サブシェルは Setup script の標準出力を継承したまま dockerd を wait し続けます**。

その結果、スクリプトが `exit 0` した後も出力パイプが閉じず、パイプの EOF を待っている環境側はセットアップの完了を検知できません。

プロセスツリーを実測した結果は次のとおりです。

```
$! が指すプロセス = bash（サブシェル）
    fd1/fd2 -> Setup script の標準出力   ← 握られたまま残る
  └ 孫プロセス = dockerd
    fd1 -> /tmp/dockerd.log              ← リダイレクトは孫にだけ効いている
```

## 修正内容

`||` リスト全体を波括弧で囲み、バックグラウンドジョブの stdio を親から切り離します。

```sh
{ service docker start >/dev/null 2>&1 || dockerd >/tmp/dockerd.log 2>&1; } </dev/null >/dev/null 2>&1 &
```

外側を `/dev/null` に向けても内側のリダイレクトが優先されるため、**dockerd のログ出力先は従来どおり `/tmp/dockerd.log` のままです**。

再発防止のため、コメントも「なぜこの形を崩してはいけないか」を説明する内容に書き換えています。

`docker/bin/cloud-up.sh` にも同じ構文がありました。こちらは `nohup ... >/dev/null 2>&1 &` 経由で呼ばれており EOF を待つ相手がいないため現状は実害が出ていませんが、呼び出し方が変われば同種の問題になるため合わせて修正しています。

## 検証

修正後の行をファイルから切り出し、`service docker start` → `false`、`dockerd` → `sleep 25` に置換して挙動を確認しました。

| 項目 | 修正前 | 修正後 |
| --- | --- | --- |
| パイプが EOF になるまで | 30 秒（子プロセスの寿命ぶん待つ） | **0 秒** |
| 孫プロセス（dockerd 相当）の fd1 | ログファイル | ログファイル（変化なし） |

あわせて以下も確認済みです。

- `bash -n` による構文チェック：両ファイルとも OK
- コンテナ 3 本（bc-php / bc-db / bc-smtp）が Up のまま
- `PagesTableTest` 再実行：16 件・Incomplete 10 件で修正前と同一の結果

## 注意点（マージ後に必要な作業）

`docs/cloud/setup-script.sh` はファイル冒頭に書かれているとおり「コピー元の正本」で、実際に実行されるのは claude.ai/code の環境ダイアログの Setup script 欄に貼り付けられたコピーです。

**このリポジトリの修正だけでは次回のセッションに反映されません。** 環境設定の Setup script 欄を、修正後の `docs/cloud/setup-script.sh` の内容で貼り替える必要があります。

---
_Generated by [Claude Code](https://claude.ai/code/session_01AUgPpCM5UpSADALcapiwSA)_