### PR TITLE
fix: データプロバイダで日時を確定していた不安定なテストを修正

### DIFF
--- a/plugins/baser-core/tests/TestCase/Model/Table/ContentsTableTest.php
+++ b/plugins/baser-core/tests/TestCase/Model/Table/ContentsTableTest.php
@@ -841,18 +841,50 @@ class ContentsTableTest extends BcTestCase
 
     public static function isPublishDataProvider()
     {
+        // 公開期間に現在日時からの相対日時を指定するケースは、データプロバイダで
+        // 日時を確定させるとテスト実行までの経過時間により結果が変わってしまうため、
+        // testIsPublishWithPublishPeriod() に分離している。
         return [
             [true, '', '', true],
             [false, '', '', false],
             [true, '0000-00-00 00:00:00', '', true],
             [true, '0000-00-00 00:00:01', '', true],
-            [true, date('Y-m-d H:i:s', strtotime("+1 hour")), '', false],
-            [true, FrozenTime::now()->addHours(1), '', false],
             [true, '', '0000-00-00 00:00:00', true],
             [true, '', '0000-00-00 00:00:01', false],
-            [true, '', date('Y-m-d H:i:s', strtotime("+1 hour")), true],
-            [true, '', FrozenTime::now()->addHours(1), true],
         ];
+    }
+
+    /**
+     * データが公開済みかどうかチェックする（公開期間を指定した場合）
+     *
+     * 日時はテスト実行時点で生成し、データプロバイダには持たせない。
+     */
+    public function testIsPublishWithPublishPeriod()
+    {
+        // 公開開始日時が未来の場合は非公開
+        $this->assertFalse($this->Contents->isPublish(true, date('Y-m-d H:i:s', strtotime('+1 hour')), ''));
+        $this->assertFalse($this->Contents->isPublish(true, FrozenTime::now()->addHours(1), ''));
+        // 公開開始日時が過去の場合は公開
+        $this->assertTrue($this->Contents->isPublish(true, date('Y-m-d H:i:s', strtotime('-1 hour')), ''));
+        $this->assertTrue($this->Contents->isPublish(true, FrozenTime::now()->subHours(1), ''));
+        // 公開終了日時が未来の場合は公開
+        $this->assertTrue($this->Contents->isPublish(true, '', date('Y-m-d H:i:s', strtotime('+1 hour'))));
+        $this->assertTrue($this->Contents->isPublish(true, '', FrozenTime::now()->addHours(1)));
+        // 公開終了日時が過去の場合は非公開
+        $this->assertFalse($this->Contents->isPublish(true, '', date('Y-m-d H:i:s', strtotime('-1 hour'))));
+        $this->assertFalse($this->Contents->isPublish(true, '', FrozenTime::now()->subHours(1)));
+        // 公開期間内の場合は公開
+        $this->assertTrue($this->Contents->isPublish(
+            true,
+            date('Y-m-d H:i:s', strtotime('-1 hour')),
+            date('Y-m-d H:i:s', strtotime('+1 hour'))
+        ));
+        // 公開期間が終了している場合は非公開
+        $this->assertFalse($this->Contents->isPublish(
+            true,
+            date('Y-m-d H:i:s', strtotime('-2 hours')),
+            date('Y-m-d H:i:s', strtotime('-1 hour'))
+        ));
     }
 
     /**

--- a/plugins/baser-core/tests/TestCase/Model/Table/ContentsTableTest.php
+++ b/plugins/baser-core/tests/TestCase/Model/Table/ContentsTableTest.php
@@ -862,29 +862,38 @@ class ContentsTableTest extends BcTestCase
     public function testIsPublishWithPublishPeriod()
     {
         // 公開開始日時が未来の場合は非公開
-        $this->assertFalse($this->Contents->isPublish(true, date('Y-m-d H:i:s', strtotime('+1 hour')), ''));
-        $this->assertFalse($this->Contents->isPublish(true, FrozenTime::now()->addHours(1), ''));
+        $this->assertFalse($this->Contents->isPublish(true, $this->createDateTime('+1 hour'), ''));
+        $this->assertFalse($this->Contents->isPublish(true, new FrozenTime($this->createDateTime('+1 hour')), ''));
         // 公開開始日時が過去の場合は公開
-        $this->assertTrue($this->Contents->isPublish(true, date('Y-m-d H:i:s', strtotime('-1 hour')), ''));
-        $this->assertTrue($this->Contents->isPublish(true, FrozenTime::now()->subHours(1), ''));
+        $this->assertTrue($this->Contents->isPublish(true, $this->createDateTime('-1 hour'), ''));
+        $this->assertTrue($this->Contents->isPublish(true, new FrozenTime($this->createDateTime('-1 hour')), ''));
         // 公開終了日時が未来の場合は公開
-        $this->assertTrue($this->Contents->isPublish(true, '', date('Y-m-d H:i:s', strtotime('+1 hour'))));
-        $this->assertTrue($this->Contents->isPublish(true, '', FrozenTime::now()->addHours(1)));
+        $this->assertTrue($this->Contents->isPublish(true, '', $this->createDateTime('+1 hour')));
+        $this->assertTrue($this->Contents->isPublish(true, '', new FrozenTime($this->createDateTime('+1 hour'))));
         // 公開終了日時が過去の場合は非公開
-        $this->assertFalse($this->Contents->isPublish(true, '', date('Y-m-d H:i:s', strtotime('-1 hour'))));
-        $this->assertFalse($this->Contents->isPublish(true, '', FrozenTime::now()->subHours(1)));
+        $this->assertFalse($this->Contents->isPublish(true, '', $this->createDateTime('-1 hour')));
+        $this->assertFalse($this->Contents->isPublish(true, '', new FrozenTime($this->createDateTime('-1 hour'))));
         // 公開期間内の場合は公開
-        $this->assertTrue($this->Contents->isPublish(
-            true,
-            date('Y-m-d H:i:s', strtotime('-1 hour')),
-            date('Y-m-d H:i:s', strtotime('+1 hour'))
-        ));
+        $this->assertTrue($this->Contents->isPublish(true, $this->createDateTime('-1 hour'), $this->createDateTime('+1 hour')));
         // 公開期間が終了している場合は非公開
-        $this->assertFalse($this->Contents->isPublish(
-            true,
-            date('Y-m-d H:i:s', strtotime('-2 hours')),
-            date('Y-m-d H:i:s', strtotime('-1 hour'))
-        ));
+        $this->assertFalse($this->Contents->isPublish(true, $this->createDateTime('-2 hours'), $this->createDateTime('-1 hour')));
+    }
+
+    /**
+     * 現在からの相対指定を日時文字列に変換する
+     *
+     * tests/bootstrap.php の Chronos::setTestNow() により FrozenTime の現在日時は
+     * テスト起動時点で固定される。一方、判定対象の ContentsTable::isPublish() は
+     * date() による実時間で比較するため、FrozenTime::now() を基準にすると
+     * テストスイートの実行が長引いた際に両者がズレて不安定になる。
+     * そのため、実時間を基準に日時を生成する。
+     *
+     * @param string $modifier strtotime() が解釈できる相対指定
+     * @return string
+     */
+    private function createDateTime(string $modifier): string
+    {
+        return date('Y-m-d H:i:s', strtotime($modifier));
     }
 
     /**

--- a/plugins/bc-blog/tests/TestCase/Model/BlogPostsTableTest.php
+++ b/plugins/bc-blog/tests/TestCase/Model/BlogPostsTableTest.php
@@ -391,35 +391,72 @@ class BlogPostsTableTest extends BcTestCase
     /**
      * 公開状態を取得する
      *
+     * 公開期間は「現在からの相対指定」で受け取り、テスト実行時点で日時へ変換する。
+     * データプロバイダで日時を確定させると、変換から実行までの経過時間により
+     * 結果が変わってしまうため。
+     *
+     * @param string|null $publishBegin 公開開始日時の相対指定
+     * @param string|null $publishEnd 公開終了日時の相対指定
+     * @param bool $status 公開状態
+     * @param bool $expected 期待値
      * @dataProvider allowPublishDataProvider
      */
     public function testAllowPublish($publishBegin, $publishEnd, $status, $expected)
     {
         $post = $this->BlogPostsTable->newEntity([
-            'publish_begin' => $publishBegin,
-            'publish_end' => $publishEnd,
+            'publish_begin' => $this->createDateTime($publishBegin),
+            'publish_end' => $this->createDateTime($publishEnd),
             'status' => $status,
         ]);
-        $this->assertEquals($this->BlogPostsTable->allowPublish($post), $expected);
+        $this->assertEquals($expected, $this->BlogPostsTable->allowPublish($post));
     }
 
     public static function allowPublishDataProvider()
     {
         return [
+            // 公開状態が false の場合は非公開
             [null, null, false, false],
+            // 公開期間の指定がない場合は公開状態に従う
             [null, null, true, true],
 
-            [null, new \Cake\I18n\DateTime('+1 hour'), true, true],
-            [new \Cake\I18n\DateTime('-1 hour'), null, true, true],
-            [null, new \Cake\I18n\DateTime('-1 hour'), true, false],
-            [new \Cake\I18n\DateTime('+1 hour'), null, true, false],
+            // 公開終了日時前の場合は公開
+            [null, '+1 hour', true, true],
+            // 公開開始日時を過ぎている場合は公開
+            ['-1 hour', null, true, true],
+            // 公開終了日時を過ぎている場合は非公開
+            [null, '-1 hour', true, false],
+            // 公開開始日時前の場合は非公開
+            ['+1 hour', null, true, false],
 
-            [new \Cake\I18n\DateTime('-1 hour'), new \Cake\I18n\DateTime('+1 hour'), true, true],
-            [new \Cake\I18n\DateTime('-1 hour'), new \Cake\I18n\DateTime('+1 hour'), false, false],
-            [new \Cake\I18n\DateTime('-1 hour'), new \Cake\I18n\DateTime('-1 hour'), true, false],
-            [new \Cake\I18n\DateTime('+1 hour'), new \Cake\I18n\DateTime('-1 hour'), true, false],
-            [new \Cake\I18n\DateTime('+1 hour'), new \Cake\I18n\DateTime('+2 hour'), true, false],
+            // 公開期間内の場合は公開
+            ['-1 hour', '+1 hour', true, true],
+            // 公開期間内でも公開状態が false の場合は非公開
+            ['-1 hour', '+1 hour', false, false],
+            // 公開期間が終了している場合は非公開
+            ['-1 hour', '-1 hour', true, false],
+            // 公開開始日時前かつ公開終了日時を過ぎている場合は非公開
+            ['+1 hour', '-1 hour', true, false],
+            // 公開開始日時前の場合は非公開
+            ['+1 hour', '+2 hours', true, false],
         ];
+    }
+
+    /**
+     * 現在からの相対指定を日時に変換する
+     *
+     * tests/bootstrap.php の Chronos::setTestNow() により Chronos の現在日時は
+     * テスト起動時点で固定される。そのため `new DateTime('+1 hour')` のような
+     * 相対指定は起動時点を基準に解釈され、実時間とはズレる。
+     * 判定対象の BlogPostsTable::allowPublish() は time() による実時間で
+     * 比較するため、ここでは実時間を基準に日時を生成する。
+     *
+     * @param string|null $modifier strtotime() が解釈できる相対指定
+     * @return \Cake\I18n\DateTime|null
+     */
+    private function createDateTime(?string $modifier): ?\Cake\I18n\DateTime
+    {
+        if ($modifier === null) return null;
+        return new \Cake\I18n\DateTime(date('Y-m-d H:i:s', strtotime($modifier)));
     }
 
     /**

--- a/plugins/bc-search-index/tests/TestCase/Model/Table/SearchIndexesTableTest.php
+++ b/plugins/bc-search-index/tests/TestCase/Model/Table/SearchIndexesTableTest.php
@@ -65,30 +65,59 @@ class SearchIndexesTableTest extends BcTestCase
         $this->assertTrue($this->SearchIndexes->hasBehavior('Timestamp'));
     }
 
-	/**
-	 * 公開状態を取得する
-	 *
-	 * @dataProvider allowPublishDataProvider
-	 */
-	public function testAllowPublish($publish_begin, $publish_end, $status, $expected)
-	{
+    /**
+     * 公開状態を取得する
+     *
+     * 公開期間は「現在からの相対指定」で受け取り、テスト実行時点で日時へ変換する。
+     * データプロバイダで日時を確定させると、変換から実行までの経過時間により
+     * 結果が変わってしまうため。
+     *
+     * @param string|null $publishBegin 公開開始日時の相対指定
+     * @param string|null $publishEnd 公開終了日時の相対指定
+     * @param bool $status 公開状態
+     * @param bool $expected 期待値
+     * @dataProvider allowPublishDataProvider
+     */
+    public function testAllowPublish($publishBegin, $publishEnd, $status, $expected)
+    {
         $this->loadFixtureScenario(SearchIndexesServiceScenario::class);
-		$data['publish_begin'] = $publish_begin;
-		$data['publish_end'] = $publish_end;
-		$data['status'] = $status;
-		$this->assertEquals($this->SearchIndexes->allowPublish($data), $expected);
-	}
+        $data = [
+            'publish_begin' => $this->createDateTime($publishBegin),
+            'publish_end' => $this->createDateTime($publishEnd),
+            'status' => $status
+        ];
+        $this->assertEquals($expected, $this->SearchIndexes->allowPublish($data));
+    }
 
-	public static function allowPublishDataProvider()
-	{
-		return [
-			[null, null, false, false],
-			[null, null, true, true],
-			[null, date('Y-m-d H:i:s'), true, false],
-			[null, date('Y-m-d H:i:s', strtotime("+1 hour")), true, true],
-			[date('Y-m-d H:i:s'), null, true, true],
-			[date('Y-m-d H:i:s', strtotime("+1 hour")), null, true, false],
-			[date('Y-m-d H:i:s'), date('Y-m-d H:i:s'), true, false]
-		];
-	}
+    public static function allowPublishDataProvider()
+    {
+        return [
+            // 公開状態が false の場合は非公開
+            [null, null, false, false],
+            // 公開期間の指定がない場合は公開状態に従う
+            [null, null, true, true],
+            // 公開終了日時を過ぎている場合は非公開
+            [null, '-1 hour', true, false],
+            // 公開終了日時前の場合は公開
+            [null, '+1 hour', true, true],
+            // 公開開始日時を過ぎている場合は公開
+            ['-1 hour', null, true, true],
+            // 公開開始日時前の場合は非公開
+            ['+1 hour', null, true, false],
+            // 公開期間が終了している場合は非公開
+            ['-2 hours', '-1 hour', true, false]
+        ];
+    }
+
+    /**
+     * 現在からの相対指定を日時文字列に変換する
+     *
+     * @param string|null $modifier strtotime() が解釈できる相対指定
+     * @return string|null
+     */
+    private function createDateTime(?string $modifier): ?string
+    {
+        if ($modifier === null) return null;
+        return date('Y-m-d H:i:s', strtotime($modifier));
+    }
 }

--- a/plugins/bc-uploader/tests/TestCase/View/Helper/UploaderHelperTest.php
+++ b/plugins/bc-uploader/tests/TestCase/View/Helper/UploaderHelperTest.php
@@ -130,14 +130,22 @@ class UploaderHelperTest extends BcTestCase
     /**
      * ファイルの公開状態を取得する
      * test isPublish
-     * @param $publishBegin
-     * @param $publishEnd
-     * @param $expected
+     *
+     * 公開期間は「現在からの相対指定」で受け取り、テスト実行時点で日時へ変換する。
+     * データプロバイダで日時を確定させると、変換から実行までの経過時間により
+     * 結果が変わってしまうため。
+     *
+     * @param string|null $publishBegin 公開開始日時の相対指定
+     * @param string|null $publishEnd 公開終了日時の相対指定
+     * @param bool $expected 期待値
      * @dataProvider isPublishDataProvider
      */
     public function testIsPublish($publishBegin, $publishEnd, $expected)
     {
-        $uploaderFile = UploaderFileFactory::make(['publish_begin' => $publishBegin, 'publish_end' => $publishEnd])->getEntity();
+        $uploaderFile = UploaderFileFactory::make([
+            'publish_begin' => $this->createDateTime($publishBegin),
+            'publish_end' => $this->createDateTime($publishEnd)
+        ])->getEntity();
         $rs = $this->UploaderHelper->isPublish($uploaderFile);
         $this->assertEquals($expected, $rs);
     }
@@ -145,13 +153,37 @@ class UploaderHelperTest extends BcTestCase
     public static function isPublishDataProvider()
     {
         return [
+            // 公開期間の指定がない場合は公開
             [null, null, true],
-            [new FrozenTime('+1 day'), null, false],
-            [null, new FrozenTime('-1 day'), false],
-            [new FrozenTime('-1 day'), new FrozenTime('+1 day'), true],
-            [new FrozenTime('+1 day'), new FrozenTime('+2 day'), false],
-            [new FrozenTime('now'), new FrozenTime('now'), false]
+            // 公開開始日時前の場合は非公開
+            ['+1 day', null, false],
+            // 公開終了日時を過ぎている場合は非公開
+            [null, '-1 day', false],
+            // 公開期間内の場合は公開
+            ['-1 day', '+1 day', true],
+            // 公開開始日時前の場合は非公開
+            ['+1 day', '+2 days', false],
+            // 公開終了日時が現在日時の場合は非公開
+            ['now', 'now', false]
         ];
+    }
+
+    /**
+     * 現在からの相対指定を日時に変換する
+     *
+     * tests/bootstrap.php の Chronos::setTestNow() により Chronos の現在日時は
+     * テスト起動時点で固定される。そのため `new FrozenTime('+1 day')` のような
+     * 相対指定は起動時点を基準に解釈され、実時間とはズレる。
+     * 判定対象の UploaderHelper::isPublish() は date() による実時間で比較する
+     * ため、ここでは実時間を基準に日時を生成する。
+     *
+     * @param string|null $modifier strtotime() が解釈できる相対指定
+     * @return FrozenTime|null
+     */
+    private function createDateTime(?string $modifier): ?FrozenTime
+    {
+        if ($modifier === null) return null;
+        return new FrozenTime(date('Y-m-d H:i:s', strtotime($modifier)));
     }
 
     /**


### PR DESCRIPTION
<!-- GitHub Copilot コードレビューへの指示: プルリクエストをレビューしてコメントする際には日本語でお願いします。 -->

## 概要

実行タイミングによって失敗することがあったユニットテストを修正しました。データプロバイダ内で日時を確定させていた箇所を、リポジトリ全体で解消しています。

## 原因

公開期間の判定テストで、データプロバイダ内に相対日時（`+1 hour` など）を生成していたことが原因です。次の2つが重なっています。

### ① データプロバイダは一度だけ評価される

データプロバイダはテストスイート構築時に**一度だけ**評価されるため、その時点で確定した「1時間後」は、テスト本体が実行されるまでの経過時間が1時間を超えると**過去日時**になります。全体テストのように実行時間の長いケースで顕在化します。

### ② Chronos の相対指定は実時間とズレる

`tests/bootstrap.php:73` の `Chronos::setTestNow(Chronos::now())` により、Chronos の現在日時は**テスト起動時点で固定**されます。実測すると次のようになります。

```
Chronos::now()              = 14:29:40  ← 起動時点で固定
実時間 date()               = 16:29:41
new DateTime("+1 hour")     = 15:29:40  ← 起動時点+1h。実時間では既に過去
```

一方、判定対象の `allowPublish()` / `isPublish()` は `date()` や `time()` による**実時間**で比較するため、両者が常にズレます。

## 変更内容

日時をデータプロバイダに持たせず、**実時間を基準にテスト実行時点で生成**する方式へ統一しました。あわせて各データセットに判定意図のコメントを付け、`assertEquals()` の引数順が期待値・実測値で逆になっていた箇所も修正しています。

| プラグイン | テスト | 状況 |
|---|---|---|
| bc-search-index | `SearchIndexesTableTest::testAllowPublish` | ローカルの全体テストで失敗（報告あり） |
| baser-core | `ContentsTableTest::testIsPublish` | 同一原因の潜在バグ |
| bc-blog | `BlogPostsTableTest::testAllowPublish` | **CI の Unit Test (8.2) で失敗**（実行時間 2時間08分） |
| bc-uploader | `UploaderHelperTest::testIsPublish` | 同一パターン（マージン1日のため失敗実績なし） |

### bc-search-index

データプロバイダは相対指定のみを持ち、テスト本体で日時へ変換します。

```php
[null, '-1 hour', true, false],   // 公開終了日時を過ぎている場合は非公開
[null, '+1 hour', true, true],    // 公開終了日時前の場合は公開
['-1 hour', null, true, true],    // 公開開始日時を過ぎている場合は公開
['+1 hour', null, true, false],   // 公開開始日時前の場合は非公開
```

### baser-core

`isPublishDataProvider()` から相対日時のケースを `testIsPublishWithPublishPeriod()` へ分離し、データプロバイダには固定値のみを残しました。分離にあたり、これまで無かった「公開開始日時が過去」「公開終了日時が過去」「公開期間内」「公開期間終了後」のケースも追加しています。

### bc-blog / bc-uploader

`new DateTime('+1 hour')` / `new FrozenTime('+1 day')` を、実時間から生成した日時文字列を基準に構築する方式へ変更しました。理由は各ヘルパーメソッドの docblock に記載しています。

## 検証

「テスト起動から2時間経過」を再現し、修正前後の挙動を確認しました。

```
[旧] new DateTime("+1 hour")     = 15:30:50 （実時間では過去）
[新] new DateTime(実時間+1時間)  = 17:30:51

[旧] 公開終了前→公開(true)期待: false  ← FAIL
[新] 公開終了前→公開(true)期待: true   ← PASS
```

変更した4ファイルのテスト結果です。

```
OK (175 tests, 290 assertions)
```

※ Incomplete は既存のスキップです。

修正後、データプロバイダ内で日時を確定させている箇所が残っていないことを横断検索で確認しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)