### PR TITLE
fix #4436 custom_entries Web API の page パラメータが機能しない問題を修正

### DIFF
--- a/plugins/bc-custom-content/src/Service/CustomEntriesService.php
+++ b/plugins/bc-custom-content/src/Service/CustomEntriesService.php
@@ -160,6 +160,7 @@ class CustomEntriesService implements CustomEntriesServiceInterface
     {
         $options = array_merge([
             'limit' => null,
+            'page' => null,    // ページ番号
             'direction' => '',    // 並び方向
             'order' => '',    // 並び順対象のフィールド
             'contain' => [],
@@ -180,10 +181,14 @@ class CustomEntriesService implements CustomEntriesServiceInterface
         }
 
         if (!empty($options['limit'])) {
-            $query->limit($options['limit']);
+            if (!empty($options['page'])) {
+                $query->page($options['page'], $options['limit']);
+            } else {
+                $query->limit($options['limit']);
+            }
         }
 
-        unset($options['order'], $options['direction'], $options['limit']);
+        unset($options['order'], $options['direction'], $options['limit'], $options['page']);
 
         if (!empty($options)) {
             $query = $this->createIndexConditions($query, $options);

--- a/plugins/bc-custom-content/tests/TestCase/Service/CustomEntriesServiceTest.php
+++ b/plugins/bc-custom-content/tests/TestCase/Service/CustomEntriesServiceTest.php
@@ -257,6 +257,19 @@ class CustomEntriesServiceTest extends BcTestCase
         $result = $this->CustomEntriesService->getIndex(['order' => 'name', 'direction' => 'desc'])->all()->toArray();
         $this->assertEquals('プログラマー 3', $result[0]->name);
 
+        //pageパラメータを入れる
+        $params = ['limit' => 2, 'order' => 'id', 'direction' => 'asc'];
+        $page1 = $this->CustomEntriesService->getIndex($params + ['page' => 1])->all()->toArray();
+        $page2 = $this->CustomEntriesService->getIndex($params + ['page' => 2])->all()->toArray();
+        //全3件を2件ずつに分割して取得できる
+        $this->assertCount(2, $page1);
+        $this->assertCount(1, $page2);
+        //2ページ目には1ページ目と異なるデータが返る
+        $this->assertNotContains($page2[0]->id, [$page1[0]->id, $page1[1]->id]);
+
+        //limitがない場合、pageパラメータは無視する
+        $result = $this->CustomEntriesService->getIndex(['page' => 2])->all();
+        $this->assertCount(3, $result);
     }
 
     /**


### PR DESCRIPTION
<!-- GitHub Copilot コードレビューへの指示: プルリクエストをレビューしてコメントする際には日本語でお願いします。 -->

## 概要

公開 Web API `GET /baser/api/bc-custom-content/custom_entries.json` に `page` クエリパラメータを付けても2ページ目以降が取得できない問題（#4436）を修正しました。

## 原因

`CustomEntriesService::getIndex()` に `page` の処理が実装されておらず、`limit` のみが適用されていました。そのため `page` を変えても常に先頭から `limit` 件が返っていました。

同プラグインの `CustomContentsService::getIndex()` には `page` 対応があり、[ドキュメント](https://baserproject.github.io/5/web_api/baser_api/bc-custom-content/custom_entries/index) にも `page` が使える旨の記載があるため、実装漏れと判断しました。

## 変更内容

`CustomContentsService::getIndex()` と同じ方式に揃えました。

```php
if (!empty($options['limit'])) {
    if (!empty($options['page'])) {
        $query->page($options['page'], $options['limit']);
    } else {
        $query->limit($options['limit']);
    }
}

unset($options['order'], $options['direction'], $options['limit'], $options['page']);
```

### `unset()` に `page` を追加している理由

`createIndexConditions()` は、既知のキーを取り除いた**残りのキーをカスタムフィールド名として扱う**実装になっています。`order` / `direction` / `limit` と同様に `page` も除外しておかないと、`page` という名前のカスタムフィールドが定義されている環境で意図しない絞り込みが発生します。

### `limit` がない場合に `page` を無視する理由

CakePHP の `Query::page()` は `limit` 未指定時に **25 件を暗黙で適用**します。

```php
$limit = $this->clause('limit');
if ($limit === null) {
    $limit = 25;
    $this->limit($limit);
}
```

`?page=2` のみを指定した既存の呼び出しが、これまでの「全件返却」から「25件返却」へ静かに変わってしまうため、`CustomContentsService` と同じく `limit` 指定時のみ `page` を適用する挙動としています。この点はテストでも固定しています。

## テスト

`CustomEntriesServiceTest::test_getIndex()` に検証を追加しました。

```php
//pageパラメータを入れる
$params = ['limit' => 2, 'order' => 'id', 'direction' => 'asc'];
$page1 = $this->CustomEntriesService->getIndex($params + ['page' => 1])->all()->toArray();
$page2 = $this->CustomEntriesService->getIndex($params + ['page' => 2])->all()->toArray();
//全3件を2件ずつに分割して取得できる
$this->assertCount(2, $page1);
$this->assertCount(1, $page2);
//2ページ目には1ページ目と異なるデータが返る
$this->assertNotContains($page2[0]->id, [$page1[0]->id, $page1[1]->id]);

//limitがない場合、pageパラメータは無視する
$result = $this->CustomEntriesService->getIndex(['page' => 2])->all();
$this->assertCount(3, $result);
```

修正を戻した状態でこのテストが失敗することを確認しています（2ページ目に1ページ目と同じ2件が返る）。

```
Failed asserting that actual size 2 matches expected size 1.
```

### 実行結果

| 対象 | 結果 |
|---|---|
| `CustomEntriesServiceTest` | OK (31 tests, 97 assertions) |
| `bc-custom-content` の API テスト | OK (6 tests, 27 assertions) |
| `bc-custom-content` 全体 | OK (303 tests, 969 assertions) |

※ Incomplete は既存のスキップです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CUtN1d5ymNZ3HocBvU2c6G)_