### PR TITLE
fix #3908 mobiledetect/mobiledetectlib の要求バージョンを ^4.8.03 に変更

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "josegonzalez/dotenv": "~4.0.0",
         "league/oauth2-server": "^8.5",
         "logiscape/mcp-sdk-php": "^2.0",
-        "mobiledetect/mobiledetectlib": "~3.74.4",
+        "mobiledetect/mobiledetectlib": "^4.8.03",
         "nikic/php-parser": "~5.8.0",
         "nyholm/psr7": "^1.8",
         "psr/http-message": "~1.1",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "josegonzalez/dotenv": "~4.0.0",
         "league/oauth2-server": "^8.5",
         "logiscape/mcp-sdk-php": "^2.0",
-        "mobiledetect/mobiledetectlib": "^4.8.03",
+        "mobiledetect/mobiledetectlib": "~4.8.03",
         "nikic/php-parser": "~5.8.0",
         "nyholm/psr7": "^1.8",
         "psr/http-message": "~1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "80cd980b6461e29399a8145f4d316722",
+    "content-hash": "87edb7b36b7ee9e8b18d913fe639c73a",
     "packages": [
         {
             "name": "cakephp/authentication",
@@ -2496,34 +2496,34 @@
         },
         {
             "name": "mobiledetect/mobiledetectlib",
-            "version": "3.74.4",
+            "version": "4.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/serbanghita/Mobile-Detect.git",
-                "reference": "e72098eba91e5f16278b17d42ca193ae71e4ae0a"
+                "reference": "992cc85e34887b090b073b46bde6d5087c908e10"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/serbanghita/Mobile-Detect/zipball/e72098eba91e5f16278b17d42ca193ae71e4ae0a",
-                "reference": "e72098eba91e5f16278b17d42ca193ae71e4ae0a",
+                "url": "https://api.github.com/repos/serbanghita/Mobile-Detect/zipball/992cc85e34887b090b073b46bde6d5087c908e10",
+                "reference": "992cc85e34887b090b073b46bde6d5087c908e10",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.4"
+                "php": ">=8.0",
+                "psr/simple-cache": "3.0.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.14",
-                "phpunit/phpunit": "^9.6",
-                "squizlabs/php_codesniffer": "^3.7"
+                "friendsofphp/php-cs-fixer": "3.95.1",
+                "phpbench/phpbench": "1.6.1",
+                "phpstan/phpstan": "2.1.47",
+                "phpunit/phpunit": "9.6.34",
+                "squizlabs/php_codesniffer": "3.13.5"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
                     "Detection\\": "src/"
-                },
-                "classmap": [
-                    "src/MobileDetect.php"
-                ]
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2533,7 +2533,7 @@
                 {
                     "name": "Serban Ghita",
                     "email": "serbanghita@gmail.com",
-                    "homepage": "https://mobiledetect.net",
+                    "homepage": "http://mobiledetect.net",
                     "role": "Developer"
                 }
             ],
@@ -2548,7 +2548,7 @@
             ],
             "support": {
                 "issues": "https://github.com/serbanghita/Mobile-Detect/issues",
-                "source": "https://github.com/serbanghita/Mobile-Detect/tree/3.74.4"
+                "source": "https://github.com/serbanghita/Mobile-Detect/tree/4.9.0"
             },
             "funding": [
                 {
@@ -2556,7 +2556,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-15T08:43:14+00:00"
+            "time": "2026-04-23T12:32:05+00:00"
         },
         {
             "name": "nikic/php-parser",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "87edb7b36b7ee9e8b18d913fe639c73a",
+    "content-hash": "5222a64f5f5496f0ecd5ecd6083c5deb",
     "packages": [
         {
             "name": "cakephp/authentication",
@@ -2496,28 +2496,28 @@
         },
         {
             "name": "mobiledetect/mobiledetectlib",
-            "version": "4.9.0",
+            "version": "4.8.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/serbanghita/Mobile-Detect.git",
-                "reference": "992cc85e34887b090b073b46bde6d5087c908e10"
+                "reference": "96b1e1fa9a968de7660a031106ab529f659d0192"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/serbanghita/Mobile-Detect/zipball/992cc85e34887b090b073b46bde6d5087c908e10",
-                "reference": "992cc85e34887b090b073b46bde6d5087c908e10",
+                "url": "https://api.github.com/repos/serbanghita/Mobile-Detect/zipball/96b1e1fa9a968de7660a031106ab529f659d0192",
+                "reference": "96b1e1fa9a968de7660a031106ab529f659d0192",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.0",
-                "psr/simple-cache": "3.0.0"
+                "psr/simple-cache": "^3"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "3.95.1",
-                "phpbench/phpbench": "1.6.1",
-                "phpstan/phpstan": "2.1.47",
-                "phpunit/phpunit": "9.6.34",
-                "squizlabs/php_codesniffer": "3.13.5"
+                "friendsofphp/php-cs-fixer": "^v3.75.0",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^2.1.11",
+                "phpunit/phpunit": "^9.6.22",
+                "squizlabs/php_codesniffer": "^3.12.1"
             },
             "type": "library",
             "autoload": {
@@ -2548,7 +2548,7 @@
             ],
             "support": {
                 "issues": "https://github.com/serbanghita/Mobile-Detect/issues",
-                "source": "https://github.com/serbanghita/Mobile-Detect/tree/4.9.0"
+                "source": "https://github.com/serbanghita/Mobile-Detect/tree/4.8.10"
             },
             "funding": [
                 {
@@ -2556,7 +2556,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-23T12:32:05+00:00"
+            "time": "2026-01-09T16:21:59+00:00"
         },
         {
             "name": "nikic/php-parser",

--- a/plugins/baser-core/composer.json
+++ b/plugins/baser-core/composer.json
@@ -15,7 +15,7 @@
         "firebase/php-jwt": "~7.0.2",
         "ezyang/htmlpurifier": "~4.19.0",
         "robmorgan/phinx": "0.16.10",
-        "mobiledetect/mobiledetectlib": "~3.74.4",
+        "mobiledetect/mobiledetectlib": "^4.8.03",
         "nikic/php-parser": "~5.8.0",
         "cakephp/debug_kit": "~5.2.4",
         "ext-json": "*",

--- a/plugins/baser-core/composer.json
+++ b/plugins/baser-core/composer.json
@@ -15,7 +15,7 @@
         "firebase/php-jwt": "~7.0.2",
         "ezyang/htmlpurifier": "~4.19.0",
         "robmorgan/phinx": "0.16.10",
-        "mobiledetect/mobiledetectlib": "^4.8.03",
+        "mobiledetect/mobiledetectlib": "~4.8.03",
         "nikic/php-parser": "~5.8.0",
         "cakephp/debug_kit": "~5.2.4",
         "ext-json": "*",


### PR DESCRIPTION
## 概要

`mobiledetect/mobiledetectlib` の要求バージョンを `~3.74.4` から `^4.8.03` へ変更します（cakephp/app の最新に合わせる）。

対象: #3908

## 変更内容

- `composer.json` / `plugins/baser-core/composer.json` の `mobiledetect/mobiledetectlib` を `^4.8.03` に変更
- `composer update` により `composer.lock` を更新（4.9.0 が解決されました）

## 動作確認

- 新バージョンでも名前空間 `Detection\MobileDetect` は変わらず、`config/bootstrap.php` で使用している `isMobile()` / `isTablet()` メソッドも引き続き利用可能なことを確認済み
- `plugins/baser-core/tests/TestCase/Utility/BcAgentTest.php`、`BcAbstractDetectorTest.php` が成功
- フルテストスイートを実行し、既存の失敗・エラーはすべて実行環境（`getcomposer.org` 等外部ホストへのネットワークアクセス制限）に起因するもので、本変更による回帰がないことを確認

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2GHfP4i8MaRXoxYV7vMDL)_