### PR TITLE
fix #4119 PhpDocumentor のワークフローが実行されない問題を修正

### DIFF
--- a/.github/workflows/php_documentor.yml
+++ b/.github/workflows/php_documentor.yml
@@ -9,12 +9,14 @@ on:
   push:
     branches:
       - 'master'
+  # ドキュメント生成のみを確認したい場合に手動実行できるようにする
+  workflow_dispatch:
 
 jobs:
   test:
     name: PhpDocumentor
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
@@ -23,13 +25,13 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run compose
         run: |
           cd docker
           cp docker-compose.yml.default docker-compose.yml
-          sed -i -e "s/basercms:php8.1/basercms:php${{ matrix.php-version }}/g" docker-compose.yml
+          sed -i -e "s|basercms:php[0-9.]*|basercms:php${{ matrix.php-version }}|g" docker-compose.yml
           sed -i -e "s/XDEBUG_MODE: \"debug\"/XDEBUG_MODE: \"off\"/g" docker-compose.yml
           docker compose up -d
 


### PR DESCRIPTION
<!-- GitHub Copilot コードレビューへの指示: プルリクエストをレビューしてコメントする際には日本語でお願いします。 -->

## 概要

PhpDocumentor のワークフローが実行されず、クラスリファレンスが更新されていない問題（#4119）を修正しました。

## 原因

**ジョブが要求するランナー `ubuntu-20.04` が GitHub 側で廃止されていた**ことが原因です。ジョブがキューに滞留したまま、24時間後に自動キャンセルされていました。

実行履歴を確認すると、**直近18回の実行すべてが `cancelled`**、かつ**いずれも開始からちょうど24時間後に終了**していました。

```
job labels   : ["ubuntu-20.04"]
created_at   : 2026-08-27T10:36:18Z
completed_at : 2026-08-28T10:36:18Z   ← ちょうど24時間後
conclusion   : cancelled
```

Issue に書かれていた「おそらく GitHub 側の仕様変更が影響？」という推測どおりでした。

## 変更内容

### 1. ランナーを `ubuntu-22.04` に変更（本修正）

`test.yml` で稼働実績のあるランナーに揃えました。

### 2. `actions/checkout` を v4 に更新

v3 は Node 20 廃止の対象で、`test.yml` の CI ログでも警告が出ています。

### 3. docker イメージのタグ置換を修正

置換元が `basercms:php8.1` のままで、`docker-compose.yml.default` の現在の値 `basercms:php8.5` に一致せず、**無効な処理になっていました**。

現状は matrix の `php-version` が `8.5` で、default 側の値と偶然一致しているため結果的に動きますが、matrix を `8.4` などに変更しても反映されない状態でした。バージョン部分をパターン指定に変更しています。

```
# 旧 sed（php8.1 を探す）で matrix=8.4 を指定した場合
image: baserproject/basercms:php8.5   ← 置換されない

# 新 sed の場合
image: baserproject/basercms:php8.4   ← 正しく置換される
```

### 4. `workflow_dispatch` を追加

このワークフローは `master` への push でのみ動くため、PR の CI では検証できません。手動実行できるようにして、リリースを待たずに動作確認できるようにしました。

## 検証

ローカルで確認できた範囲は以下のとおりです。

| 確認項目 | 結果 |
|---|---|
| YAML の構文・トリガー・ランナー・checkout バージョン | パース成功、意図した値を確認 |
| 修正した sed の置換動作 | 上記のとおり、旧版が無効・新版が有効なことを確認 |
| phpdoc の出力先 `reference` とデプロイ手順の整合 | `phpdoc.dist.xml` の `<output>reference</output>` と `cp -pr ../reference` が一致 |
| コンテナ名 `bc-php` | `docker-compose.yml.default` の `container_name` と一致 |
| `XDEBUG_MODE` の置換対象 | `docker-compose.yml.default` に存在することを確認 |

### 未検証の点

`phpDocumentor.phar` のダウンロードと実行については、作業環境のネットワークポリシーが `phpdoc.org` への接続を拒否するため、ローカルで確認できていません。

```
connect_rejected: gateway answered 403 to CONNECT (policy denial)  host: phpdoc.org:443
```

ジョブはこれまでランナー待ちの段階で止まっており、ダウンロード以降のステップは一度も実行されていません。そのため、ランナー修正後に別の問題が出る可能性は残ります。

マージ後、追加した `workflow_dispatch` から手動実行して確認していただくのが確実です。もし後続ステップで失敗した場合は、続けて対応します。

## 影響範囲

ワークフロー定義のみの変更で、プログラムコードへの影響はありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CUtN1d5ymNZ3HocBvU2c6G)_