### PR TITLE
fix #4450 プラグインのアップデート画面に不要なメッセージが表示される問題を修正

### DIFF
--- a/plugins/baser-core/src/Utility/BcUtil.php
+++ b/plugins/baser-core/src/Utility/BcUtil.php
@@ -2392,7 +2392,13 @@ class BcUtil
     }
 
     /**
-     * 開発版かどうかを判定
+     * baserCMSコアが開発版かどうかを判定
+     *
+     * plugins フォルダに baser-core が存在する場合、開発版として判定する。
+     * 判定対象は baserCMSコアのみであり、個別のプラグインの状態は判定しない。
+     * そのため、プラグイン単位の画面や処理で利用する場合は、
+     * 対象がコアプラグインかどうかを別途判定した上で利用すること。
+     *
      * @return bool
      */
     public static function isDevelopmentVersion(): bool

--- a/plugins/baser-core/tests/TestCase/Controller/Admin/PluginsControllerTest.php
+++ b/plugins/baser-core/tests/TestCase/Controller/Admin/PluginsControllerTest.php
@@ -211,6 +211,21 @@ class PluginsControllerTest extends BcTestCase
     }
 
     /**
+     * test update
+     *
+     * 「手動アップデート手順」は、baserCMSコアのアップデート画面の場合のみ表示する
+     */
+    public function test_update_manualUpdateGuide(): void
+    {
+        // テスト環境は plugins/baser-core が存在するため開発版として判定される
+        $this->assertTrue(BcUtil::isDevelopmentVersion());
+        PluginFactory::make(['name' => 'BcPluginSample', 'version' => '0.0.1'])->persist();
+        $this->get('/baser/admin/baser-core/plugins/update/BcPluginSample');
+        $this->assertResponseOk();
+        $this->assertResponseNotContains('手動アップデート手順');
+    }
+
+    /**
      * test update core
      */
     public function testUpdateCore(): void

--- a/plugins/bc-admin-third/templates/Admin/Plugins/update.php
+++ b/plugins/bc-admin-third/templates/Admin/Plugins/update.php
@@ -36,7 +36,7 @@ $this->BcBaser->js('admin/plugins/update.bundle', false, [
 
 
 <div class="bca-plugin-update">
-  <?php if ($isDevelopmentVersion): ?>
+  <?php if ($isCore && $isDevelopmentVersion): ?>
     <div class="bca-panel-box">
       <h2 class="bca-main__heading" data-bca-heading-size="lg">
         <?php echo __d('baser_core', '手動アップデート手順') ?>


### PR DESCRIPTION
## 概要
プラグインのアップデート画面で「手動アップデート手順」が表示される条件を修正しました。この情報はbaserCMSコアのアップデート画面でのみ表示すべきですが、現在は開発版判定のみで表示されていたため、他のプラグインでも表示されていました。

## 変更内容

### 1. テンプレート修正 (`bc-admin-third/templates/Admin/Plugins/update.php`)
- 「手動アップデート手順」の表示条件を `$isDevelopmentVersion` から `$isCore && $isDevelopmentVersion` に変更
- コアプラグインかつ開発版の場合のみ表示するようにしました

### 2. ドキュメント更新 (`plugins/baser-core/src/Utility/BcUtil.php`)
- `isDevelopmentVersion()` メソッドのコメントを拡充
- 本メソッドはbaserCMSコア専用であり、プラグイン単位の画面で使用する場合はコアプラグイン判定を別途実施すべきことを明記

### 3. テスト追加 (`plugins/baser-core/tests/TestCase/Controller/Admin/PluginsControllerTest.php`)
- `test_update_manualUpdateGuide()` テストを追加
- コアプラグイン以外のプラグインアップデート画面では「手動アップデート手順」が表示されないことを検証

## テスト計画
新規追加されたテスト `test_update_manualUpdateGuide()` により、非コアプラグインのアップデート画面で「手動アップデート手順」が表示されないことが保証されます。